### PR TITLE
Simplify Html5 and Svg signatures using tyxml's signature functors.

### DIFF
--- a/src/lib/eliom_content.client.mli
+++ b/src/lib/eliom_content.client.mli
@@ -52,19 +52,9 @@ module Svg : sig
        See {% <<a_api project="tyxml" | module Svg_sigs.T >> %} *)
   module F : sig
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                             and type Xml.event_handler = Xml.event_handler
-                             and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                             and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                             and type Xml.attrib = Xml.attrib
-                             and type Xml.elt = Xml.elt
-			     and type 'a elt = 'a elt
-                             and type 'a Xml.wrap = 'a
-                             and type 'a wrap = 'a
-                             and type 'a Xml.list_wrap = 'a list
-                             and type 'a list_wrap = 'a list
-                             and type 'a attrib = 'a attrib
-		             and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
   end
@@ -75,39 +65,18 @@ module Svg : sig
        See {% <<a_api project="tyxml" | module Svg_sigs.T >> %} *)
   module D : sig
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                             and type Xml.event_handler = Xml.event_handler
-                             and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                             and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                             and type Xml.attrib = Xml.attrib
-                             and type Xml.elt = Xml.elt
-			     and type 'a elt = 'a elt
-                             and type 'a Xml.wrap = 'a
-                             and type 'a wrap = 'a
-                             and type 'a Xml.list_wrap = 'a list
-                             and type 'a list_wrap = 'a list
-                             and type 'a attrib = 'a attrib
-		             and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
   end
 
   (** Creation of reactive content *)
   module R : sig
-    module Raw : Svg_sigs.T
-      with type Xml.uri = Xml.uri
-       and type Xml.event_handler = Xml.event_handler
-       and type Xml.mouse_event_handler = Xml.mouse_event_handler
-       and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-       and type Xml.attrib = Xml.attrib
-       and type Xml.elt = Xml.elt
-       and type 'a elt = 'a elt
-       and type 'a Xml.wrap = 'a React.signal Eliom_pervasives.client_value
-       and type 'a wrap = 'a React.signal Eliom_pervasives.client_value
-       and type 'a Xml.list_wrap = 'a ReactiveData.RList.t Eliom_pervasives.client_value
-       and type 'a list_wrap = 'a ReactiveData.RList.t Eliom_pervasives.client_value
-       and type 'a attrib = 'a attrib
-       and type uri = uri
+    module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
   end
@@ -290,21 +259,9 @@ module Html5 : sig
         See {% <<a_api project="tyxml" | module Html5_sigs.T >> %} *)
 
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   with module Svg := Svg.F.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a
-                    and type 'a list_wrap = 'a list
-                   and type 'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
 
@@ -351,21 +308,10 @@ module Html5 : sig
         See {% <<a_api project="tyxml" | module Html5_sigs.T >> %} *)
 
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   with module Svg := Svg.D.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a
-                    and type 'a list_wrap = 'a list
-                   and type 'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
+
     include module type of Raw
 
     (**/**)
@@ -430,21 +376,10 @@ module Html5 : sig
     val filter_attrib : 'a attrib -> bool React.signal -> 'a attrib
 
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                    and type Xml.event_handler = Xml.event_handler
-                    and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                    and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                    and type Xml.attrib = Xml.attrib
-                    and type Xml.elt = Xml.elt
-                    and type 'a Xml.wrap = 'a React.signal Eliom_pervasives.client_value
-                    and type 'a Xml.list_wrap = 'a ReactiveData.RList.t Eliom_pervasives.client_value
-                   with module Svg := Svg.R.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a React.signal Eliom_pervasives.client_value
-                    and type 'a list_wrap = 'a ReactiveData.RList.t Eliom_pervasives.client_value
-                    and type 'a attrib = 'a attrib
-                    and type uri = uri
+    module Raw : Html5_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml)(Svg.R.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
+
     include module type of Raw
   end
 

--- a/src/lib/eliom_content.server.mli
+++ b/src/lib/eliom_content.server.mli
@@ -183,19 +183,9 @@ module Svg : sig
   module F : sig
 
     (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                             and type Xml.event_handler = Xml.event_handler
-                             and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                             and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                             and type Xml.attrib = Xml.attrib
-                             and type Xml.elt = Xml.elt
-                             and type +'a elt = 'a elt
-                             and type 'a Xml.wrap = 'a
-                             and type 'a wrap = 'a
-                             and type 'a Xml.list_wrap = 'a list
-                             and type 'a list_wrap = 'a list
-                             and type +'a attrib = 'a attrib
-                             and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
 
@@ -206,19 +196,9 @@ module Svg : sig
   module D : sig
 
     (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                             and type Xml.event_handler = Xml.event_handler
-                             and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                             and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                             and type Xml.attrib = Xml.attrib
-                             and type Xml.elt = Xml.elt
-                             and type +'a elt = 'a elt
-                             and type 'a Xml.wrap = 'a
-                             and type 'a wrap = 'a
-                             and type 'a Xml.list_wrap = 'a list
-                             and type 'a list_wrap = 'a list
-                             and type +'a attrib = 'a attrib
-                             and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
 
@@ -293,21 +273,9 @@ module Html5 : sig
         see {{:http://ocsigen.org/howto/forms/}"how to make forms"} *)
 
     (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   with module Svg := Svg.F.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a
-                    and type 'a list_wrap = 'a list
-                   and type +'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
 
@@ -362,21 +330,10 @@ module Html5 : sig
         see {{:http://ocsigen.org/howto/forms/}"how to make forms"} *)
 
     (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   with module Svg := Svg.D.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a
-                    and type 'a list_wrap = 'a list
-                   and type +'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
+
     include module type of Raw
 
     (**/**)

