### PR TITLE
Eliom_content.Svg.R.node

### DIFF
--- a/src/lib/eliom_content.client.mli
+++ b/src/lib/eliom_content.client.mli
@@ -75,9 +75,9 @@ module Svg : sig
   (** Creation of reactive content *)
   module R : sig
 
-    (** the function [node s] create an SVG [elt] from a signal [s].
+    (** The function [node s] creates an SVG [elt] from a signal [s].
         The resulting SVG [elt] can then be used like any other SVG
-        [elt] *)
+        [elt]. *)
     val node : 'a elt React.signal -> 'a elt
 
     module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T

--- a/src/lib/eliom_content.client.mli
+++ b/src/lib/eliom_content.client.mli
@@ -74,6 +74,12 @@ module Svg : sig
 
   (** Creation of reactive content *)
   module R : sig
+
+    (** the function [node s] create an SVG [elt] from a signal [s].
+        The resulting SVG [elt] can then be used like any other SVG
+        [elt] *)
+    val node : 'a elt React.signal -> 'a elt
+
     module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib

--- a/src/lib/eliom_content_core.client.ml
+++ b/src/lib/eliom_content_core.client.ml
@@ -251,6 +251,9 @@ module Svg = struct
   end
 
   module R = struct
+
+    let node s = Xml.make_react s
+
     module Raw = Svg_f.MakeWrapped(Tyxml_js.Xml_wrap)(Xml_wed)
     include Raw
 

--- a/src/lib/eliom_content_core.client.mli
+++ b/src/lib/eliom_content_core.client.mli
@@ -197,6 +197,11 @@ module Svg : sig
   (** Typed interface for building valid reactive SVG tree. *)
   module R : sig
 
+    (** the function [node s] create an SVG [elt] from a signal [s].
+        The resulting SVG [elt] can then be used like any other SVG
+        [elt] *)
+    val node : 'a elt React.signal -> 'a elt
+
     module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib

--- a/src/lib/eliom_content_core.client.mli
+++ b/src/lib/eliom_content_core.client.mli
@@ -197,9 +197,9 @@ module Svg : sig
   (** Typed interface for building valid reactive SVG tree. *)
   module R : sig
 
-    (** the function [node s] create an SVG [elt] from a signal [s].
+    (** The function [node s] creates an SVG [elt] from a signal [s].
         The resulting SVG [elt] can then be used like any other SVG
-        [elt] *)
+        [elt]. *)
     val node : 'a elt React.signal -> 'a elt
 
     module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T


### PR DESCRIPTION
This small patch implements `Eliom_content.Svg.R.node`. This is much like `Eliom_content.Html5.R.node`.