### PR TITLE
Fixes for eliomc -i

### DIFF
--- a/src/tools/eliomc.ml
+++ b/src/tools/eliomc.ml
@@ -191,6 +191,10 @@ let compile_server_type_eliom file =
   Unix.close out
 
 let output_eliom_interface ~impl_intf file =
+  if !do_dump then begin
+    Printf.eprintf "Dump (-dump) not supported for interface inference (-i).";
+    exit 1
+  end;
   let indent ch =
     try
       while true do


### PR DESCRIPTION
Output the client interface in the respective section when using `eliomc -i`. Before, the server interface was wrongly repeated in the client section.

Furthermore, the simultaneous usage of `-i` and `-dump` results now in an error. The former behavour was to ignore the option `-dump` silently when `-i`.
