### PR TITLE
Update Eliommod_timeouts interface

### DIFF
--- a/src/lib/eliom_state.server.ml
+++ b/src/lib/eliom_state.server.ml
@@ -82,7 +82,7 @@ let set_default_global_service_state_timeout ~cookie_level
   let sitedata =
     Eliom_request_info.find_sitedata "set_global_service_timeout"
   in
-  Eliommod_timeouts.set_default_global_service_timeout
+  Eliommod_timeouts.set_default_global `Service
     cookie_level override_configfile false sitedata timeout
 
 
@@ -95,15 +95,17 @@ let set_global_service_state_timeout
     Eliom_request_info.find_sitedata "set_global_service_timeout"
   in
   let secure = Eliom_common.get_secure secure sitedata in
-  Eliommod_timeouts.set_global_service_timeout
-    ~cookie_scope ~secure ~recompute_expdates
+  Eliommod_timeouts.set_global
+    ~kind:`Service ~cookie_scope ~secure ~recompute_expdates
     override_configfile sitedata timeout
 
 let set_default_global_volatile_data_state_timeout ~cookie_level
     ?(override_configfile = false) timeout =
-  let sitedata = Eliom_request_info.find_sitedata "set_global_data_timeout" in
-  Eliommod_timeouts.set_default_global_data_timeout
-    cookie_level override_configfile false sitedata timeout
+  let sitedata =
+    Eliom_request_info.find_sitedata "set_global_data_timeout"
+  in
+  Eliommod_timeouts.set_default_global
+    `Data cookie_level override_configfile false sitedata timeout
 
 let set_global_volatile_data_state_timeout
     ~cookie_scope
@@ -112,64 +114,77 @@ let set_global_volatile_data_state_timeout
     ?(override_configfile = false) timeout =
   let sitedata = Eliom_request_info.find_sitedata "set_global_data_timeout" in
   let secure = Eliom_common.get_secure secure sitedata in
-  Eliommod_timeouts.set_global_data_timeout
-    ~cookie_scope ~secure ~recompute_expdates
+  Eliommod_timeouts.set_global
+    ~kind:`Data ~cookie_scope ~secure ~recompute_expdates
     override_configfile sitedata timeout
 
 let set_default_global_volatile_state_timeout ~cookie_level
     ?(override_configfile = false) timeout =
-  let sitedata = Eliom_request_info.find_sitedata "set_global_volatile_timeouts" in
-  Eliommod_timeouts.set_default_global_service_timeout
-    cookie_level override_configfile false sitedata timeout;
-  Eliommod_timeouts.set_default_global_data_timeout
-    cookie_level override_configfile false sitedata timeout
+  let sitedata =
+    Eliom_request_info.find_sitedata "set_global_volatile_timeouts"
+  in
+  Eliommod_timeouts.set_default_global
+    `Service cookie_level override_configfile false sitedata timeout;
+  Eliommod_timeouts.set_default_global
+    `Data cookie_level override_configfile false sitedata timeout
 
 let set_global_volatile_state_timeout
     ~cookie_scope
     ?secure
     ?(recompute_expdates = false)
     ?(override_configfile = false) timeout =
-  let sitedata = Eliom_request_info.find_sitedata "set_global_volatile_timeouts" in
+  let sitedata =
+    Eliom_request_info.find_sitedata "set_global_volatile_timeouts"
+  in
   let secure = Eliom_common.get_secure secure sitedata in
-  Eliommod_timeouts.set_global_service_timeout
-    ~cookie_scope ~secure ~recompute_expdates
+  Eliommod_timeouts.set_global
+    ~kind:`Service ~cookie_scope ~secure ~recompute_expdates
     override_configfile sitedata timeout;
-  Eliommod_timeouts.set_global_data_timeout
-    ~cookie_scope ~secure ~recompute_expdates
+  Eliommod_timeouts.set_global
+    ~kind:`Data ~cookie_scope ~secure ~recompute_expdates
     override_configfile sitedata timeout
 
 let set_default_global_persistent_data_state_timeout ~cookie_level
     ?(override_configfile = false) timeout =
