### PR TITLE
Remove Eliom_parameter.TCoordv

### DIFF
--- a/src/lib/eliom_parameter.server.ml
+++ b/src/lib/eliom_parameter.server.ml
@@ -161,13 +161,6 @@ let reconstruct_params_
          | r, l ->
            let rr, ll = parse_suffix (TAtom ("",TInt)) l in
            {abscissa = r; ordinate=rr}, ll)
-      | TCoordv (_, t), l ->
-          let a, l = parse_suffix t l in
-          (match parse_suffix (TAtom ("",TInt)) l with
-           | _, [] -> raise Eliom_common.Eliom_Wrong_parameter
-           | r, l ->
-             let rr, ll = parse_suffix (TAtom ("",TInt)) l in
-             (a, {abscissa = r; ordinate=rr}), ll)
       | TNLParams _, _ ->
           failwith "It is not possible to have non localized parameters in suffix"
       | TJson (_, Some typ), v::l -> Deriving_Json.from_string typ v, l
@@ -311,8 +304,6 @@ let reconstruct_params_
                 ignore (int_of_string v);
                 Errors_ (errs, l, f)
               with e -> Errors_ (((pref^name^suff^".y"), v, e)::errs, l, f)))
-        | TCoordv (name, t) ->
-            aux (TProd (t, TCoord name)) params files pref suff
         | TUserType (name, ofto) ->
           let v,l = (List.assoc_remove (pref^name^suff) params) in
           (try Res_ (ofto.of_string v,l,files)

--- a/src/lib/eliom_parameter_sigs.shared.mli
+++ b/src/lib/eliom_parameter_sigs.shared.mli
@@ -164,53 +164,6 @@ module type S = sig
      [ `WithoutSuffix ],
      [ `One of coordinates ] param_name) params_type
 
-  (** [coordinates s] means that the service takes as parameters the
-      coordinates of a point in an [<input type="image" ...>] (plus
-      the associated string value). *)
-  val string_coordinates :
-    string ->
-    (string * coordinates,
-     [ `WithoutSuffix ],
-     [ `One of (string * coordinates) ] param_name) params_type
-
-  (** Same as [string_coordinates] but for an integer value *)
-  val int_coordinates :
-    string ->
-    (int * coordinates,
-     [`WithoutSuffix],
-     [ `One of (int * coordinates) ] param_name) params_type
-
-  (** Same as [string_coordinates] but for a 32-bit integer value *)
-  val int32_coordinates :
-    string ->
-    (int32 * coordinates,
-     [`WithoutSuffix],
-     [ `One of (int32 * coordinates) ] param_name) params_type
-
-  (** Same as [string_coordinates] but for a 64-bit integer value *)
-  val int64_coordinates :
-    string ->
-    (int64 * coordinates,
-     [`WithoutSuffix],
-     [ `One of (int64 * coordinates) ] param_name) params_type
-
-  (** Same as [string_coordinates] but for a float value *)
-  val float_coordinates :
-    string ->
-    (float * coordinates,
-     [`WithoutSuffix],
-     [ `One of (float * coordinates) ] param_name) params_type
-
-  (** Same as [string_coordinates] but for a value of your own
-      type. See {!user_type} for a description of the [of_string] and
-      [to_string] parameters. *)
-  val user_type_coordinates :
-    of_string:(string -> 'a) ->
-    to_string:('a -> string) -> string ->
-    ('a * coordinates,
-     [`WithoutSuffix],
-     [ `One of ('a * coordinates) ] param_name) params_type
-
   (** {2 Composing types of pages parameters} *)
 
   (** The combinator [p1 ** p2] allows one to define a service that


### PR DESCRIPTION
This PR removes the `Eliom_parameter.TCoordv` constructor, which is for coordinates that carry an additional value. Such coordinates could be produced by form elements like the following:

```html
<input type="image" value="foo" />
```

However, the above is not of much use, it is [not universally supported](https://stackoverflow.com/questions/7935456/input-type-image-submit-form-value) by browsers, and it is no longer supported by `Eliom_form`. So let's remove some cruft.