### PR TITLE
Rename *AllChildren to *Children

### DIFF
--- a/src/client/eliom_content_.ml
+++ b/src/client/eliom_content_.ml
@@ -94,12 +94,12 @@ module MakeManip
       let node2 = get_unique_node "replaceChild" elt2 in
       ignore(node1##replaceChild(node2, get_node elt3))
 
-    let raw_removeAllChildren node =
+    let raw_removeChildren node =
       let childrens = Dom.list_of_nodeList (node##childNodes) in
       List.iter (fun c -> ignore(node##removeChild(c))) childrens
 
-    let raw_replaceAllChildren node elts =
-      raw_removeAllChildren node;
+    let raw_replaceChildren node elts =
+      raw_removeChildren node;
       List.iter (fun elt -> ignore(node##appendChild(get_node elt))) elts
 
     let nth elt n =
@@ -144,13 +144,13 @@ module MakeManip
       let node1 = get_unique_node "replaceChild" elt1 in
       raw_replaceChild node1 elt2 elt3
 
-    let removeAllChildren elt =
-      let node = get_unique_node "removeAllChildren" elt in
-      raw_removeAllChildren node
+    let removeChildren elt =
+      let node = get_unique_node "removeChildren" elt in
+      raw_removeChildren node
 
-    let replaceAllChildren elt elts =
-      let node = get_unique_node "replaceAllChildren" elt in
-      raw_replaceAllChildren node elts
+    let replaceChildren elt elts =
+      let node = get_unique_node "replaceChildren" elt in
+      raw_replaceChildren node elts
 
     let childNodes elt =
       let node = get_unique_node "childNodes" elt in
@@ -187,13 +187,13 @@ module MakeManip
         let node1 = Id.get_element' id1 in
         raw_replaceChild node1 elt2 elt3
 
-      let removeAllChildren id =
+      let removeChildren id =
         let node = Id.get_element' id in
-        raw_removeAllChildren node
+        raw_removeChildren node
 
-      let replaceAllChildren id elts =
+      let replaceChildren id elts =
         let node = Id.get_element' id in
-        raw_replaceAllChildren node elts
+        raw_replaceChildren node elts
 
     end
 

--- a/src/clientserver/eliom_content.client.mli
+++ b/src/clientserver/eliom_content.client.mli
@@ -125,15 +125,15 @@ module Svg : sig
         list of [e1] children. *)
     val replaceChild: 'a elt -> 'b elt -> 'c elt -> unit
 
-    (** The function [removeAllChildren e1] removes [e1] children. *)
-    val removeAllChildren: 'a elt -> unit
+    (** The function [removeChildren e1] removes [e1] children. *)
+    val removeChildren: 'a elt -> unit
 
     (** [removeSelf e] removes element e from the DOM. *)
     val removeSelf: 'a elt -> unit
 
-    (** The function [replaceAllChildren e1 elts] replaces all the children of
+    (** The function [replaceChildren e1 elts] replaces all the children of
         [e1] by [elt]. *)
-    val replaceAllChildren: 'a elt -> 'b elt list -> unit
+    val replaceChildren: 'a elt -> 'b elt list -> unit
 
     (* (\** The function [addEventListener elt evt handler] attach the *)
         (* [handler] for the event [evt] on the element [elt]. See the *)
@@ -164,10 +164,10 @@ module Svg : sig
       val removeChild: 'a Id.id -> 'b elt -> unit
       (** see [replaceChild] *)
       val replaceChild: 'a Id.id -> 'b elt -> 'c elt -> unit
-      (** see [removeAllChildren] *)
-      val removeAllChildren: 'a Id.id -> unit
-      (** see [replaceAllChildren] *)
-      val replaceAllChildren: 'a Id.id -> 'b elt list -> unit
+      (** see [removeChildren] *)
+      val removeChildren: 'a Id.id -> unit
+      (** see [replaceChildren] *)
+      val replaceChildren: 'a Id.id -> 'b elt list -> unit
 
       (* (\** see [addEventListener] *\) *)
       (* val addEventListener: *)
@@ -511,15 +511,15 @@ module Html5 : sig
         list of [e1] children. *)
     val replaceChild: 'a elt -> 'b elt -> 'c elt -> unit
 
-    (** The function [removeAllChildren e1] removes [e1] children. *)
-    val removeAllChildren: 'a elt -> unit
+    (** The function [removeChildren e1] removes [e1] children. *)
+    val removeChildren: 'a elt -> unit
 
     (** [removeSelf e] removes element e from the DOM. *)
     val removeSelf: 'a elt -> unit
 
-    (** The function [replaceAllChildren e1 elts] replaces all the children of
+    (** The function [replaceChildren e1 elts] replaces all the children of
         [e1] by [elt]. *)
-    val replaceAllChildren: 'a elt -> 'b elt list -> unit
+    val replaceChildren: 'a elt -> 'b elt list -> unit
 
     (** The function [addEventListener elt evt handler] attach the
         [handler] for the event [evt] on the element [elt]. See the
@@ -550,10 +550,10 @@ module Html5 : sig
       val removeChild: 'a Id.id -> 'b elt -> unit
       (** see [replaceChild] *)
       val replaceChild: 'a Id.id -> 'b elt -> 'c elt -> unit
-      (** see [removeAllChildren] *)
-      val removeAllChildren: 'a Id.id -> unit
-      (** see [replaceAllChildren] *)
-      val replaceAllChildren: 'a Id.id -> 'b elt list -> unit
+      (** see [removeChildren] *)
+      val removeChildren: 'a Id.id -> unit
+      (** see [replaceChildren] *)
+      val replaceChildren: 'a Id.id -> 'b elt list -> unit
 
       (** see [addEventListener] *)
       val addEventListener:

--- a/src/clientserver/eliom_content.eliom
+++ b/src/clientserver/eliom_content.eliom
@@ -62,7 +62,7 @@ module Xml_react = struct
     let n = Xmld.node ?a name [] in
     let _ = {unit{
         ignore (React.S.map
-                  (fun l -> Html5.Manip.replaceAllChildren
+                  (fun l -> Html5.Manip.replaceChildren
                       (Html5.F.tot %((n : elt)))
                       (Html5.F.totl l))
                 %((children_signal_client_value : elt list React.signal client_value)))
@@ -77,7 +77,7 @@ module Xml_react = struct
     let _ = {unit{
         ignore (React.S.map
                   (fun l ->
-                     Html5.Manip.replaceAllChildren
+                     Html5.Manip.replaceChildren
                        (Html5.F.tot %((n : elt)))
                        (Html5.F.totl l))
                 %((children_signal_client_value : elt list React.signal client_value)))

--- a/tests/eliom_testsuite3.eliom
+++ b/tests/eliom_testsuite3.eliom
@@ -3702,7 +3702,7 @@ let tmpl1_update (id : Html5_types.flow5 Html5.Id.id) (contents : Html5_types.fl
   Eliom_client.onload
     (fun () ->
       debug "Update";
-      Html5.Manip.Named.replaceAllChildren %id %contents)
+      Html5.Manip.Named.replaceChildren %id %contents)
 }}
 
 module Tmpl_1 = Eliom_registration.Eliom_tmpl(My_appl)(struct


### PR DESCRIPTION
Since we are breaking those things. `Children` seems a better English to me, compared to `AllChildren`.