-  let sitedata = Eliom_request_info.find_sitedata "set_global_persistent_timeout" in
-  Eliommod_timeouts.set_default_global_service_timeout
-    cookie_level override_configfile false sitedata timeout
+  let sitedata =
+    Eliom_request_info.find_sitedata "set_global_persistent_timeout"
+  in
+  Eliommod_timeouts.set_default_global
+    `Service cookie_level override_configfile false sitedata timeout
 
 let set_global_persistent_data_state_timeout
     ~cookie_scope
     ?secure
     ?(recompute_expdates = false)
     ?(override_configfile = false) timeout =
-  let sitedata = Eliom_request_info.find_sitedata "set_global_persistent_timeout" in
+  let sitedata =
+    Eliom_request_info.find_sitedata "set_global_persistent_timeout"
+  in
   let secure = Eliom_common.get_secure secure sitedata in
-  Eliommod_timeouts.set_global_persistent_timeout
-    ~cookie_scope ~secure ~recompute_expdates
+  Eliommod_timeouts.set_global
+    ~kind:`Persistent ~cookie_scope ~secure ~recompute_expdates
     override_configfile sitedata timeout
 
 
 let get_global_service_state_timeout ?secure ~cookie_scope () =
   let sitedata = Eliom_request_info.find_sitedata "get_global_timeout" in
   let secure = Eliom_common.get_secure secure sitedata in
-  Eliommod_timeouts.get_global_service_timeout ~cookie_scope ~secure sitedata
+  Eliommod_timeouts.get_global
+    ~kind:`Service ~cookie_scope ~secure sitedata
 
 let get_global_volatile_data_state_timeout ?secure ~cookie_scope () =
   let sitedata = Eliom_request_info.find_sitedata "get_global_timeout" in
   let secure = Eliom_common.get_secure secure sitedata in
-  Eliommod_timeouts.get_global_data_timeout ~cookie_scope ~secure sitedata
+  Eliommod_timeouts.get_global
+    ~kind:`Data ~cookie_scope ~secure sitedata
 
 let get_global_persistent_data_state_timeout ?secure ~cookie_scope () =
-  let sitedata = Eliom_request_info.find_sitedata "get_global_persistent_timeout" in
+  let sitedata =
+    Eliom_request_info.find_sitedata "get_global_persistent_timeout"
+  in
   let secure = Eliom_common.get_secure secure sitedata in
-  Eliommod_timeouts.get_global_persistent_timeout ~cookie_scope ~secure sitedata
+  Eliommod_timeouts.get_global
+    ~kind:`Persistent ~cookie_scope ~secure sitedata
 
 
 
@@ -224,12 +239,13 @@ let get_service_state_timeout ~cookie_scope ?secure () =
     let tor = c.Eliom_common.sc_timeout in
     match !tor with
     | Eliom_common.TGlobal ->
-        Eliommod_timeouts.get_global_service_timeout
-          ~cookie_scope ~secure sitedata
+      Eliommod_timeouts.get_global
+        ~kind:`Service ~cookie_scope ~secure sitedata
     | Eliom_common.TNone -> None
     | Eliom_common.TSome t -> Some t
   with Not_found | Eliom_common.Eliom_Session_expired ->
-    Eliommod_timeouts.get_global_service_timeout ~cookie_scope ~secure sitedata
+    Eliommod_timeouts.get_global
+      ~kind:`Service ~cookie_scope ~secure sitedata
 
 let get_volatile_data_state_timeout ~cookie_scope ?secure () =
   let sp = Eliom_common.get_sp () in
@@ -243,17 +259,13 @@ let get_volatile_data_state_timeout ~cookie_scope ?secure () =
     let tor = c.Eliom_common.dc_timeout in
     match !tor with
     | Eliom_common.TGlobal ->
-        Eliommod_timeouts.get_global_data_timeout ~cookie_scope ~secure sitedata
+      Eliommod_timeouts.get_global
+        ~kind:`Data ~cookie_scope ~secure sitedata
     | Eliom_common.TNone -> None
     | Eliom_common.TSome t -> Some t
   with Not_found | Eliom_common.Eliom_Session_expired ->
