### PR TITLE
Update with latest js_of_ocaml: need review, need testing (could not test myself)

### DIFF
--- a/src/client/eliom_lib.ml
+++ b/src/client/eliom_lib.ml
@@ -115,8 +115,8 @@ let encode_header_value x =
   (* We remove end of lines *)
   String.remove_eols (to_json x)
 
-let unmarshal_js_var s =
-  Marshal.from_string (Js.to_bytestring (Js.Unsafe.variable s)) 0
+let unmarshal_js var =
+  Marshal.from_string (Js.to_bytestring var) 0
 
 type file_info = File.file Js.t
 

--- a/src/client/eliom_lib.mli
+++ b/src/client/eliom_lib.mli
@@ -92,7 +92,7 @@ val trace : ('a, unit, string, unit) format4 -> 'a
 val lwt_ignore : ?message:string -> unit Lwt.t -> unit
 
 val encode_form_value : 'a -> string
-val unmarshal_js_var : string -> 'a
+val unmarshal_js : Js.js_string Js.t -> 'a
 
 val encode_header_value : 'a -> string
 

--- a/src/client/eliom_process.ml
+++ b/src/client/eliom_process.ml
@@ -30,11 +30,11 @@ let get_set_js_serverside_value r name =
     | None ->
       (* if variable toto does not exist,
          Js.Unsafe.variable "toto" fails, but
-         Js.Unsafe.variable "this.toto" returns undefined *)
-      Js.Optdef.case (Js.def (Js.Unsafe.variable ("this."^name)))
+         Js.Unsafe.get Js.Unsafe.global (Js.string "toto") returns undefined *)
+      Js.Optdef.case (Js.def (Js.Unsafe.get Js.Unsafe.global (Js.string name)))
         (fun () -> failwith (name^" not defined. A client Eliom application must either be sent by an Eliom server application of you must call Eliom_process.init_client_app."))
-        (fun _ ->
-          let s = unmarshal_js_var name in
+        (fun var ->
+          let s = unmarshal_js var in
           r := Some s;
           s))
 

--- a/src/client/eliom_request.ml
+++ b/src/client/eliom_request.ml
@@ -276,8 +276,8 @@ let rec send ?(expecting_process_page = false) ?cookies_info
 
 (* BEGIN FORMDATA HACK *)
 let add_button_arg inj args form =
-  let button = (Js.Unsafe.variable "window")##eliomLastButton in
-  (Js.Unsafe.variable "window")##eliomLastButton <- None;
+  let button = Js.Unsafe.global##eliomLastButton in
+  Js.Unsafe.global##eliomLastButton <- None;
   match button with
     | None -> args
     | Some b ->

--- a/src/client/eliom_request_info.ml
+++ b/src/client/eliom_request_info.ml
@@ -214,12 +214,12 @@ let get_request_data, set_request_data, reset_request_data =
     match !eliom_data with
       | Some data -> data
       | None ->
-        let name = "__eliom_request_data" in
-        Js.Optdef.case (Js.def (Js.Unsafe.variable ("this."^name)))
+        let eliom_request_data = Js.Unsafe.get Js.Unsafe.global (Js.string "__eliom_request_data") in
+        Js.Optdef.case (Js.def eliom_request_data)
           (fun () -> eliom_data := Some default_request_data;
             default_request_data)
