### PR TITLE
Syntax for Shared Expressions

### DIFF
--- a/src/lib/eliom_lib.client.ml
+++ b/src/lib/eliom_lib.client.ml
@@ -35,6 +35,9 @@ exception Exception_on_server of string
 
 type 'a client_value = 'a
 type 'a shared_value = 'a
+
+let create_shared_value (_ : 'a) (c : 'a client_value) = c
+
 (*****************************************************************************)
 
 module Url = struct

--- a/src/lib/eliom_lib.client.mli
+++ b/src/lib/eliom_lib.client.mli
@@ -39,6 +39,8 @@ include module type of Eliom_lib_base
 type 'a client_value = 'a
 type 'a shared_value = 'a
 
+val create_shared_value : 'a -> 'a client_value -> 'a shared_value
+
 exception Eliom_Internal_Error of string
 
 (** This exception is raised (in Lwt) on the client if a call to a

--- a/src/syntax/pa_eliom_client_client.ml
+++ b/src/syntax/pa_eliom_client_client.ml
@@ -190,7 +190,7 @@ module Client_pass(Helpers : Pa_eliom_seed.Helpers) = struct
     match context_level with
       | `Server ->
           <:expr@loc< >>
-      | `Shared_Expr ->
+      | `Shared_expr _ ->
           orig_expr
       | `Shared ->
           let bindings =
@@ -231,8 +231,10 @@ module Client_pass(Helpers : Pa_eliom_seed.Helpers) = struct
       ignore ((Ast.map_ctyp f)#ctyp typ)
     in
     match context_level with
-      | Escaped_in_client_value_in section ->
-          (* {section{ ... {{ ... %x ... }} ... }} *)
+      | Escaped_in_client_value_in _
+      | Escaped_in_shared_value_in _ ->
+          (* {section{ ... {{ ... %x ... }} ... }} or
+             {section{ ... {shared# ... { ... %x ... }} ... }} *)
           let typ =
             drop_client_value_ctyp
               (get_type Helpers.find_escaped_ident_type gen_id)

--- a/src/syntax/pa_eliom_client_client.ml
+++ b/src/syntax/pa_eliom_client_client.ml
@@ -190,6 +190,8 @@ module Client_pass(Helpers : Pa_eliom_seed.Helpers) = struct
     match context_level with
       | `Server ->
           <:expr@loc< >>
+      | `Shared_Expr ->
+          orig_expr
       | `Shared ->
           let bindings =
             List.map

--- a/src/syntax/pa_eliom_client_client.ml
+++ b/src/syntax/pa_eliom_client_client.ml
@@ -209,7 +209,10 @@ module Client_pass(Helpers : Pa_eliom_seed.Helpers) = struct
           <:expr@loc<
             let $Ast.binding_of_pel bindings$ in
             $lid:gen_id$ $args$
-          >>
+          >> ;;
+
+  let shared_value_expr typ orig_expr gen_num gen_id loc =
+    client_value_expr typ `Server orig_expr gen_num gen_id loc
 
   let escape_inject context_level ?ident orig_expr gen_id =
     let open Pa_eliom_seed in

--- a/src/syntax/pa_eliom_client_client.ml
+++ b/src/syntax/pa_eliom_client_client.ml
@@ -213,8 +213,7 @@ module Client_pass(Helpers : Pa_eliom_seed.Helpers) = struct
             $lid:gen_id$ $args$
           >> ;;
 
-  let shared_value_expr typ orig_expr gen_num gen_id loc =
-    client_value_expr typ `Server orig_expr gen_num gen_id loc
+  let shared_value_expr = client_value_expr
 
   let escape_inject context_level ?ident orig_expr gen_id =
     let open Pa_eliom_seed in

--- a/src/syntax/pa_eliom_client_server.ml
+++ b/src/syntax/pa_eliom_client_server.ml
@@ -172,7 +172,7 @@ module Server_pass(Helpers : Pa_eliom_seed.Helpers) = struct
        : $typ$ Eliom_pervasives.client_value)
     >> ;;
 
-  let shared_value_expr typ orig_expr gen_num _ loc =
+  let shared_value_expr typ _ orig_expr gen_num _ loc =
     let typ =
       match typ with
         | Some typ -> typ

--- a/src/syntax/pa_eliom_client_server.ml
+++ b/src/syntax/pa_eliom_client_server.ml
@@ -201,7 +201,7 @@ module Server_pass(Helpers : Pa_eliom_seed.Helpers) = struct
   let escape_inject context_level ?ident orig_expr gen_id =
     let open Pa_eliom_seed in
     match context_level with
-      | Escaped_in_client_value_in `Shared ->
+      | Escaped_in_client_value_in `Shared_Expr ->
           push_escaped_binding orig_expr gen_id;
           orig_expr
       | Escaped_in_client_value_in _ ->

--- a/src/syntax/pa_eliom_client_server.ml
+++ b/src/syntax/pa_eliom_client_server.ml
@@ -201,7 +201,7 @@ module Server_pass(Helpers : Pa_eliom_seed.Helpers) = struct
   let escape_inject context_level ?ident orig_expr gen_id =
     let open Pa_eliom_seed in
     match context_level with
-      | Escaped_in_client_value_in `Shared_Expr ->
+      | Escaped_in_shared_value_in _ ->
           push_escaped_binding orig_expr gen_id;
           orig_expr
       | Escaped_in_client_value_in _ ->

--- a/src/syntax/pa_eliom_seed.ml
+++ b/src/syntax/pa_eliom_seed.ml
@@ -609,7 +609,7 @@ module Register(Id : sig val name: string end)(Pass : Pass) = struct
               | Hole_expr context ->
                   Some (Escaped_in_client_value_in context)
               | Shared_expr ->
-                  Some (Escaped_in_client_value_in `Shared)
+                  Some (Escaped_in_client_value_in `Shared_Expr)
               | Client_item ->
                   Some (Injected_in `Client)
               | Shared_item ->
@@ -622,8 +622,8 @@ module Register(Id : sig val name: string end)(Pass : Pass) = struct
                   set_current_level (Escaped_expr context);
                   Some (Escaped_in_client_value_in context)
               | Shared_expr ->
-                  set_current_level (Escaped_expr `Shared);
-                  Some (Escaped_in_client_value_in `Shared)
+                  set_current_level (Escaped_expr `Shared_Expr);
+                  Some (Escaped_in_client_value_in `Shared_Expr)
               | Client_item ->
                   set_current_level (Injected_expr `Client);
                   Some (Injected_in `Client)

--- a/src/syntax/pa_eliom_seed.ml
+++ b/src/syntax/pa_eliom_seed.ml
@@ -742,16 +742,6 @@ module Register(Id : sig val name: string end)(Pass : Pass) = struct
                      (gen_closure_escaped_ident id) _loc)
                 "The syntax {shared| type{ ... } is not allowed in %s."
                 (level_to_string !current_level)
-          | KEYWORD "{shared{"; opt_lvl = dummy_set_level_shared_value_expr ;
-            e = expr; KEYWORD "}}" ->
-              from_some_or_raise opt_lvl _loc
-                (fun lvl ->
-                   set_current_level lvl;
-                   let id = gen_closure_num _loc in
-                   Pass.shared_value_expr None e id
-                     (gen_closure_escaped_ident id) _loc)
-                "The syntax {shared{ ... } is not allowed in %s."
-                (level_to_string !current_level)
           | KEYWORD "{"; typ = TRY [ typ = OPT ctyp; KEYWORD "{" -> typ]; opt_lvl = dummy_set_level_client_value_expr ; e = expr; KEYWORD "}}" ->
               from_some_or_raise opt_lvl _loc
                 (fun lvl ->

--- a/src/syntax/pa_eliom_type_filter.ml
+++ b/src/syntax/pa_eliom_type_filter.ml
@@ -126,7 +126,7 @@ module Type_pass(Helpers : Pa_eliom_seed.Helpers) = struct
     push_typing_str_item orig_expr gen_id;
     push_typing_expr orig_expr gen_id;
     match context_level with
-      | Escaped_in_client_value_in `Shared_Expr ->
+      | Escaped_in_shared_value_in _ ->
           orig_expr
       | Escaped_in_client_value_in _ ->
           let _loc = Ast.loc_of_expr orig_expr in

--- a/src/syntax/pa_eliom_type_filter.ml
+++ b/src/syntax/pa_eliom_type_filter.ml
@@ -128,6 +128,8 @@ module Type_pass(Helpers : Pa_eliom_seed.Helpers) = struct
     match context_level with
       | Escaped_in_client_value_in `Shared ->
         orig_expr
+      | Escaped_in_client_value_in `Shared_Expr ->
+        orig_expr
       | Escaped_in_client_value_in `Server ->
           let _loc = Ast.loc_of_expr orig_expr in
           <:expr< >>

--- a/src/syntax/pa_eliom_type_filter.ml
+++ b/src/syntax/pa_eliom_type_filter.ml
@@ -126,11 +126,9 @@ module Type_pass(Helpers : Pa_eliom_seed.Helpers) = struct
     push_typing_str_item orig_expr gen_id;
     push_typing_expr orig_expr gen_id;
     match context_level with
-      | Escaped_in_client_value_in `Shared ->
-        orig_expr
       | Escaped_in_client_value_in `Shared_Expr ->
-        orig_expr
-      | Escaped_in_client_value_in `Server ->
+          orig_expr
+      | Escaped_in_client_value_in _ ->
           let _loc = Ast.loc_of_expr orig_expr in
           <:expr< >>
       | Injected_in `Shared ->

--- a/src/syntax/pa_eliom_type_filter.ml
+++ b/src/syntax/pa_eliom_type_filter.ml
@@ -102,7 +102,7 @@ module Type_pass(Helpers : Pa_eliom_seed.Helpers) = struct
       match ! $lid:gen_tid $ with | Some x -> x | None -> assert false
     end >>
 
-  let shared_value_expr typ orig_expr gen_id gen_tid loc =
+  let shared_value_expr typ _ orig_expr gen_id gen_tid loc =
     push_typing_str_item orig_expr gen_tid;
     let typ = match typ with
       | Some typ -> typ

--- a/src/syntax/pa_eliom_type_filter.ml
+++ b/src/syntax/pa_eliom_type_filter.ml
@@ -102,12 +102,33 @@ module Type_pass(Helpers : Pa_eliom_seed.Helpers) = struct
       match ! $lid:gen_tid $ with | Some x -> x | None -> assert false
     end >>
 
+  let shared_value_expr typ orig_expr gen_id gen_tid loc =
+    push_typing_str_item orig_expr gen_tid;
+    let typ = match typ with
+      | Some typ -> typ
+      | None -> let _loc = Loc.ghost in <:ctyp< _ >>
+    in
+    let _loc = loc in
+    <:expr<
+      Eliom_lib.create_shared_value $orig_expr$
+        begin
+          $flush_typing_expr ()$;
+          $lid:gen_tid$ :=
+            Some (Eliom_service.Syntax_helpers.client_value 0L 0 :
+                   $typ$ Eliom_pervasives.client_value);
+          match ! $lid:gen_tid $ with
+          | Some x -> x
+          | None -> assert false
+        end >>
+
   let escape_inject context_level ?ident orig_expr gen_id =
     let open Pa_eliom_seed in
     push_typing_str_item orig_expr gen_id;
     push_typing_expr orig_expr gen_id;
     match context_level with
-      | Escaped_in_client_value_in _ ->
+      | Escaped_in_client_value_in `Shared ->
+        orig_expr
+      | Escaped_in_client_value_in `Server ->
           let _loc = Ast.loc_of_expr orig_expr in
           <:expr< >>
       | Injected_in `Shared ->


### PR DESCRIPTION
This PR introduces syntax for shared expressions. The syntax is as follows:

    {shared# t { e }}

where `t` is a type, and `e` is an expression. `t` is optional.

I initially tried `|` instead of `#`, but that was causing trouble for Tuareg / ocp-indent. The above syntax is indented in a fairly decent way.

Allowing `{shared{ e }}` would introduce ambiguity: the same syntax is used for `str_item`, and expressions are allowed in the context of `str_item`.

We are transitioning to PPX, but the transition is not happening overnight, and it is good to have more usable shared expressions in the meantime.