### PR TITLE
[Fix] Eliom_client.rebuild_{r,}attrib

### DIFF
--- a/src/client/eliom_client.js
+++ b/src/client/eliom_client.js
@@ -1,11 +1,3 @@
-//Provides: lookup_real_attrib_name
-function lookup_real_attrib_name(o,s) {
-  for(var attr in o) {
-    if(attr.toLowerCase() == s) return attr;
-  }
-  return null;
-}
-
 // Unmarshall and unwrapping.
 
 //Provides: caml_unwrap_value_from_string mutable
@@ -272,4 +264,3 @@ var caml_unwrap_value_from_string = function (){
     return intern_obj_table[0][0][2];
   }
 }();
-

--- a/src/client/eliom_client.ml
+++ b/src/client/eliom_client.ml
@@ -1174,43 +1174,26 @@ type tmp_elt = {
   tmp_node_id : Xml.node_id;
 }
 
-external lookup_real_attrib_name : #Dom_html.element Js.t -> Js.js_string Js.t -> Js.js_string Js.t Js.opt = "lookup_real_attrib_name"
-
-let js_name,fix_attrib =
-  let tbl = Hashtbl.create 17 in
-  let add_js name v = Hashtbl.add tbl name v in
-  let add name = add_js (String.lowercase name) (Js.string name) in
-  let find node name =
-    try Hashtbl.find tbl name with
-      | Not_found ->
-        let js_name = Js.string name in
-        let v =
-          Js.Opt.get
-            (lookup_real_attrib_name node js_name)
-            (fun () -> js_name) in
-        add_js name v;
-        v in
-  find,add
-
-let rebuild_attrib node name a = match a with
-  | Xml.AFloat f -> Js.Unsafe.set node (js_name node name) (Js.Unsafe.inject f)
-  | Xml.AInt i -> Js.Unsafe.set node (js_name node name) (Js.Unsafe.inject i)
-  | Xml.AStr s ->
-    node##setAttribute(js_name node name, Js.string s)
+let rebuild_attrib node name a =
+  let name = Js.string name in
+  match a with
+  | Xml.AFloat f -> node##setAttribute (name, Obj.magic f)
+  | Xml.AInt i -> node##setAttribute (name, Obj.magic i)
+  | Xml.AStr s -> node##setAttribute(name, Js.string s)
   | Xml.AStrL (Xml.Space, sl) ->
-    node##setAttribute(js_name node name, Js.string (String.concat " " sl))
+    node##setAttribute(name, Js.string (String.concat " " sl))
   | Xml.AStrL (Xml.Comma, sl) ->
-    node##setAttribute(js_name node name, Js.string (String.concat "," sl))
+    node##setAttribute(name, Js.string (String.concat "," sl))
 
 let rebuild_rattrib node ra = match Xml.racontent ra with
   | Xml.RA a -> rebuild_attrib node (Xml.aname ra) a
   | Xml.RACamlEventHandler ev -> register_event_handler node (Xml.aname ra, ev)
   | Xml.RALazyStr s ->
-      node##setAttribute(js_name node (Xml.aname ra), Js.string s)
+      node##setAttribute(Js.string (Xml.aname ra), Js.string s)
   | Xml.RALazyStrL (Xml.Space, l) ->
-      node##setAttribute(js_name node (Xml.aname ra), Js.string (String.concat " " l))
+      node##setAttribute(Js.string (Xml.aname ra), Js.string (String.concat " " l))
   | Xml.RALazyStrL (Xml.Comma, l) ->
-      node##setAttribute(js_name node (Xml.aname ra), Js.string (String.concat "," l))
+      node##setAttribute(Js.string (Xml.aname ra), Js.string (String.concat "," l))
 
 let rec rebuild_node' ns elt =
   match Xml.get_node elt with

--- a/src/client/eliom_client.mli
+++ b/src/client/eliom_client.mli
@@ -219,12 +219,6 @@ val rebuild_node' : Eliom_content_core.content_ns -> Eliom_content_core.Xml.elt 
 val rebuild_node : string -> 'a Eliom_content_core.Html5.elt -> < .. > Js.t
 val rebuild_node_svg : string -> 'a Eliom_content_core.Svg.elt -> < .. > Js.t
 
-(** Javascript expect some attributes to have capital letters.
-    Eliom does the translation for some of them.
-    If some are missing, use this function to add them.
-    It takes the attribute name with capital letters as parameter. *)
-val fix_attrib : string -> unit
-
 (* This is necessary when generating/hacking eliom forms, e.g. when
    deriving forms from a runtime type represantation. *)
 val form_handler : (Dom_html.element Js.t, Dom_html.event Js.t) Dom_html.event_listener


### PR DESCRIPTION
It seams previous fixes were wrong.
setAttribute works as expected.
The issue was coming from the use
of `Js.Unsafe.set node name v` for int
and float attributes.

That said,
`elt.setAttribute('value', val)` no longer works after value property
has be set (`elt.value = otherval`).

https://developer.mozilla.org/en-US/docs/Web/API/Element.setAttribute
Using setAttribute() to modify certain attributes, most notably value
in XUL, works inconsistently, as the attribute specifies the default
value. To access or modify the current values, you should use the
properties. For example, use elt.value instead of
elt.setAttribute('value', val).