-          (fun _ ->
-            let data = Eliom_unwrap.unwrap_js_var name in
+          (fun var ->
+             let data = Eliom_unwrap.unwrap_js var in
             eliom_data := Some data;
             data)
   in

--- a/src/client/eliom_unwrap.ml
+++ b/src/client/eliom_unwrap.ml
@@ -26,7 +26,7 @@ class type ['a,'b] weakMap = object
   method has : 'a -> bool Js.t Js.meth
 end
 
-let weakMap : ('a,'b) weakMap Js.t Js.constr = Js.Unsafe.variable "window.WeakMap"
+let weakMap : ('a,'b) weakMap Js.t Js.constr = Js.Unsafe.global##_WeakMap
 
 let map : (Obj.t,Obj.t) weakMap Js.t = jsnew weakMap ()
 
@@ -195,5 +195,5 @@ let unwrap s i =
   res
 
 
-let unwrap_js_var s =
-  unwrap (Js.to_bytestring (Js.Unsafe.variable s)) 0
+let unwrap_js s =
+  unwrap (Js.to_bytestring s) 0

--- a/src/client/eliom_unwrap.mli
+++ b/src/client/eliom_unwrap.mli
@@ -28,7 +28,7 @@ val register_unwrapper : unwrap_id -> ('a -> 'b) -> unit
 
 (** [unwrap_js_var v] execute [unwrap] on the content of the javascript
     variable [v] *)
-val unwrap_js_var : string -> 'a
+val unwrap_js : Js.js_string Js.t -> 'a
 
 (**/**)
 

--- a/src/client/private/eliommod_dom.ml
+++ b/src/client/private/eliommod_dom.ml
@@ -676,11 +676,11 @@ let touch_base () =
 let onclick_on_body_handler event =
   (match Dom_html.tagged (Dom_html.eventTarget event) with
     | Dom_html.Button button ->
-        (Js.Unsafe.variable "window")##eliomLastButton <- Some button;
+        Js.Unsafe.global##eliomLastButton <- Some button;
     | Dom_html.Input input when input##_type = Js.string "submit" ->
-        (Js.Unsafe.variable "window")##eliomLastButton <- Some input;
+        Js.Unsafe.global##eliomLastButton <- Some input;
     | _ ->
-        (Js.Unsafe.variable "window")##eliomLastButton <- None);
+        Js.Unsafe.global##eliomLastButton <- None);
   Js._true
 
 let add_formdata_hack_onclick_handler () =

--- a/src/client/private/eliommod_jstable.ml
+++ b/src/client/private/eliommod_jstable.ml
@@ -1,5 +1,5 @@
 type 'a t = < > Js.t
-let obj = Js.Unsafe.variable "Object"
+let obj = Js.Unsafe.global##_Object
 let create () : 'a t = jsnew obj ()
 let add (t:'a t) (k:Js.js_string Js.t) (v:'a) =
   (* '_' is added to avoid conflicts with objects methods *)
@@ -8,10 +8,7 @@ let find (t:'a t) (k:Js.js_string Js.t) : 'a Js.Optdef.t =
   Js.Unsafe.get t (k##concat(Js.string "_"))
 let keys (t:'a t) : Js.js_string Js.t list =
   let key_array : Js.js_string Js.t Js.js_array Js.t =
-    Js.Unsafe.meth_call
-      (Js.Unsafe.variable "Object")
-      "keys"
-      [| Js.Unsafe.inject t |]
+    Js.Unsafe.global##_Object##keys(t)
   in
   let res = ref [] in
   for i = 0 to pred key_array##length do

--- a/tests/eliom_testsuite4.eliom
+++ b/tests/eliom_testsuite4.eliom
@@ -222,7 +222,7 @@ let data_sharing =
        ignore {unit{
          Html5.Manip.appendChild %data_sharing_data
            (Html5.F.pcdata
-              (Js.to_string (Js.Unsafe.variable "__eliom_request_data")))
+              (Js.to_string (Js.Unsafe.get Js.Unsafe.global (Js.string "__eliom_request_data"))))
        }};
        Lwt.return Html5.F.([
          data_sharing_elt1;


### PR DESCRIPTION
https://github.com/ocsigen/js_of_ocaml/commit/f152eafd86adce5e26a9775e28de0181d5084341 and https://github.com/ocsigen/js_of_ocaml/commit/831f15039e55229b04e2444c417ce42b27ab7a53 introduced `strict mode`.
in that context, accessing `this` do not reference the global object anymore.
there is a new js value `Js.Unsafe.global` that reference the global object.
