### PR TITLE
Remove most references to Eliom_content_core from the public APIs

### DIFF
--- a/src/client/eliom_registration.ml
+++ b/src/client/eliom_registration.ml
@@ -1,7 +1,9 @@
 
 open Eliom_lib
 
-include Eliom_registration_base
+type non_ocaml_service = Eliom_service.non_ocaml_service
+type appl_service = Eliom_service.appl_service
+type http_service = Eliom_service.http_service
 
 module type Base =
 sig

--- a/src/clientserver/eliom_content.server.mli
+++ b/src/clientserver/eliom_content.server.mli
@@ -97,7 +97,6 @@ module Xml : sig
       Cf. {% <<a_api project="tyxml" | module Xml_sigs.Iterable >> %}. *)
 
   include Xml_sigs.Iterable with type 'a wrap = 'a
-                             and type uri = Eliom_content_core.Xml.uri
 
   (** {2 Unique nodes } *)
 
@@ -130,7 +129,7 @@ module Xml : sig
   val uri_of_fun: (unit -> string) -> uri
 
   (* Building ref tree. *)
-  type event_handler_table = Eliom_content_core.Xml.event_handler_table
+  type event_handler_table = Eliom_lib.RawXML.event_handler_table
   (* Concrete on client-side only. *)
   type node_id
   val get_node_id : elt -> node_id
@@ -175,8 +174,8 @@ module Svg : sig
       semantics>> %} for SVG tree manipulated by client/server
       application. *)
 
-  type +'a elt = 'a Eliom_content_core.Svg.elt
-  type +'a attrib = 'a Eliom_content_core.Svg.attrib
+  type +'a elt
+  type +'a attrib
   type 'a wrap = 'a
   type uri = Xml.uri
 
@@ -184,9 +183,6 @@ module Svg : sig
       semantics). See {% <<a_api project="tyxml" | module type
       Svg_sigs.T >> %}. *)
   module F : sig
-
-    type +'a elt = 'a Eliom_content_core.Svg.elt
-    type +'a attrib = 'a Eliom_content_core.Svg.attrib
 
     (** Cf. {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
     module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
@@ -200,8 +196,6 @@ module Svg : sig
 		             and type uri = uri
 
     include module type of Raw
-    with type +'a elt := 'a elt
-     and type +'a attrib := 'a attrib
 
 
     (** {2 Event handlers} *)
@@ -215,9 +209,6 @@ module Svg : sig
       {% <<a_api project="tyxml" | module type Svg_sigs.T >> %}. *)
   module D : sig
 
-    type +'a elt = 'a Eliom_content_core.Svg.elt
-    type +'a attrib = 'a Eliom_content_core.Svg.attrib
-
     (** Cf. {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
     module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
                              and type Xml.event_handler = Xml.event_handler
@@ -230,8 +221,6 @@ module Svg : sig
 		             and type uri = uri
 
     include module type of Raw
-    with type +'a elt := 'a elt
-     and type +'a attrib := 'a attrib
 
     (** {2 Event handlers} *)
 
@@ -245,9 +234,6 @@ module Svg : sig
       {% <<a_api project="tyxml" | module type Svg_sigs.T >> %}. *)
   module R : sig
 
-    type +'a elt = 'a Eliom_content_core.Svg.elt
-    type +'a attrib = 'a Eliom_content_core.Svg.attrib
-
     module Raw : Svg_sigs.T
       with type Xml.uri = Xml.uri
        and type Xml.event_handler = Xml.event_handler
@@ -260,8 +246,6 @@ module Svg : sig
        and type uri = uri
 
     include module type of Raw
-    with type +'a elt := 'a elt
-     and type +'a attrib := 'a attrib
 
     (** {2 Event handlers} *)
 
@@ -313,8 +297,8 @@ module Html5 : sig
       semantics>> %} in Eliom's manual
       for HTML5 tree manipulated by client/server application. *)
 
-  type +'a elt = 'a Eliom_content_core.Html5.elt
-  type +'a attrib = 'a Eliom_content_core.Html5.attrib
+  type +'a elt
+  type +'a attrib
   type uri = Xml.uri
 
   (** Creation of {b F}unctional HTML5 content (copy-able but not referable, see also {% <<a_api|module Eliom_content>> %}). *)
