### PR TITLE
fixing encoding of Boolean parameters (true -> "on", false -> nothing)

### DIFF
--- a/src/lib/eliom_parameter_base.shared.ml
+++ b/src/lib/eliom_parameter_base.shared.ml
@@ -273,6 +273,12 @@ let rec aux : type a c. (a,'b,c) params_type -> string list option -> 'y -> a ->
         (fun (psuff, nlp, l) v -> aux t psuff nlp v pref suff l)
         (psuff, nlp, l)
         params
+    | TAtom (name,TBool) ->
+      psuff, nlp,
+      if params then
+        (pref^name^suff, insert_string "on") :: l
+      else
+        l
     | TAtom (name,a) -> psuff,nlp,((pref^name^suff,insert_string (string_of_atom a params))::l )
     | TCoord name ->
       psuff, nlp,


### PR DESCRIPTION
This patch fixes how Boolean parameters are encoded as part of the URL. Our convention is that any string for the parameter means true, and absence of the parameter means false.