-    Eliommod_timeouts.get_global_data_timeout ~cookie_scope ~secure sitedata
-
-
-
-
-
-
+    Eliommod_timeouts.get_global
+      ~kind:`Data ~cookie_scope ~secure sitedata
 
 let set_persistent_data_state_timeout ~cookie_scope ?secure t =
   lwt c = Eliommod_persess.find_or_create_persistent_cookie
@@ -286,16 +298,16 @@ let get_persistent_data_state_timeout ~cookie_scope ?secure () =
     return
       (match !tor with
         | Eliom_common.TGlobal ->
-          Eliommod_timeouts.get_global_persistent_timeout
-            ~cookie_scope ~secure sitedata
+          Eliommod_timeouts.get_global
+            ~kind:`Persistent ~cookie_scope ~secure sitedata
         | Eliom_common.TNone -> None
         | Eliom_common.TSome t -> Some t)
   with
     | Not_found
     | Eliom_common.Eliom_Session_expired ->
       return
-        (Eliommod_timeouts.get_global_persistent_timeout
-           ~cookie_scope ~secure sitedata)
+        (Eliommod_timeouts.get_global
+           ~kind:`Persistent ~cookie_scope ~secure sitedata)
 
 
 (* Preventing memory leaks: we must close empty sessions *)

--- a/src/lib/server/eliommod.ml
+++ b/src/lib/server/eliommod.ml
@@ -501,7 +501,9 @@ let rec parse_global_config = function
   | e::ll ->
       parse_eliom_option
         true
-        ((fun ct _ -> Eliommod_timeouts.set_default_volatile ct),
+        ((fun ct _ m ->
+           Eliommod_timeouts.set_default `Data ct m;
+           Eliommod_timeouts.set_default `Service ct m),
          (fun ct _ -> Eliommod_timeouts.set_default `Data ct),
          (fun ct _ -> Eliommod_timeouts.set_default `Service ct),
          (fun ct _ -> Eliommod_timeouts.set_default `Persistent ct),

--- a/src/lib/server/eliommod.ml
+++ b/src/lib/server/eliommod.ml
@@ -501,10 +501,10 @@ let rec parse_global_config = function
   | e::ll ->
       parse_eliom_option
         true
