### PR TITLE
Fix typo in reactive DOM description in Eliom 4

### DIFF
--- a/doc/manual-wiki/clientserver-html.wiki
+++ b/doc/manual-wiki/clientserver-html.wiki
@@ -284,7 +284,7 @@ let () =
     (fun () () ->
        let inp = make_input () in
        let cldiv = D.div [] in
-       ignore {unit{ Manip.appendChilds %cldiv (make_client_nodes ()) }};
+       ignore {unit{ Manip.appendChildren %cldiv (make_client_nodes ()) }};
        Lwt.return
          (Eliom_tools.F.html
             ~title:"testnodes"


### PR DESCRIPTION
Hi,

I was taking a look to new implementation of the reactive DOM (introduced with eliom 4) and I found a little typo in the given code. I'm not sure if it was an intended typo or not (I've seen some issues about the naming of `AllChildren`/`Children`, maybe it is the same here for `appendChilds`/`appendChildren`), but anyway it is a little thing to change, but it could be confusing for fresh beginners on ocsigen. :)

I prefer to use a pull request here instead of fixing it directly on the repo since I'm not sure if it is due to an unintended typo.