--- a/src/lib/eliom_content_core.client.mli
+++ b/src/lib/eliom_content_core.client.mli
@@ -167,19 +167,10 @@ module Svg : sig
       See {% <<a_api project="tyxml" | module type Svg_sigs.T >> %}. *)
   module F : sig
 
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                            and type Xml.event_handler = Xml.event_handler
-                            and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                            and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                            and type Xml.attrib = Xml.attrib
-                            and type Xml.elt = Xml.elt
-                              with type +'a elt = 'a elt
-                              and type 'a Xml.wrap = 'a
-                              and type 'a wrap = 'a
-                              and type 'a Xml.list_wrap = 'a list
-                              and type 'a list_wrap = 'a list
-                              and type +'a attrib = 'a attrib
-                              and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
+
 
     (** See {% <<a_api project="tyxml" | module type Svg_sigs.T >> %}. *)
     include module type of Raw
@@ -192,19 +183,9 @@ module Svg : sig
       {% <<a_api project="tyxml" | module type Svg_sigs.T >> %}. *)
   module D : sig
 
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                            and type Xml.event_handler = Xml.event_handler
-                            and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                            and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                            and type Xml.attrib = Xml.attrib
-                            and type Xml.elt = Xml.elt
-                              with type +'a elt = 'a elt
-                              and type 'a Xml.wrap = 'a
-                              and type 'a wrap = 'a
-                              and type 'a Xml.list_wrap = 'a list
-                              and type 'a list_wrap = 'a list
-                              and type +'a attrib = 'a attrib
-                              and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     (** See {% <<a_api project="tyxml" | module type Svg_sigs.T >> %}. *)
     include module type of Raw
@@ -216,19 +197,9 @@ module Svg : sig
   (** Typed interface for building valid reactive SVG tree. *)
   module R : sig
 
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                            and type Xml.event_handler = Xml.event_handler
-                            and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                            and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                            and type Xml.attrib = Xml.attrib
-                            and type Xml.elt = Xml.elt
-                              with type +'a elt = 'a elt
-                              and type 'a Xml.wrap = 'a React.signal
-                              and type 'a wrap = 'a React.signal
-                              and type 'a Xml.list_wrap = 'a ReactiveData.RList.t
-                              and type 'a list_wrap = 'a ReactiveData.RList.t
-                              and type +'a attrib = 'a attrib
-                              and type uri = uri
+    module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     (** See {% <<a_api project="tyxml" | module type Svg_sigs.T >> %}. *)
     include module type of Raw
