### PR TITLE
Update for new-style TyXML wrapping

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -1,8 +1,8 @@
 opam pin add --no-action eliom .
 opam pin add --no-action reactiveData 'https://github.com/hhugo/reactiveData.git#master'
-#opam pin add --no-action tyxml 'https://github.com/ocsigen/tyxml.git#master'
+opam pin add --no-action tyxml 'https://github.com/ocsigen/tyxml.git#master'
 opam pin add --no-action ocsigenserver 'https://github.com/ocsigen/ocsigenserver.git#master'
-#opam pin add --no-action js_of_ocaml 'https://github.com/ocsigen/js_of_ocaml.git#master'
+opam pin add --no-action js_of_ocaml 'https://github.com/ocsigen/js_of_ocaml.git#master'
 opam install --deps-only eliom
 opam install --verbose eliom
 

--- a/opam
+++ b/opam
@@ -11,8 +11,8 @@ build: [make]
 depends: [
   "ocamlfind"
   "deriving" {>= "0.6"}
-  "js_of_ocaml" {>= "2.5"}
-  "tyxml" {>= "3.3.0"}
+  "js_of_ocaml" {> "2.6"}
+  "tyxml" {> "3.5.0"}
   "calendar"
   "ocsigenserver" {>= "2.6"}
   "ipaddr" {>= "2.1"}

--- a/src/lib/eliom_content.client.mli
+++ b/src/lib/eliom_content.client.mli
@@ -80,7 +80,7 @@ module Svg : sig
         [elt]. *)
     val node : 'a elt React.signal -> 'a elt
 
-    module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T
+    module Raw : Svg_sigs.Make(Eliom_content_core.Xml_wed).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -403,7 +403,7 @@ module Html5 : sig
     val filter_attrib : 'a attrib -> bool React.signal -> 'a attrib
 
     (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml)(Svg.R.Raw).T
+    module Raw : Html5_sigs.Make(Eliom_content_core.Xml_wed)(Svg.R.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 

--- a/src/lib/eliom_content_core.client.ml
+++ b/src/lib/eliom_content_core.client.ml
@@ -27,6 +27,7 @@ open Eliom_lib
 
 module Xml = struct
   include RawXML
+  module W = Xml_wrap.NoWrap
   type 'a wrap = 'a
   type 'a list_wrap = 'a list
   type econtent =
@@ -164,8 +165,9 @@ end
 
 module Xml_wed =
 struct
-  type 'a wrap = 'a Tyxml_js.Xml_wrap.t
-  type 'a list_wrap = 'a Tyxml_js.Xml_wrap.tlist
+  module W = Tyxml_js.Xml_wrap
+  type 'a wrap = 'a W.t
+  type 'a list_wrap = 'a W.tlist
   type uri = Xml.uri
   let string_of_uri = Xml.string_of_uri
   let uri_of_string = Xml.uri_of_string
@@ -254,7 +256,7 @@ module Svg = struct
 
     let node s = Xml.make_react s
 
-    module Raw = Svg_f.MakeWrapped(Tyxml_js.Xml_wrap)(Xml_wed)
+    module Raw = Svg_f.Make(Xml_wed)
     include Raw
 
   end
@@ -326,7 +328,7 @@ module Html5 = struct
 
     let node s = Xml.make_react s
 
-    module Raw = Html5_f.MakeWrapped(Tyxml_js.Xml_wrap)(Xml_wed)(Svg.R)
+    module Raw = Html5_f.Make(Xml_wed)(Svg.R)
     let filter_attrib (name,a) on =
       let v = match a with
         | Xml.RA a -> Xml.RAReact (React.S.map (function

--- a/src/lib/eliom_content_core.client.mli
+++ b/src/lib/eliom_content_core.client.mli
@@ -22,6 +22,8 @@
 
 module Xml : sig
 
+  module W : Xml_wrap.T with type 'a t = 'a and type 'a tlist = 'a list
+
   type uri = string
   val uri_of_string : uri -> string
   val string_of_uri : string -> uri
@@ -147,6 +149,8 @@ module Xml : sig
   val set_classes_of_elt : elt -> elt
 end
 
+module Xml_wed : Xml_sigs.T with module W = Tyxml_js.Xml_wrap
+
 (** Building SVG tree. *)
 module Svg : sig
 
@@ -202,7 +206,7 @@ module Svg : sig
         [elt]. *)
     val node : 'a elt React.signal -> 'a elt
 
-    module Raw : Svg_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml).T
+    module Raw : Svg_sigs.Make(Xml_wed).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -303,7 +307,7 @@ module Html5 : sig
 
     val filter_attrib : 'a attrib -> bool React.signal -> 'a attrib
 
-    module Raw : Html5_sigs.MakeWrapped(Tyxml_js.Xml_wrap)(Xml)(Svg.R.Raw).T
+    module Raw : Html5_sigs.Make(Xml_wed)(Svg.R.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 

--- a/src/lib/eliom_content_core.server.ml
+++ b/src/lib/eliom_content_core.server.ml
@@ -28,6 +28,7 @@ open Eliom_lib
 
 module Xml = struct
   include RawXML
+  module W = Xml_wrap.NoWrap
   type 'a wrap = 'a
   type 'a list_wrap = 'a list
 


### PR DESCRIPTION
This brings Eliom up-to-speed with the new-style wrapping available in current TyXML master. See ocsigen/tyxml#58 for the TyXML side of the story. This PR presupposes ocsigen/js_of_ocaml#348.