### PR TITLE
Fix compilation (with help of @hnrgrgr)

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -489,9 +489,9 @@ let iter_prop node name f =
   | Some n -> f n
   | None -> ()
 
-let rec rebuild_rattrib node ra = match Xml.racontent ra with
+let rec rebuild_rattrib (node : Dom_html.element Js.t) ra = match Xml.racontent ra with
   | Xml.RA a ->
-    let name = Xml.aname ra in
+    let name = Js.string (Xml.aname ra) in
     let v = rebuild_attrib_val a in
     node##setAttribute (name,v);
   | Xml.RAReact s ->

--- a/src/lib/eliom_content.eliom
+++ b/src/lib/eliom_content.eliom
@@ -78,7 +78,9 @@ module Html5 = struct
           let real = Html5.To_dom.of_element (unboxed client_boxed) in
           Js.Opt.iter
             (dummy_dom##parentNode)
-            (fun parent -> ignore (parent##replaceChild(real, dummy_dom)));
+            (fun parent -> ignore (parent##replaceChild(
+                                    (real :> Dom.node Js.t),
+                                    (dummy_dom :> Dom.node Js.t))));
         }} in
       init
 


### PR DESCRIPTION
Eliom does not compile out-of-box but @ocsigen-buildbot compile. I think clean the buildbot does not work because I have not seen in the logs the compilation of `eliom_client.client.ml` especially.
