### PR TITLE
Eliom_client.unload: ability to ask for confirmation before leaving

### DIFF
--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -215,11 +215,20 @@ val call_service :
 *)
 val onload : (unit -> unit) -> unit
 
-(** Register a function to be called before changing the page the next
-    time. If the return value is [Some s], then we ask the user to
-    confirm quitting; [s] is used in the confirmation pop-up, if the
-    browser permits. None means no confirmation needed. Multiple
-    callbacks can be registered. *)
+(** [onunload f] registers [f] as a handler to be called before
+    changing the page the next time. If [f] returns [Some s], then we
+    ask the user to confirm quitting. We try to use [s] in the
+    confirmation pop-up. [None] means no confirmation needed.
+
+    The callback [f] is sometimes trigerred by internal service calls,
+    and sometimes by the browser [onbeforeunload] event. In the
+    [onbeforeunload] case, the confirmation pop-up is managed by the
+    browser. For Firefox, the string [s] returned by [f] is ignored:
+    https://bugzilla.mozilla.org/show_bug.cgi?id=641509
+
+    [onunload] can be used to register multiple callbacks. If the user
+    decides to stay, we call any remaining callbacks, but these cannot
+    ask for further confirmation. *)
 val onunload : (unit -> string option) -> unit
 
 (** Wait for the initialization phase to terminate *)

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -216,8 +216,11 @@ val call_service :
 val onload : (unit -> unit) -> unit
 
 (** Register a function to be called before changing the page the next
-    time. *)
-val onunload : (unit -> unit) -> unit
+    time. If the return value is [Some s], then we ask the user to
+    confirm quitting; [s] is used in the confirmation pop-up, if the
+    browser permits. None means no confirmation needed. Multiple
+    callbacks can be registered. *)
+val onunload : (unit -> string option) -> unit
 
 (** Wait for the initialization phase to terminate *)
 val wait_load_end : unit -> unit Lwt.t

--- a/src/lib/eliom_lib.client.ml
+++ b/src/lib/eliom_lib.client.ml
@@ -113,8 +113,14 @@ let lwt_ignore ?(message="") t =
 let jsalert a = Dom_html.window##alert (a)
 let alert fmt = Printf.ksprintf (fun s -> jsalert (Js.string s)) fmt
 
-let debug_var s v = Js.Unsafe.set Dom_html.window (Js.string s) v
+let confirm =
+  let f s =
+    let s = Js.string s in
+    Dom_html.window##confirm(s) |> Js.to_bool
+  in
+  fun fmt -> Printf.ksprintf f fmt
 
+let debug_var s v = Js.Unsafe.set Dom_html.window (Js.string s) v
 
 module String = struct
   include String_base

--- a/src/lib/eliom_lib.client.mli
+++ b/src/lib/eliom_lib.client.mli
@@ -109,6 +109,7 @@ val jsdebug : 'a -> unit
 
 val alert : ('a, unit, string, unit) format4 -> 'a
 val jsalert : Js.js_string Js.t -> unit
+val confirm : ('a, unit, string, bool) format4 -> 'a
 val debug_var : string -> 'a -> unit
 val trace : ('a, unit, string, unit) format4 -> 'a
 val lwt_ignore : ?message:string -> unit Lwt.t -> unit


### PR DESCRIPTION
This PR enhances the `onunload` callback handling to allow asking for a confirmation. If some callback returns `Some s` (for a string `s`), then a confirmation message *usually* showing `s` appears. Note that the signature changes.

We react both to the `onbeforeunload` event, and to page changes initiated by calling a service. We try to provide consistent behavior in the two cases. The string `s` is not used by Firefox in the `onbeforeunload` case ([FF bug 578828](https://bugzilla.mozilla.org/show_bug.cgi?id=578828)).

Multiple callbacks are allowed, and we try to execute the remaining ones if the user decides to stay. This happens via an `onunload` handler if the whole thing has started by `onbeforeunload`.

The custom `addEventListener` wrapper (`add_string_event_listener`) is because WebKit cares about the return value of the callback, so we need to return a string and not a Boolean. I removed the check for `(Js.Unsafe.coerce o)##addEventListener == Js.undefined` because `Dom.addEventListener` and `add_string_event_listener` take care of this.