@@ -328,9 +312,6 @@ module Html5 : sig
         For more information,
         see {{:http://ocsigen.org/howto/forms/}"how to make forms"} *)
     open Pervasives
-
-    type +'a elt = 'a Eliom_content_core.Html5.elt
-    type +'a attrib = 'a Eliom_content_core.Html5.attrib
 
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
     module Raw : Html5_sigs.T
@@ -346,8 +327,6 @@ module Html5 : sig
                    and type uri = uri
 
     include module type of Raw (*BB TODO Hide untyped [input]. *)
-    with type +'a elt := 'a elt
-     and type +'a attrib := 'a attrib
 
     (** {2 Event handlers} *)
 
@@ -406,9 +385,6 @@ module Html5 : sig
         see {{:http://ocsigen.org/howto/forms/}"how to make forms"} *)
     open Pervasives
 
-    type +'a elt = 'a Eliom_content_core.Html5.elt
-    type +'a attrib = 'a Eliom_content_core.Html5.attrib
-
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
     module Raw : Html5_sigs.T
                    with type Xml.uri = Xml.uri
@@ -422,8 +398,6 @@ module Html5 : sig
                    and type +'a attrib = 'a attrib
                    and type uri = uri
     include module type of Raw (*BB TODO Hide untyped [input]. *)
-    with type +'a elt := 'a elt
-     and type +'a attrib := 'a attrib
 
     (** {2 Event handlers} *)
 
@@ -485,24 +459,20 @@ module Html5 : sig
     The resulting HTML5 [elt] can then be used like anyother HTML5 [elt] *)
     val node : 'a elt React.signal Eliom_pervasives.client_value -> 'a elt
 
-    type +'a elt = 'a Eliom_content_core.Html5.elt
-    type +'a attrib = 'a Eliom_content_core.Html5.attrib
-
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
     module Raw : Html5_sigs.T
                    with type Xml.uri = Xml.uri
                     and type Xml.event_handler = Xml.event_handler
                     and type Xml.attrib = Xml.attrib
                     and type Xml.elt = Xml.elt
+                    and type +'a elt = 'a elt
                     and type 'a Xml.wrap = 'a React.signal Eliom_pervasives.client_value
+                    and type +'a attrib = 'a attrib
                    with module Svg := Svg.D.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a React.signal Eliom_pervasives.client_value
+                   with type 'a wrap = 'a React.signal Eliom_pervasives.client_value
                     and type +'a attrib = 'a attrib
                     and type uri = uri
     include module type of Raw (*BB TODO Hide untyped [input]. *)
-    with type +'a elt := 'a elt
-     and type +'a attrib := 'a attrib
 
     (** {2 Event handlers} *)
 

--- a/src/common/eliom_registration_base.ml
+++ b/src/common/eliom_registration_base.ml
@@ -24,8 +24,6 @@ open Eliom_content_core
 open Eliom_service
 open Eliom_parameter
 
-type appl_service = Eliom_service.appl_service
-type http_service = Eliom_service.http_service
 type non_ocaml_service = Eliom_service.non_ocaml_service
 
 type input_type =

--- a/src/server/eliom_content_core.mli
+++ b/src/server/eliom_content_core.mli
@@ -136,6 +136,11 @@ end
 
 module Html5 : sig
 
+  (** See the Eliom manual for more information on {% <<a_manual
+      chapter="clientserver-html" fragment="unique"| dom semantics vs. functional
+      semantics>> %} for HTML5 tree manipulated by client/server
+      application. *)
+
   type +'a elt = Xml.elt (* ***!!! will be abstracted later! O.o DO NOT INSTALL eliom_content_core.cmi **)
   type 'a wrap = 'a
   type 'a attrib = Xml.attrib (* ***!!! will be abstracted later! O.o DO NOT INSTALL eliom_content_core.cmi **)

--- a/src/server2/eliom_registration.ml
+++ b/src/server2/eliom_registration.ml
@@ -28,7 +28,9 @@ let code_of_code_option = function
   | None -> 200
   | Some c -> c
 
-include Eliom_registration_base
+type non_ocaml_service = Eliom_service.non_ocaml_service
+type appl_service = Eliom_service.appl_service
+type http_service = Eliom_service.http_service
 
 (******************************************************************************)
 (* Send return types                                                          *)
@@ -2022,7 +2024,7 @@ module Eliom_appl_reg_make_param
       split_page (Eliom_content.Html5.D.toelt page) in
     let head_elts =
          appl_data_script
-      :: Eliom_content.Html5.F.base ~a:[a_id Eliom_common_base.base_elt_id; Eliom_content.Html5.D.a_href (Eliom_content_core.Html5.D.uri_of_string base_url)] ()
+      :: Eliom_content.Html5.F.base ~a:[a_id Eliom_common_base.base_elt_id; Eliom_content.Html5.D.a_href (Eliom_content.Xml.uri_of_string base_url)] ()
       :: ( if List.exists is_eliom_appl_script head_elts
            then head_elts
 	   else ( head_elts


### PR DESCRIPTION
Ocsimore compiles with this change.

I have made the types elt/attrib abstracts in `Eliom_content`.

As far as I can see, we only reference type `Eliom_content_core.event_handler_table` in public APIs, which is harmless.
