### PR TITLE
PPX support in Ocamlbuild

### DIFF
--- a/doc/manual-wiki/workflow-compilation.wiki
+++ b/doc/manual-wiki/workflow-compilation.wiki
@@ -132,6 +132,16 @@ versions of Eliom, {{{package(eliom.server)}}} and {{{package(eliom.client)}}}
 may be omitted.  Dependencies are added with {{{package(yourdep)}}} on the
 same line.
 
+By default, our {{{ocamlbuild}}} plugin uses the
+<<a_manual chapter="clientserver-language"|Camlp4 syntax extension>>.
+To use <<a_manual chapter="ppx-syntax"|PPX>>, you can set the
+{{{eliom_ppx}}} flag in {{{_tags}}}, as follows:
+
+{{{
+<*.eliom>: eliom_ppx
+<*.eliomi>: eliom_ppx
+}}}
+
 For libraries, don't forget to add the corresponding .mllib file.
 Then, you can compile your project with:
 


### PR DESCRIPTION
PPX support for our Ocamlbuild plugin.

You can use PPX by using the `eliom_ppx` in flags as follows:

```
<*.eliom>: eliom_ppx
<*.eliomi>: eliom_ppx
```

Fixes #257. The plugin has an early adopter already; thanks @paurkedal!