### PR TITLE
Fix Eliom_service.ocaml_service variance

### DIFF
--- a/src/lib/eliom_client.server.ml
+++ b/src/lib/eliom_client.server.ml
@@ -21,7 +21,7 @@
 
 let is_client_app () = false
 
-type ('a, +'b) server_function =
+type ('a, 'b) server_function =
   ('a, 'b) Eliom_client_base.server_function_service * Eliom_wrap.unwrapper
 
 let mk_serv_fun a b : ('a, 'b) server_function = (a, b)

--- a/src/lib/eliom_client.server.mli
+++ b/src/lib/eliom_client.server.mli
@@ -17,7 +17,7 @@ val is_client_app : unit -> bool
     function ['a -> 'b Lwt.t] and provides a given function on the client side.
     See also {% <<a_api subproject="client" text="the concrete client side representation"|
               type Eliom_client.server_function>> %}. *)
-type ('a, +'b) server_function
+type ('a, 'b) server_function
 
 (** [server_function argument_type f] creates a value of type {%
     <<a_api | type Eliom_client.server_function>> %}. This allows

--- a/src/lib/eliom_client_base.shared.ml
+++ b/src/lib/eliom_client_base.shared.ml
@@ -1,5 +1,5 @@
 
-type ('a, +'b) server_function_service =
+type ('a, 'b) server_function_service =
   (unit, 'a, [`Post], Eliom_service.non_attached_kind, [`NonattachedCoservice], [ `WithoutSuffix ],
    unit, [ `One of 'a Eliom_parameter.ocaml ] Eliom_parameter.param_name,
    [ `Registrable ],

--- a/src/lib/eliom_service.client.ml
+++ b/src/lib/eliom_service.client.ml
@@ -21,7 +21,7 @@ include Eliom_service_base
 
 type http_service = [ `Http ]
 type appl_service = [ `Appl ]
-type +'a ocaml_service = [ `Ocaml of 'a ]
+type 'a ocaml_service = [ `Ocaml of 'a ]
 
 type non_ocaml_service = [ appl_service | http_service ]
 

--- a/src/lib/eliom_service.client.mli
+++ b/src/lib/eliom_service.client.mli
@@ -128,7 +128,7 @@ type ('get,'post,+'meth,+'attached,+'kind,+'tipo,'gn,'pn,+'reg,+'ret) service
 
 type http_service = [ `Http ]
 type appl_service = [ `Appl ]
-type +'a ocaml_service
+type 'a ocaml_service
 
 (** The type [non_ocaml_service] is used as phantom type parameters for
     the {!Eliom_registration.kind}. It used to type functions that operates

--- a/src/lib/eliom_service.server.ml
+++ b/src/lib/eliom_service.server.ml
@@ -190,7 +190,7 @@ let unregister ?scope ?secure service =
 
 type http_service = [ `Http ]
 type appl_service = [ `Appl ]
-type +'a ocaml_service = [ `Ocaml of 'a ]
+type 'a ocaml_service = [ `Ocaml of 'a ]
 
 type non_ocaml_service = [ appl_service | http_service ]
 

--- a/src/lib/eliom_service.server.mli
+++ b/src/lib/eliom_service.server.mli
@@ -148,7 +148,7 @@ type ('get,'post,+'meth,+'attached,+'kind,+'tipo,'gn,'pn,+'reg,+'ret) service
 
 type http_service = [ `Http ]
 type appl_service = [ `Appl ]
-type +'a ocaml_service
+type 'a ocaml_service
 
 (** The type [non_ocaml_service] is used as phantom type parameters for
     the {!Eliom_registration.kind}. It used to type functions that operates


### PR DESCRIPTION
The type cannot be covariant as this would make the type of function `Eliom_registration.Ocaml.register` unsound.