@@ -276,21 +247,9 @@ module Html5 : sig
       See {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
   module F : sig
 
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   with module Svg := Svg.F.Raw
-                   with type +'a elt = 'a elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   and type 'a list_wrap = 'a list
-                   and type +'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     (** See {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
     include module type of Raw (*BB TODO Hide untyped [input]. *)
@@ -309,21 +268,10 @@ module Html5 : sig
       {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
   module D: sig
 
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and module Svg := Svg.D.Raw
-                   and type +'a elt = 'a elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   and type 'a list_wrap = 'a list
-                   and type +'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
+
     include module type of Raw
 
     (**/**)
@@ -350,21 +298,10 @@ module Html5 : sig
 
     val filter_attrib : 'a attrib -> bool React.signal -> 'a attrib
 
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and module Svg := Svg.D.Raw
-                   and type +'a elt = 'a elt
-                   and type 'a Xml.wrap = 'a React.signal
-                   and type 'a wrap = 'a React.signal
-                   and type 'a Xml.list_wrap = 'a ReactiveData.RList.t
-                   and type 'a list_wrap = 'a ReactiveData.RList.t
-                   and type +'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml)(Svg.R.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
+
     include module type of Raw
 
   end

--- a/src/lib/eliom_content_core.server.mli
+++ b/src/lib/eliom_content_core.server.mli
@@ -88,19 +88,9 @@ module Svg : sig
 
   module F : sig
 
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                             and type Xml.event_handler = Xml.event_handler
-                             and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                             and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                             and type Xml.attrib = Xml.attrib
-                             and type Xml.elt = Xml.elt
-			     and type +'a elt = 'a elt
-                             and type 'a Xml.wrap = 'a
-                             and type 'a wrap = 'a
-                             and type 'a Xml.list_wrap = 'a list
-                             and type 'a list_wrap = 'a list
-                             and type +'a attrib = 'a attrib
-		             and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
 
@@ -108,19 +98,9 @@ module Svg : sig
 
   module D : sig
 
-    module Raw : Svg_sigs.T with type Xml.uri = Xml.uri
-                             and type Xml.event_handler = Xml.event_handler
-                             and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                             and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                             and type Xml.attrib = Xml.attrib
-                             and type Xml.elt = Xml.elt
-			     and type +'a elt = 'a elt
-                             and type 'a Xml.wrap = 'a
-                             and type 'a wrap = 'a
-                             and type 'a Xml.list_wrap = 'a list
-                             and type 'a list_wrap = 'a list
-                             and type +'a attrib = 'a attrib
-		             and type uri = uri
+    module Raw : Svg_sigs.Make(Xml).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
 
@@ -159,21 +139,9 @@ module Html5 : sig
 
   module F : sig
 
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   with module Svg := Svg.F.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a
-                    and type 'a list_wrap = 'a list
-                   and type +'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
 
     include module type of Raw
 
@@ -187,21 +155,10 @@ module Html5 : sig
 
   module D : sig
 
-    module Raw : Html5_sigs.T
-                   with type Xml.uri = Xml.uri
-                   and type Xml.event_handler = Xml.event_handler
-                   and type Xml.mouse_event_handler = Xml.mouse_event_handler
-                   and type Xml.keyboard_event_handler = Xml.keyboard_event_handler
-                   and type Xml.attrib = Xml.attrib
-                   and type Xml.elt = Xml.elt
-                   and type 'a Xml.wrap = 'a
-                   and type 'a Xml.list_wrap = 'a list
-                   with module Svg := Svg.D.Raw
-                   with type +'a elt = 'a elt
-                    and type 'a wrap = 'a
-                    and type 'a list_wrap = 'a list
-                   and type +'a attrib = 'a attrib
-                   and type uri = uri
+    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+      with type +'a elt = 'a elt
+       and type +'a attrib = 'a attrib
+
     include module type of Raw
 
     val client_attrib : ?init:'a attrib -> 'a attrib Eliom_lib.client_value -> 'a attrib


### PR DESCRIPTION
See ocsigen/tyxml#50

It doesn't actually fix anything (afaict) but it's simpler (and doesn't make the documentation any worse). It will also auto-update in the future, if the export is changed.

There is one "question" about uri. Currently `uri` is **defined** in Html5_sigs.T as `Xml.uri`, so there is no need to reexport it everywhere (hence why I didn't). I could add an explicit `with type uri = uri` just to make sure that everything is consistent, but it's not necessary (and I doubt we will ever change it).
