### PR TITLE
Fix cache issue

### DIFF
--- a/src/client/eliom_client.ml
+++ b/src/client/eliom_client.ml
@@ -960,6 +960,8 @@ let load_data_script page =
     Firebug.console##time(Js.string "load_data_script");
   ignore (Js.Unsafe.eval_string (Js.to_string script));
   Eliom_request_info.reset_request_data ();
+  Eliom_process.reset_request_template ();
+  Eliom_process.reset_request_cookies ();
   if !Eliom_config.debug_timings then
     Firebug.console##timeEnd(Js.string "load_data_script")
 

--- a/src/client/eliom_process.ml
+++ b/src/client/eliom_process.ml
@@ -36,23 +36,29 @@ let get_set_js_serverside_value r name =
         (fun var ->
           let s = unmarshal_js var in
           r := Some s;
-          s))
+          s)),
+  (fun () -> r:= None)
 
 let set_sitedata, is_set_sitedata,
-  (get_sitedata : unit -> Eliom_types.sitedata) =
+    (get_sitedata : unit -> Eliom_types.sitedata),
+    (reset_sitedata)=
   get_set_js_serverside_value Eliom_common.sitedata "__eliom_appl_sitedata"
 
 let set_info, is_set_info,
-  (get_info : unit -> Eliom_common.client_process_info) =
+    (get_info : unit -> Eliom_common.client_process_info),
+    (reset_info)
+  =
   get_set_js_serverside_value (ref None) "__eliom_appl_process_info"
 
 let set_request_cookies, is_set_request_cookies,
-  (get_request_cookies : unit -> Eliommod_cookies.cookie
-   Ocsigen_cookies.CookiesTable.t Ocsigen_cookies.Cookies.t) =
+    (get_request_cookies : unit -> Eliommod_cookies.cookie
+       Ocsigen_cookies.CookiesTable.t Ocsigen_cookies.Cookies.t),
+  reset_request_cookies =
   get_set_js_serverside_value (ref None) "__eliom_request_cookies"
 
 let set_request_template, is_set_request_template,
-  (get_request_template : unit -> string option) =
+    (get_request_template : unit -> string option),
+  reset_request_template =
   get_set_js_serverside_value (ref None) "__eliom_request_template"
 
 let appl_name =

--- a/tests/eliom_testsuite3.eliom
+++ b/tests/eliom_testsuite3.eliom
@@ -3698,13 +3698,12 @@ let tmpl2_page2 = Eliom_service.App.service
   ~get_params:unit
   ()
 
-let tmpl1_update (id : Html5_types.flow5 Html5.Id.id) (contents : Html5_types.flow5 Html5.elt list) = {{
+let tmpl_update (id : Html5_types.flow5 Html5.Id.id) (contents : Html5_types.flow5 Html5.elt list) = {{
   Eliom_client.onload
     (fun () ->
       debug "Update";
       Html5.Manip.Named.replaceChildren %id %contents)
 }}
-
 module Tmpl_1 = Eliom_registration.Eliom_tmpl(My_appl)(struct
   type t = Html5_types.flow5 Html5.elt list
   let name = "template_one"
@@ -3730,7 +3729,7 @@ module Tmpl_1 = Eliom_registration.Eliom_tmpl(My_appl)(struct
                  [pcdata "Click me 2 (change_page, tmpl2)"];
              ];
           Html5.Id.create_named_elt ~id:content_id (div contents)])
-  let update  = tmpl1_update content_id
+  let update  = tmpl_update content_id
 end)
 
 module Tmpl_2 = Eliom_registration.Eliom_tmpl(My_appl)(struct
@@ -3758,23 +3757,23 @@ module Tmpl_2 = Eliom_registration.Eliom_tmpl(My_appl)(struct
                  [pcdata "Click me 2 (change_page)"];
              ];
           Html5.Id.create_named_elt ~id:content_id (div contents)])
-  let update  = tmpl1_update content_id
+  let update  = tmpl_update content_id
 end)
 
 let () = Tmpl_1.register ~service:tmpl1_page1
-  (fun () () -> Lwt.return [h3 [pcdata "Page 1"]])
+  (fun () () -> Lwt.return [h3 [pcdata "Page 1 with tmpl1"]])
 
 let () = Tmpl_1.register ~service:tmpl1_page2
-  (fun () () -> Lwt.return [h3 [pcdata "Page 2"]])
+  (fun () () -> Lwt.return [h3 [pcdata "Page 2 with tmpl1" ]])
 
 let () = Tmpl_1.register ~service:tmpl1_page3
-  (fun () () -> Lwt.return [h3 [pcdata "Page 3"]])
+  (fun () () -> Lwt.return [h3 [pcdata "Page 3 with tmpl1"]])
 
 let () = Tmpl_2.register ~service:tmpl2_page1
-  (fun () () -> Lwt.return [h3 [pcdata "Page 1"]])
+  (fun () () -> Lwt.return [h3 [pcdata "Page 1 with tmpl2"]])
 
 let () = Tmpl_2.register ~service:tmpl2_page2
-  (fun () () -> Lwt.return [h3 [pcdata "Page 2"]])
+  (fun () () -> Lwt.return [h3 [pcdata "Page 2 with tmpl2"]])
 
 
 (**** HISTORY ****)


### PR DESCRIPTION
There was an issue when navigating throw different templates.
The `get_request_template` value was cached and never updated
The same for `request_cookies`.
It fixes navigation between pages `/tmpl2/page[1,2]` and `/tmp1/page[1,2,3]` from the testsuite