-        ((fun ct _ -> Eliommod_timeouts.set_default_volatile_timeout ct),
-         (fun ct _ -> Eliommod_timeouts.set_default_data_timeout ct),
-         (fun ct _ -> Eliommod_timeouts.set_default_service_timeout ct),
-         (fun ct _ -> Eliommod_timeouts.set_default_persistent_timeout ct),
+        ((fun ct _ -> Eliommod_timeouts.set_default_volatile ct),
+         (fun ct _ -> Eliommod_timeouts.set_default `Data ct),
+         (fun ct _ -> Eliommod_timeouts.set_default `Service ct),
+         (fun ct _ -> Eliommod_timeouts.set_default `Persistent ct),
          (fun v -> default_max_service_sessions_per_group := v),
          (fun v -> default_max_service_sessions_per_subnet := v),
          (fun v -> default_max_volatile_data_sessions_per_group := v),
@@ -794,12 +794,17 @@ let parse_config hostpattern conf_info site_dir =
         let content =
           parse_eliom_options
             ((fun ct snoo v ->
-              set_timeout Eliommod_timeouts.set_global_data_timeout_ ct snoo v;
-              set_timeout Eliommod_timeouts.set_global_service_timeout_ ct snoo v
+              set_timeout
+                (Eliommod_timeouts.set_global_ ~kind:`Data) ct snoo v;
+              set_timeout
+                (Eliommod_timeouts.set_global_ ~kind:`Service) ct snoo v
              ),
-             (set_timeout Eliommod_timeouts.set_global_data_timeout_),
-             (set_timeout Eliommod_timeouts.set_global_service_timeout_),
-             (set_timeout Eliommod_timeouts.set_global_persistent_timeout_),
+             (set_timeout
+                (Eliommod_timeouts.set_global_ ~kind:`Data)),
+             (set_timeout
+                (Eliommod_timeouts.set_global_ ~kind:`Service)),
+             (set_timeout
+                (Eliommod_timeouts.set_global_ ~kind:`Persistent)),
              (fun v -> sitedata.Eliom_common.max_service_sessions_per_group <- v, true),
              (fun v -> sitedata.Eliom_common.max_service_sessions_per_subnet <- v, true),
              (fun v -> sitedata.Eliom_common.max_volatile_data_sessions_per_group <- v, true),

--- a/src/lib/server/eliommod_pagegen.ml
+++ b/src/lib/server/eliommod_pagegen.ml
@@ -60,7 +60,7 @@ let update_cookie_table ?now sitedata (ci, sci) =
               match !(newc.Eliom_common.sc_timeout) with
                 | Eliom_common.TGlobal ->
                   let globaltimeout =
-                    Eliommod_timeouts.find_global_service_timeout name sitedata
+                    Eliommod_timeouts.find_global `Service name sitedata
                   in
                   (match globaltimeout with
                     | None -> None
@@ -86,7 +86,7 @@ let update_cookie_table ?now sitedata (ci, sci) =
                 match !(newc.Eliom_common.dc_timeout) with
                   | Eliom_common.TGlobal ->
                     let globaltimeout =
-                      Eliommod_timeouts.find_global_data_timeout name sitedata
+                      Eliommod_timeouts.find_global `Data name sitedata
                     in
                     (match globaltimeout with
                       | None -> None
@@ -115,7 +115,7 @@ let update_cookie_table ?now sitedata (ci, sci) =
                   match !(newc.Eliom_common.pc_timeout) with
                     | Eliom_common.TGlobal ->
                       let globaltimeout =
-                        Eliommod_timeouts.find_global_persistent_timeout
+                        Eliommod_timeouts.find_global `Persistent
                           name sitedata
                       in
                       (match globaltimeout with

--- a/src/lib/server/eliommod_timeouts.ml
+++ b/src/lib/server/eliommod_timeouts.ml
@@ -64,12 +64,6 @@ let set_default kind level timeout = (get_ref kind level) := timeout
 
 let get_default kind level = !(get_ref kind level)
 
-let set_default_volatile level timeout =
-  set_default `Data    level timeout ;
-  set_default `Service level timeout
-
-let add k v l = (k, v) :: List.remove_assoc k l
-
 let set_timeout_ get set get_default update =
   fun ?full_st_name ?cookie_level ~recompute_expdates
     override_configfile fromconfigfile sitedata t ->

--- a/src/lib/server/eliommod_timeouts.mli
+++ b/src/lib/server/eliommod_timeouts.mli
@@ -22,13 +22,8 @@ type kind = [ `Service | `Data | `Persistent ]
 val set_default :
   [< kind ] -> [< Eliom_common.cookie_level ] -> float option -> unit
 
-val set_default_volatile :
-  [< Eliom_common.cookie_level ] -> float option -> unit
-
 val get_default :
   [< kind ] -> [< Eliom_common.cookie_level ] -> float option
-
-val add : 'a -> 'b -> ('a * 'b) list -> ('a * 'b) list
 
 val find_global :
   [< kind ] ->

--- a/src/lib/server/eliommod_timeouts.mli
+++ b/src/lib/server/eliommod_timeouts.mli
@@ -15,78 +15,49 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- *)
-val set_default_service_timeout : [< Eliom_common.cookie_level ] -> float option -> unit
-val set_default_data_timeout : [< Eliom_common.cookie_level ] -> float option -> unit
-val set_default_persistent_timeout : [< Eliom_common.cookie_level ] -> float option -> unit
-val get_default_service_timeout : [< Eliom_common.cookie_level ] -> float option
-val get_default_data_timeout : [< Eliom_common.cookie_level ] -> float option
-val get_default_persistent_timeout : [< Eliom_common.cookie_level ] -> float option
-val set_default_volatile_timeout :  [< Eliom_common.cookie_level ] -> float option -> unit
+*)
+
+type kind = [ `Service | `Data | `Persistent ]
+
+val set_default :
+  [< kind ] -> [< Eliom_common.cookie_level ] -> float option -> unit
+
+val set_default_volatile :
+  [< Eliom_common.cookie_level ] -> float option -> unit
+
+val get_default :
+  [< kind ] -> [< Eliom_common.cookie_level ] -> float option
+
 val add : 'a -> 'b -> ('a * 'b) list -> ('a * 'b) list
 
-val find_global_service_timeout :
-  Eliom_common.full_state_name -> Eliom_common.sitedata -> float option
-val find_global_data_timeout :
-  Eliom_common.full_state_name -> Eliom_common.sitedata -> float option
-val find_global_persistent_timeout :
-  Eliom_common.full_state_name -> Eliom_common.sitedata -> float option
+val find_global :
+  [< kind ] ->
+  Eliom_common.full_state_name ->
+  Eliom_common.sitedata ->
+  float option
 
-val get_global_service_timeout :
-  cookie_scope:[< Eliom_common.cookie_scope ] ->
-  secure:bool ->
-  Eliom_common.sitedata -> float option
-val get_global_data_timeout :
-  cookie_scope:[< Eliom_common.cookie_scope ] ->
-  secure:bool ->
-  Eliom_common.sitedata -> float option
-val get_global_persistent_timeout :
+val get_global :
+  kind:[< kind ] ->
   cookie_scope:[< Eliom_common.cookie_scope ] ->
   secure:bool ->
   Eliom_common.sitedata -> float option
 
-val set_global_service_timeout :
-  cookie_scope:[< Eliom_common.cookie_scope ] ->
-  secure:bool ->
-  recompute_expdates:bool ->
-  bool -> Eliom_common.sitedata -> float option -> unit
-val set_global_data_timeout :
-  cookie_scope:[< Eliom_common.cookie_scope ] ->
-  secure:bool ->
-  recompute_expdates:bool ->
-  bool -> Eliom_common.sitedata -> float option -> unit
-val set_global_persistent_timeout :
+val set_global :
+  kind:[< kind ] ->
   cookie_scope:[< Eliom_common.cookie_scope ] ->
   secure:bool ->
   recompute_expdates:bool ->
   bool -> Eliom_common.sitedata -> float option -> unit
 
-val set_global_service_timeout_ :
+val set_global_ :
   ?full_st_name:Eliom_common.full_state_name ->
   ?cookie_level:[< Eliom_common.cookie_level ] ->
-  recompute_expdates:bool ->
-  bool ->
-  bool -> Eliom_common.sitedata -> float option -> unit
-val set_global_data_timeout_ :
-  ?full_st_name:Eliom_common.full_state_name ->
-  ?cookie_level:[< Eliom_common.cookie_level ] ->
-  recompute_expdates:bool ->
-  bool ->
-  bool -> Eliom_common.sitedata -> float option -> unit
-val set_global_persistent_timeout_ :
-  ?full_st_name:Eliom_common.full_state_name ->
-  ?cookie_level:[< Eliom_common.cookie_level ] ->
+  kind:[< kind ] ->
   recompute_expdates:bool ->
   bool ->
   bool -> Eliom_common.sitedata -> float option -> unit
 
-
-val set_default_global_service_timeout :
-  [< Eliom_common.cookie_level ] ->
-  bool -> bool -> Eliom_common.sitedata -> float option -> unit
-val set_default_global_data_timeout :
-  [< Eliom_common.cookie_level ] ->
-  bool -> bool -> Eliom_common.sitedata -> float option -> unit
-val set_default_global_persistent_timeout :
+val set_default_global :
+  [< kind ] ->
   [< Eliom_common.cookie_level ] ->
   bool -> bool -> Eliom_common.sitedata -> float option -> unit


### PR DESCRIPTION
This patch re-organizes `Eliommod_timeouts`.

Previously, there were separate `*_data_*`, `*_service_*`, and `*_persistent_*` functions. These have been unified by means of a parameter of type ``[ `Service | `Data | `Persistent ]``. I dropped the redundant `_timeout` suffix from everything.

I intend to do similar re-structuring in `Eliom_state` which wraps this interface, but let's review things incrementally.