### PR TITLE
Call client-side services for forms 

### DIFF
--- a/src/lib/eliom_content.client.mli
+++ b/src/lib/eliom_content.client.mli
@@ -879,3 +879,8 @@ val set_client_fun :
 val wrap_client_fun :
   ('g -> 'p -> Html5_types.html Html5.elt Lwt.t)
   -> ('g -> 'p -> unit Lwt.t)
+
+(** With [set_form_error_handler f], [f] becomes the action to be
+    called when we are unable to call a client-side service due to
+    invalid form data. *)
+val set_form_error_handler : (unit -> unit Lwt.t) -> unit

--- a/src/lib/eliom_content.eliom
+++ b/src/lib/eliom_content.eliom
@@ -102,4 +102,6 @@ let wrap_client_fun f get_params post_params =
   lwt content = f get_params post_params in
   let content = Html5.To_dom.of_element content in
   Eliom_client.set_content_local content
+
+let set_form_error_handler = Eliom_form.set_error_handler
  }}

--- a/src/lib/eliom_content_.client.ml
+++ b/src/lib/eliom_content_.client.ml
@@ -392,6 +392,7 @@ module Html5 = struct
           (Html5.F.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
+      let to_elt = toelt
     end
     include Eliom_form.Make_links(Arg)
     module Form = Eliom_form.Make(Arg)
@@ -412,6 +413,7 @@ module Html5 = struct
           (Html5.D.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
+      let to_elt = toelt
     end
     include Eliom_form.Make_links(Arg)
     module Form = Eliom_form.Make(Arg)

--- a/src/lib/eliom_content_.server.ml
+++ b/src/lib/eliom_content_.server.ml
@@ -60,6 +60,7 @@ module Html5 = struct
           (Html5.F.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
+      let to_elt = toelt
     end
     include Eliom_form.Make_links(Arg)
     module Form = Eliom_form.Make(Arg)
@@ -76,6 +77,7 @@ module Html5 = struct
           (Html5.D.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
+      let to_elt = toelt
     end
     include Eliom_form.Make_links(Arg)
     module Form = Eliom_form.Make(Arg)

--- a/src/lib/eliom_content_core.client.mli
+++ b/src/lib/eliom_content_core.client.mli
@@ -37,7 +37,11 @@ module Xml : sig
                                     (* 'a Js.t -> unit) client_value_server *)
     | CE_client_closure of ((#Dom_html.event as 'a) Js.t -> unit)
     | CE_call_service of
-        ([ `A | `Form_get | `Form_post] * (bool * string list) option * string option) option Eliom_lazy.request
+        ( [ `A | `Form_get | `Form_post] *
+          ((bool * string list) option) *
+          string option *
+          Ocsigen_lib.poly (* (unit -> bool) client_value *)
+        ) option Eliom_lazy.request
 
   (* Inherit from all events.
      Necessary for subtyping since caml_event_handler is contravariant. *)
@@ -70,9 +74,12 @@ module Xml : sig
   (**/**)
 
   val internal_event_handler_of_service :
-    ( [ `A | `Form_get | `Form_post ]
-      * (bool * string list) option
-      * string option) option Eliom_lazy.request -> internal_event_handler
+    (  [ `A | `Form_get | `Form_post]
+       * (bool * string list) option
+       * string option
+       * Eliom_lib.poly
+    )  option Eliom_lazy.request
+    -> internal_event_handler
 
   type separator = Space | Comma
   type acontent = private

--- a/src/lib/eliom_content_core.server.mli
+++ b/src/lib/eliom_content_core.server.mli
@@ -60,7 +60,8 @@ module Xml : sig
   val internal_event_handler_of_service :
     ( [ `A | `Form_get | `Form_post ]
       * (bool * string list) option
-      * string option) option Eliom_lazy.request -> internal_event_handler
+      * string option
+      * Eliom_lib.poly) option Eliom_lazy.request -> internal_event_handler
 
   val caml_event_handler :
     ((#Dom_html.event as 'a) Js.t -> unit) Eliom_client_value.t ->

--- a/src/lib/eliom_form.eliom
+++ b/src/lib/eliom_form.eliom
@@ -43,7 +43,8 @@ module type Html5 = sig
     string ->
     ([ `A | `Form_get | `Form_post] *
      (bool * string list) option *
-     string option) option Eliom_lazy.request ->
+     string option *
+     Eliom_lib.poly) option Eliom_lazy.request ->
     Html5_types.form_attrib attrib
 
   val to_elt : 'a elt -> Eliom_content_core.Xml.elt
@@ -237,7 +238,7 @@ module Make (Html5 : Html5) = struct
     let service = %service in
     (* FIXME *)
     let y = Obj.magic (Eliom_service.get_get_params_type_ service)
-    and elt = Eliom_client0.rebuild_node' `HTML5 %(Html5.to_elt elt) in
+    and elt = Eliom_client_core.rebuild_node' `HTML5 %(Html5.to_elt elt) in
     (* FIXME *)
     let elt = Js.Unsafe.coerce elt in
     Lwt_js_events.async @@ fun () ->
@@ -562,7 +563,12 @@ module Make (Html5 : Html5) = struct
       | None ->
         None
       | Some tmpl ->
-        Some (kind, Eliom_uri.make_cookies_info (https, service), tmpl)
+        Some (
+          kind,
+          Eliom_uri.make_cookies_info (https, service),
+          tmpl,
+          Eliom_lib.to_poly (Eliom_service.has_client_fun_lazy service)
+        )
     in
     Eliom_lazy.from_fun f
 

--- a/src/lib/eliom_form.eliomi
+++ b/src/lib/eliom_form.eliomi
@@ -18,6 +18,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 *)
 
+{client{
+val set_error_handler : (unit -> unit Lwt.t) -> unit
+}}
+
 {shared{
 
 module type Html5 = sig

--- a/src/lib/eliom_form.eliomi
+++ b/src/lib/eliom_form.eliomi
@@ -42,9 +42,11 @@ module type Html5 = sig
 
   val attrib_of_service :
     string ->
-    ([ `A | `Form_get | `Form_post] *
-     (bool * string list) option *
-     string option) option Eliom_lazy.request ->
+    ([ `A | `Form_get | `Form_post]
+     * (bool * string list) option
+     * string option
+     * Eliom_lib.poly
+    ) option Eliom_lazy.request ->
     Html5_types.form_attrib attrib
 
   val to_elt : 'a elt -> Eliom_content_core.Xml.elt

--- a/src/lib/eliom_form.eliomi
+++ b/src/lib/eliom_form.eliomi
@@ -47,6 +47,8 @@ module type Html5 = sig
      string option) option Eliom_lazy.request ->
     Html5_types.form_attrib attrib
 
+  val to_elt : 'a elt -> Eliom_content_core.Xml.elt
+
 end
 
 type 'a param

--- a/src/lib/eliom_parameter.client.ml
+++ b/src/lib/eliom_parameter.client.ml
@@ -1,2 +1,147 @@
+(* Ocsigen
+ * http://www.ocsigen.org
+ * Copyright (C) 2016 Vasilis Papavasileiou
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
 
 include Eliom_parameter_base
+
+module M : sig
+  type 'a t
+  val remove : 'a t -> string -> ('a * 'a t) option
+  val of_assoc_list : (string * 'a) list -> 'a t
+end = struct
+
+  module Raw =
+    Map.Make(struct
+      type t = string
+      let compare = compare
+    end)
+
+  type 'a t = 'a list Raw.t
+
+  let remove m id =
+    try
+      match Raw.find id m with
+      | [h] ->
+        Some (h, Raw.remove id m)
+      | h :: t ->
+        Some (h, Raw.add id t m)
+      | [] ->
+        None
+    with Not_found ->
+      None
+
+  let of_assoc_list l =
+    let f acc (id, v) =
+      try
+        let l = Raw.find id acc in
+        Raw.add id (v :: l) acc
+      with Not_found ->
+        Raw.add id [v] acc
+    in
+    List.fold_left f Raw.empty l
+
+end
+
+let reconstruct_atom ~f m name =
+  try
+    match M.remove m name with
+    | Some (`String v, m) ->
+      let v = f (Js.to_string v) in
+      Some (v, m)
+    | _ ->
+      None
+  with _ ->
+    None
+
+let (>>=) x f = match x with Some x -> f x | None -> None
+
+let rec reconstruct_set :
+  type a c .
+  (a list * Form.form_elt M.t) ->
+  (a, _, c) params_type ->
+  a list * Form.form_elt M.t =
+  fun ((acc, m) as p) y ->
+    match reconstruct_params m y with
+    | Some (v, m) ->
+      reconstruct_set (v :: acc, m) y
+    | None ->
+      p
+
+and reconstruct_params :
+  type a c .
+  Form.form_elt M.t ->
+  (a, [`WithoutSuffix], c) params_type ->
+  (a * Form.form_elt M.t) option =
+  fun m -> function
+    | TAtom (name, TBool) ->
+      (match M.remove m name with
+       | Some (_, m) ->
+         Some (true, m)
+       | None ->
+         Some (false, m))
+    | TAtom (name, y) ->
+      reconstruct_atom ~f:(atom_of_string y) m name
+    | TProd (TList _, _) ->
+      failwith "Lists or sets in suffixes must be last"
+    | TProd (TSet _, _) ->
+      failwith "Lists or sets in suffixes must be last"
+    | TProd (y1, y2) ->
+      reconstruct_params m y1 >>= fun (x1, m) ->
+      reconstruct_params m y2 >>= fun (x2, m) ->
+      Some ((x1, x2), m)
+    | TUnit ->
+      Some ((), m)
+    | TOption (TAtom (_, TString) as y, b) ->
+      (match reconstruct_params m y with
+       | Some ("", m) ->
+         Some (None, m)
+       | Some (s, m) ->
+         Some (Some s, m)
+       | None ->
+         Some (None, m))
+    | TOption (y, b) ->
+      (match reconstruct_params m y with
+       | Some (x, m) ->
+         Some (Some x, m)
+       | None ->
+         Some (None, m))
+    | TSet (TAtom (_, TBool) as y) ->
+      reconstruct_params m y >>= fun (x, m) ->
+      Some ([x], m)
+    | TSet y ->
+      Some (reconstruct_set ([], m) y)
+    | TSum (y1, y2) ->
+      (match reconstruct_params m y1 with
+       | Some (x, m) ->
+         Some (Inj1 x, m)
+       | None ->
+         reconstruct_params m y2 >>= fun (x, m) ->
+         Some (Inj2 x, m))
+    | TCoord name ->
+      let f = int_of_string in
+      reconstruct_atom ~f m (name ^ ".x") >>= fun (abscissa, m) ->
+      reconstruct_atom ~f m (name ^ ".y") >>= fun (ordinate, m) ->
+      Some ({abscissa ; ordinate}, m)
+    | TUserType (name, {of_string = f}) ->
+      reconstruct_atom ~f m name
+    | _ ->
+      None
+
+let reconstruct_params l y =
+  reconstruct_params (M.of_assoc_list l) y >>= fun (v, _) ->
+  Some v

--- a/src/lib/eliom_parameter.client.mli
+++ b/src/lib/eliom_parameter.client.mli
@@ -1,1 +1,4 @@
 include Eliom_parameter_sigs.S
+
+val reconstruct_params :
+  (string * Form.form_elt) list -> ('a, _, _) params_type -> 'a option

--- a/src/lib/eliom_parameter_base.shared.ml
+++ b/src/lib/eliom_parameter_base.shared.ml
@@ -434,27 +434,6 @@ let make_params_names params =
       | TRaw_post_data -> failwith "Not possible with raw post data"
   in aux false "" "" params
 
-type boxed_atom_fun =
-  { boxed_atom_fun : 'a . 'a atom -> string -> 'a option }
-
-let rec read_params :
-  type y n . f:boxed_atom_fun -> (y, _, n) params_type -> y option =
-  let (>>=) x f = match x with Some x -> f x | None -> None in
-  fun ~f:({boxed_atom_fun} as f) -> function
-    | TAtom (name, a) ->
-      boxed_atom_fun a name
-    | TProd (y1, y2) ->
-      read_params ~f y1 >>= fun x1 ->
-      read_params ~f y2 >>= fun x2 ->
-      Some (x1, x2)
-    | TUnit ->
-      Some ()
-    | TOption (y, b) ->
-      (* TODO: check meaning of b *)
-      Some (read_params ~f y)
-    | _ ->
-      None
-
 let string_of_param_name = id
 
 (* Add a prefix to parameters *)

--- a/src/lib/eliom_runtime.shared.ml
+++ b/src/lib/eliom_runtime.shared.ml
@@ -54,8 +54,11 @@ module RawXML = struct
     | CE_client_closure of
         ((#Dom_html.event as 'a) Js.t -> unit) (* Client side-only *)
     | CE_call_service of
-        ([ `A | `Form_get | `Form_post] * (cookie_info option) * string option)
-          option Eliom_lazy.request
+        ( [ `A | `Form_get | `Form_post] *
+          (cookie_info option) *
+          string option *
+          Ocsigen_lib.poly (* (unit -> bool) client_value *)
+        ) option Eliom_lazy.request
 
   (* Inherit from all events.
      Necessary for subtyping since caml_event_handler is contravariant. *)
@@ -178,7 +181,7 @@ module RawXML = struct
       begin
         match Eliom_lazy.force link_info with
           | None -> freepos, acc_class, acc_attr
-          | Some (kind,cookie_info,tmpl) ->
+          | Some (kind, cookie_info, tmpl, _) ->
             let acc_class = ce_call_service_class::acc_class in
             let acc_attr =
               match cookie_info with

--- a/src/lib/eliom_runtime.shared.mli
+++ b/src/lib/eliom_runtime.shared.mli
@@ -56,7 +56,11 @@ module RawXML : sig
         string * Ocsigen_lib.poly (* 'a Js.t -> unit) client_value *)
     | CE_client_closure of ((#Dom_html.event as 'a) Js.t -> unit)
     | CE_call_service of
-        ([ `A | `Form_get | `Form_post] * (cookie_info option) * string option) option Eliom_lazy.request
+        ( [ `A | `Form_get | `Form_post] *
+          (cookie_info option) *
+          string option *
+          Ocsigen_lib.poly (* (unit -> bool) client_value *)
+        ) option Eliom_lazy.request
 
   (* Inherit from all events.
      Necessary for subtyping since caml_event_handler is contravariant. *)
@@ -76,8 +80,12 @@ module RawXML : sig
   val uri_of_fun : (unit -> string) -> uri
 
   val internal_event_handler_of_service :
-    ([ `A | `Form_get | `Form_post] * (cookie_info option) * string option) option Eliom_lazy.request ->
-      internal_event_handler
+    (  [ `A | `Form_get | `Form_post]
+       * cookie_info option
+       * string option
+       * Eliom_lib.poly
+    )  option Eliom_lazy.request
+    -> internal_event_handler
 
   val ce_registered_closure_class : string
   val ce_registered_attr_class : string

--- a/src/lib/eliom_service.client.mli
+++ b/src/lib/eliom_service.client.mli
@@ -388,6 +388,9 @@ val set_client_fun_ :
   unit
 val has_client_fun_ :
   ('a, 'b, 'meth, 'attch, 'kind, 'd, 'e, 'f, 'g, 'return) service -> bool
+val has_client_fun_lazy :
+  (_, _, _, _, _, _, _, _, _, _) service ->
+  (unit -> bool) Eliom_client_value.t
 val internal_set_client_fun_ :
   service:('a, 'b, 'meth, 'attached, 'c, 'd, 'e, 'f, 'g, 'return) service ->
   (unit ->

--- a/src/lib/eliom_service.server.mli
+++ b/src/lib/eliom_service.server.mli
@@ -405,6 +405,9 @@ val set_client_fun_ :
   unit
 val has_client_fun_ :
   ('a, 'b, 'meth, 'attch, 'kind, 'd, 'e, 'f, 'g, 'return) service -> bool
+val has_client_fun_lazy :
+  (_, _, _, _, _, _, _, _, _, _) service ->
+  (unit -> bool) Eliom_client_value.t
 val internal_set_client_fun_ :
   service:('a, 'b, 'meth, 'attached, 'c, 'd, 'e, 'f, 'g, 'return) service ->
   (unit ->

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -178,6 +178,17 @@ let get_timeout_ s = s.timeout
 let get_https s = s.https
 let get_priority_ s = s.priority
 let get_client_fun_ s = !(s.client_fun)
+let has_client_fun_lazy s =
+  let f = get_client_fun_ s in
+  {unit -> bool{
+     fun () ->
+       match %f () with
+       | Some _ ->
+         true
+       | None ->
+         false
+   }}
+
 let internal_set_client_fun_ ~service:s f = s.client_fun := f
 
 let set_client_fun_ ?app ~service:s f =


### PR DESCRIPTION
This addresses #281. Not sure this is ready to merge, but it can be reviewed.

Our service infrastructure allows client-side implementations, but these were not previously used by out typed forms infrastructure. With this PR we detect the existence of a client-side function and handle form submission with that instead of calling the server-side service. 

* The code in `Eliom_parameter` parses the form data.
* The code in `Eliom_form` adds a "submit" event handler that calls the client-side service implementation, if it exists.

Unfortunately, there is a second "submit" event handler for calling services (in `Eliom_client_core`). This is too low level to use for our purpose, i.e., it doesn't have access to all the needed service info. I have just modified this second handler to do nothing if a client-side implementation exists, thus letting the handler in `Eliom_form` do the work.

TODO:

- [x] More exhaustive `Eliom_parameter.reconstruct_params`
- [x] Double-check handler logic