### PR TITLE
Restore user parameters in forms

### DIFF
--- a/src/lib/eliom_content_.client.ml
+++ b/src/lib/eliom_content_.client.ml
@@ -425,7 +425,7 @@ module Html5 = struct
   type +'a elt = 'a F.elt
   type +'a attrib = 'a F.attrib
   type uri = F.uri
-  type 'a form_param = 'a Eliom_parameter_base.atom
+  type 'a form_param = 'a Eliom_form.param
 
   module Custom_data = Eliom_content_core.Html5.Custom_data
 

--- a/src/lib/eliom_content_.server.ml
+++ b/src/lib/eliom_content_.server.ml
@@ -94,6 +94,6 @@ module Html5 = struct
   type 'a list_wrap = 'a F.list_wrap
   type 'a attrib = 'a F.attrib
   type uri = F.uri
-  type 'a form_param = 'a Eliom_parameter_base.atom
+  type 'a form_param = 'a Eliom_form.param
 
 end

--- a/src/lib/eliom_form.eliom
+++ b/src/lib/eliom_form.eliom
@@ -124,20 +124,33 @@ module Make_links (Html5 : Html5) = struct
 
 end
 
+type _ param =
+  | Atom : 'a Eliom_parameter_base.atom -> 'a param
+  | User : ('a -> string) -> 'a param
+
 module Make (Html5 : Html5) = struct
 
-  type 'a param = 'a Eliom_parameter_base.atom
+  type 'a param' = 'a param
+  type 'a param = 'a param'
+
+  let string_of_param = function
+    | Atom a ->
+      Eliom_parameter_base.string_of_atom a
+    | User f ->
+      f
+
   type +'a elt = 'a Html5.elt
   type +'a attrib = 'a Html5.attrib
   type uri = Html5.uri
 
-  let float = Eliom_parameter_base.TFloat
-  let int = Eliom_parameter_base.TInt
-  let int32 = Eliom_parameter_base.TInt32
-  let int64 = Eliom_parameter_base.TInt64
-  let nativeint = Eliom_parameter_base.TNativeint
-  let bool = Eliom_parameter_base.TBool
-  let string = Eliom_parameter_base.TString
+  let float     = Atom Eliom_parameter_base.TFloat
+  let int       = Atom Eliom_parameter_base.TInt
+  let int32     = Atom Eliom_parameter_base.TInt32
+  let int64     = Atom Eliom_parameter_base.TInt64
+  let nativeint = Atom Eliom_parameter_base.TNativeint
+  let bool      = Atom Eliom_parameter_base.TBool
+  let string    = Atom Eliom_parameter_base.TString
+  let user f    = User f
 
   open Html5
 
@@ -333,7 +346,7 @@ module Make (Html5 : Html5) = struct
     make_input ?a ?value ~typ:input_type ?name ?src ()
 
   let input ?a ~input_type ?name ?value y =
-    let f = Eliom_parameter_base.string_of_atom y in
+    let f = string_of_param y in
     gen_input ?a ~input_type ?value ?name f
 
   let file_input ?a ~name () =
@@ -347,7 +360,7 @@ module Make (Html5 : Html5) = struct
 
   let checkbox ?a ?checked ~name ~value y =
     let name = Eliom_parameter.string_of_param_name name
-    and value = Eliom_parameter_base.string_of_atom y value
+    and value = string_of_param y value
     and typ = `Checkbox in
     make_input ?a ?checked ~typ ~name ~value ()
 
@@ -358,7 +371,7 @@ module Make (Html5 : Html5) = struct
 
   let radio ?a ?checked ~name ~value y =
     let name = Eliom_parameter.string_of_param_name name
-    and value = Eliom_parameter_base.string_of_atom y value
+    and value = string_of_param y value
     and typ = `Radio in
     make_input ?a ?checked ~typ ~name ~value ()
 
@@ -375,7 +388,7 @@ module Make (Html5 : Html5) = struct
 
   let button ?a ~button_type ~name ~value y c =
     let name = Eliom_parameter.string_of_param_name name
-    and value = Eliom_parameter_base.string_of_atom y value in
+    and value = string_of_param y value in
     make_button ?a ~button_type ~name ~value c
 
   let button_no_value ?a ~button_type c =
@@ -493,13 +506,13 @@ module Make (Html5 : Html5) = struct
   let select ?a ?required ~name y fl ol =
     let multiple = false
     and name = Eliom_parameter.string_of_param_name name
-    and f = Eliom_parameter_base.string_of_atom y in
+    and f = string_of_param y in
     gen_select ?a ?required ~multiple ~name fl ol f
 
   let multiple_select ?a ?required ~name y fl ol =
     let multiple = true
     and name = Eliom_parameter.string_of_param_name name
-    and f = Eliom_parameter_base.string_of_atom y in
+    and f = string_of_param y in
     gen_select ?a ?required ~multiple ~name fl ol f
 
   let make_info ~https kind service =

--- a/src/lib/eliom_form.eliomi
+++ b/src/lib/eliom_form.eliomi
@@ -49,6 +49,8 @@ module type Html5 = sig
 
 end
 
+type 'a param
+
 module Make_links (H : Html5) :
   Eliom_form_sigs.LINKS
   with type +'a elt := 'a H.elt
@@ -60,6 +62,6 @@ module Make (H : Html5) :
   with type +'a elt := 'a H.elt
    and type +'a attrib := 'a H.attrib
    and type uri := H.uri
-   and type 'a param = 'a Eliom_parameter_base.atom
+   and type 'a param = 'a param
 
 }}

--- a/src/lib/eliom_form_sigs.shared.mli
+++ b/src/lib/eliom_form_sigs.shared.mli
@@ -228,6 +228,7 @@ module type S = sig
   val nativeint : nativeint param
   val bool : bool param
   val string : string param
+  val user : ('a -> string) -> 'a param
 
   (** Same as {!LINK.make_uri_components}, but also returns a list of
       post parameters. *)


### PR DESCRIPTION
A re-implementation of user-type form parameters, which had gone away with #215.

I hope this is temporary, with a better solution (integrated with `Eliom_parameter`) coming in the future.

Fixes #256. @darioteixeira @paurkedal, sorry for the inconvenience.