### PR TITLE
Catch up with TyXML

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -1,7 +1,8 @@
 opam pin add --no-action eliom .
 opam pin add --no-action reactiveData 'https://github.com/ocsigen/reactiveData.git#master'
-opam pin add --no-action ocsigenserver 'https://github.com/ocsigen/ocsigenserver.git#master'
-opam pin add --no-action js_of_ocaml 'https://github.com/ocsigen/js_of_ocaml.git#master'
+opam pin add --no-action tyxml 'https://github.com/ocsigen/tyxml.git#master'
+opam pin add --no-action ocsigenserver 'https://github.com/ocsigen/ocsigenserver.git#tyxml'
+opam pin add --no-action js_of_ocaml 'https://github.com/ocsigen/js_of_ocaml.git#tyxml'
 
 opam install --deps-only eliom
 opam install --verbose eliom

--- a/opam
+++ b/opam
@@ -13,9 +13,9 @@ depends: [
   "deriving" {>= "0.6"}
   ("base-no-ppx" | "ppx_tools" {>= "0.99.3"})
   "js_of_ocaml" {> "2.7"}
-  "tyxml" {= "3.6.0"}
+  "tyxml" {> "3.6.0"}
   "calendar"
-  "ocsigenserver" {>= "2.6"}
+  "ocsigenserver" {> "2.7"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2"}
   "base-bytes"

--- a/pkg/distillery/basic.camlp4/PROJECT_NAME.eliom
+++ b/pkg/distillery/basic.camlp4/PROJECT_NAME.eliom
@@ -1,7 +1,7 @@
 {shared{
   open Eliom_lib
   open Eliom_content
-  open Html5.D
+  open Html.D
 }}
 
 module %%%MODULE_NAME%%%_app =
@@ -25,6 +25,6 @@ let () =
         (Eliom_tools.F.html
            ~title:"%%%PROJECT_NAME%%%"
            ~css:[["css";"%%%PROJECT_NAME%%%.css"]]
-           Html5.F.(body [
+           Html.F.(body [
              h1 [pcdata "Welcome from Eliom's distillery!"];
            ])))

--- a/pkg/distillery/basic.ppx/PROJECT_NAME.eliom
+++ b/pkg/distillery/basic.ppx/PROJECT_NAME.eliom
@@ -1,7 +1,7 @@
 [%%shared
     open Eliom_lib
     open Eliom_content
-    open Html5.D
+    open Html.D
 ]
 
 module %%%MODULE_NAME%%%_app =
@@ -25,6 +25,6 @@ let () =
         (Eliom_tools.F.html
            ~title:"%%%PROJECT_NAME%%%"
            ~css:[["css";"%%%PROJECT_NAME%%%.css"]]
-           Html5.F.(body [
+           Html.F.(body [
              h1 [pcdata "Welcome from Eliom's distillery!"];
            ])))

--- a/pkg/distillery/mobile/PROJECT_NAME.eliom
+++ b/pkg/distillery/mobile/PROJECT_NAME.eliom
@@ -1,7 +1,7 @@
 {shared{
   open Eliom_lib
   open Eliom_content
-  open Html5.D
+  open Html.D
 }}
 
 module %%%MODULE_NAME%%%_app =
@@ -25,6 +25,6 @@ let () =
         (Eliom_tools.F.html
            ~title:"%%%PROJECT_NAME%%%"
            ~css:[["css";"%%%PROJECT_NAME%%%.css"]]
-           Html5.F.(body [
+           Html.F.(body [
              h1 [pcdata "Welcome from Eliom's distillery!"];
            ])))

--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -1188,15 +1188,15 @@ let rebuild_node_svg context elt =
 (** The first argument describes the calling function (if any) in case
     of an error. *)
 let rebuild_node context elt =
-  let elt' = Eliom_content_core.Html5.F.toelt elt in
+  let elt' = Eliom_content_core.Html.F.toelt elt in
   rebuild_node_ns `HTML5 context elt'
 
 (******************************************************************************)
 (*                            Register unwrappers                             *)
 
-(* == Html5 elements
+(* == Html elements
 
-   Html5 elements are unwrapped lazily (cf. use of Xml.make_lazy in
+   Html elements are unwrapped lazily (cf. use of Xml.make_lazy in
    unwrap_tyxml), because the unwrapping of process and request
    elements needs access to the DOM.
 

--- a/src/lib/eliom_client_value.client.mli
+++ b/src/lib/eliom_client_value.client.mli
@@ -36,7 +36,7 @@ type 'a t = 'a
     {!Printexc.to_string}. *)
 exception Exception_on_server of string
 
-(** Event handlers like {% <<a_api | Eliom_content.Html5.F.a_onclick
+(** Event handlers like {% <<a_api | Eliom_content.Html.F.a_onclick
     >> %} may raise [False] to cancel the event (as if the JavaScript
     function returned [false]). *)
 

--- a/src/lib/eliom_config.server.mli
+++ b/src/lib/eliom_config.server.mli
@@ -68,7 +68,7 @@ val get_config_default_charset : unit -> string
 
 (** The provided value serves as a default value for the optional parameter
     [~xhr] in the functions [Eliom_registration.*.{a, get_form, post_form,
-    lwt_get_form, lwt_post_form}] (cf. {!Eliom_registration.Html5.a} et al.).
+    lwt_get_form, lwt_post_form}] (cf. {!Eliom_registration.Html.a} et al.).
     This value can also be set in the
     {{:http://ocsigen.org/eliom/dev/manual/config#h5o-25}config file}.  *)
 val set_default_links_xhr : ?override_configfile:bool -> bool -> unit

--- a/src/lib/eliom_content.client.mli
+++ b/src/lib/eliom_content.client.mli
@@ -51,7 +51,7 @@ module Svg : sig
 
        See {% <<a_api project="tyxml" | module Svg_sigs.T >> %} *)
   module F : sig
-    (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
+    (** Cf. {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
     module Raw : Svg_sigs.Make(Xml).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
@@ -64,7 +64,7 @@ module Svg : sig
 
        See {% <<a_api project="tyxml" | module Svg_sigs.T >> %} *)
   module D : sig
-    (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
+    (** Cf. {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
     module Raw : Svg_sigs.Make(Xml).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
@@ -266,7 +266,7 @@ module Svg : sig
   end
 
   (** Conversion functions from DOM nodes ({% <<a_api project="js_of_ocaml"| type Dom_html.element>> %} {% <<a_api
-      project="js_of_ocaml"| type Js.t>> %}) to Eliom nodes ({% <<a_api | type Eliom_content.Html5.elt>> %}). *)
+      project="js_of_ocaml"| type Js.t>> %}) to Eliom nodes ({% <<a_api | type Eliom_content.Html.elt>> %}). *)
   module Of_dom : sig
     val of_element: Dom_html.element Js.t -> 'a elt
   end
@@ -274,7 +274,7 @@ module Svg : sig
 end
 
 (** Building valid (X)HTML5. *)
-module Html5 : sig
+module Html : sig
 
   (** See the Eliom manual for more information on {% <<a_manual
       chapter="clientserver-html" fragment="unique"| dom semantics vs. functional
@@ -289,10 +289,10 @@ module Html5 : sig
   (** Creation of {e f}unctional HTML5 content (copy-able but not referable). *)
   module F : sig
     (** {2 Content creation}
-        See {% <<a_api project="tyxml" | module Html5_sigs.T >> %} *)
+        See {% <<a_api project="tyxml" | module Html_sigs.T >> %} *)
 
-    (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+    (** Cf. {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
+    module Raw : Html_sigs.Make(Xml)(Svg.F.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -310,10 +310,10 @@ module Html5 : sig
   (** Creation of HTML5 content with {e D}OM semantics (referable) *)
   module D : sig
     (** {2 Content creation}
-        See {% <<a_api project="tyxml" | module Html5_sigs.T >> %} *)
+        See {% <<a_api project="tyxml" | module Html_sigs.T >> %} *)
 
-    (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+    (** Cf. {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
+    module Raw : Html_sigs.Make(Xml)(Svg.D.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -335,9 +335,9 @@ module Html5 : sig
       corresponding signals change.  *)
   module R : sig
     (** {2 Content creation}
-        See {% <<a_api project="tyxml" | module Html5_sigs.T >> %},
+        See {% <<a_api project="tyxml" | module Html_sigs.T >> %},
         If you want to create an untyped form,
-        you will have to use {% <<a_api|module Eliom_content.Html5.D.Raw>> %}
+        you will have to use {% <<a_api|module Eliom_content.Html.D.Raw>> %}
         otherwise, use the form module.
         For more information,
         see {{:http://ocsigen.org/howto/forms/}"how to make forms"} *)
@@ -351,8 +351,8 @@ module Html5 : sig
         and behave like if there was no attribute when [on] is [false] *)
     val filter_attrib : 'a attrib -> bool React.signal -> 'a attrib
 
-    (** Cf. {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.Make(Eliom_content_core.Xml_wed)(Svg.R.Raw).T
+    (** Cf. {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
+    module Raw : Html_sigs.Make(Eliom_content_core.Xml_wed)(Svg.R.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -412,7 +412,7 @@ module Html5 : sig
 
     (** Create a custom data field by providing string conversion functions.
         If the [default] is provided, calls to {% <<a_api project="eliom" subproject="client" |
-        val Eliom_content.Html5.Custom_data.get_dom>> %} return that instead of throwing an
+        val Eliom_content.Html.Custom_data.get_dom>> %} return that instead of throwing an
         exception [Not_found].  *)
     val create : name:string -> ?default:'a -> to_string:('a -> string) -> of_string:(string -> 'a) -> unit -> 'a t
 
@@ -421,7 +421,7 @@ module Html5 : sig
 
     (** [attrib my_data value ] creates a HTML5 attribute for the custom-data
         type [my_data] with value [value] for injecting it into an a HTML5 tree
-        ({% <<a_api | type Eliom_content.Html5.elt >> %}). *)
+        ({% <<a_api | type Eliom_content.Html.elt >> %}). *)
     val attrib : 'a t -> 'a -> [> | `User_data ] attrib
 
     val get_dom : Dom_html.element Js.t -> 'a t -> 'a
@@ -860,7 +860,7 @@ module Html5 : sig
   end
 
   (** Conversion functions from DOM nodes ({% <<a_api project="js_of_ocaml"| type Dom_html.element>> %} {% <<a_api
-      project="js_of_ocaml"| type Js.t>> %}) to Eliom nodes ({% <<a_api | type Eliom_content.Html5.elt>> %}). *)
+      project="js_of_ocaml"| type Js.t>> %}) to Eliom nodes ({% <<a_api | type Eliom_content.Html.elt>> %}). *)
   module Of_dom : Tyxml_cast_sigs.OF with type 'a elt = 'a elt
 
 end
@@ -876,7 +876,7 @@ val set_client_fun :
   unit
 
 val wrap_client_fun :
-  ('g -> 'p -> Html5_types.html Html5.elt Lwt.t)
+  ('g -> 'p -> Html_types.html Html.elt Lwt.t)
   -> ('g -> 'p -> unit Lwt.t)
 
 (** With [set_form_error_handler f], [f] becomes the action to be

--- a/src/lib/eliom_content.eliom
+++ b/src/lib/eliom_content.eliom
@@ -66,9 +66,9 @@ module Svg = struct
 
 end
 
-module Html5 = struct
+module Html = struct
 
-  include Eliom_content_.Html5
+  include Eliom_content_.Html
 
   module C = struct
     let node ?(init=D.Unsafe.node "span" []) x =
@@ -76,9 +76,9 @@ module Html5 = struct
       (* We need to box / unbox the client_value to convince eliom it's not polymorphic *)
       let client_boxed : boxed Eliom_client_value.t = boxed x in
       let _ = {unit{
-          let dummy_dom = Html5.To_dom.of_element (Html5.D.tot %((dummy_elt : Xml.elt))) in
+          let dummy_dom = Html.To_dom.of_element (Html.D.tot %((dummy_elt : Xml.elt))) in
           let client_boxed = %client_boxed in
-          let real = Html5.To_dom.of_element (unboxed client_boxed) in
+          let real = Html.To_dom.of_element (unboxed client_boxed) in
           Js.Opt.iter
             (dummy_dom##parentNode)
             (fun parent -> Dom.replaceChild parent real dummy_dom)
@@ -100,7 +100,7 @@ end
 {client{
 let wrap_client_fun f get_params post_params =
   lwt content = f get_params post_params in
-  let content = Html5.To_dom.of_element content in
+  let content = Html.To_dom.of_element content in
   Eliom_client.set_content_local content
 
 let set_form_error_handler = Eliom_form.set_error_handler

--- a/src/lib/eliom_content.server.mli
+++ b/src/lib/eliom_content.server.mli
@@ -24,17 +24,17 @@
     XML tree manipulation within Eliom is based on the TyXML library
     but Eliom is using a custom representation for XML values (see
     {!Xml}). Then, [Eliom_content] redefines the two high level
-    interfaces ({!Svg}, {!Html5}) that are provided by
+    interfaces ({!Svg}, {!Html}) that are provided by
     TyXML for valid XML tree creation and printing.
 
-    - If you want to generate typed HTML, use {!Eliom_content.Html5},
+    - If you want to generate typed HTML, use {!Eliom_content.Html},
     - If you want to write untyped html, use {!Eliom_content.Html_text},
     - If you want to generate typed svg, use {!Eliom_content.Svg}.
 
-    Modules {!Eliom_content.Html5}, {!Eliom_content.Svg} contain two
-    sub-modules: {!Eliom_content.Html5.F}, {!Eliom_content.Html5.D}
+    Modules {!Eliom_content.Html}, {!Eliom_content.Svg} contain two
+    sub-modules: {!Eliom_content.Html.F}, {!Eliom_content.Html.D}
     corresponding to tow different semantics.
-    They also contain a module {!Eliom_content.Html5.C} that allows to
+    They also contain a module {!Eliom_content.Html.C} that allows to
     inject client-side content into server-side content.
 
     {5 Functional semantics}
@@ -64,8 +64,8 @@
     Secondly, those values have an identifier,
     which means they can be referred to
     on client side (by [%variable]) or used with the functions in
-    {% <<a_api subproject="client"|module Eliom_content.Html5.To_dom>> %} and
-    {% <<a_api subproject="client"|module Eliom_content.Html5.Manip>> %}.
+    {% <<a_api subproject="client"|module Eliom_content.Html.To_dom>> %} and
+    {% <<a_api subproject="client"|module Eliom_content.Html.Manip>> %}.
 
     In case of doubt, always use [D]-nodes when you are writing a
     client-server Eliom app. You can also mix F-nodes and D-nodes.
@@ -112,7 +112,7 @@ module Xml : sig
       build with the [{{ ... }}] syntax (see the Eliom manual for more
       information on {% <<a_manual chapter="clientserver-html"
       fragment="syntax"|syntax extension>>%}). Such values are
-      expected by functions like {!Eliom_content.Html5.a_onclick}. The
+      expected by functions like {!Eliom_content.Html.a_onclick}. The
       type parameter is the type of the javascript event expected by
       the handler, for example {% <<a_api project="js_of_ocaml" | type
       Dom_html.mouseEvent>>%} or {% <<a_api project="js_of_ocaml" |
@@ -192,7 +192,7 @@ module Svg : sig
       Svg_sigs.T >> %}. *)
   module F : sig
 
-    (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
+    (** See {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
     module Raw : Svg_sigs.Make(Xml).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
@@ -205,7 +205,7 @@ module Svg : sig
       {% <<a_api project="tyxml" | module Svg_sigs.T >> %}. *)
   module D : sig
 
-    (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
+    (** See {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
     module Raw : Svg_sigs.Make(Xml).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
@@ -284,9 +284,9 @@ end
 
 
 (** Building and printing valid HTML5 tree.
-    Information about Html5 api can be found at
-    {% <<a_api project="tyxml" | module Html5_sigs.T >> %} .*)
-module Html5 : sig
+    Information about Html api can be found at
+    {% <<a_api project="tyxml" | module Html_sigs.T >> %} .*)
+module Html : sig
 
   (** See {% <<a_manual
       chapter="clientserver-html" fragment="unique"|
@@ -305,14 +305,14 @@ module Html5 : sig
 
     (** {2 Content creation}
 
-        See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}.
+        See {% <<a_api project="tyxml" | module Html_sigs.T >> %}.
         If you want to create an untyped form, you will have to use {%
-        <<a_api|module Eliom_content.Html5.F.Raw>> %} otherwise, use
+        <<a_api|module Eliom_content.Html.F.Raw>> %} otherwise, use
         Eliom form widgets.  For more information, see
         {{:http://ocsigen.org/howto/forms/}"how to make forms"} *)
 
-    (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+    (** See {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
+    module Raw : Html_sigs.Make(Xml)(Svg.F.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -327,20 +327,20 @@ module Html5 : sig
 
   end
 
-  (** Creation of HTML5 content with {b D}OM semantics (referable, see
+  (** Creation of HTML content with {b D}OM semantics (referable, see
       also {% <<a_api|module Eliom_content>> %}). *)
   module D : sig
 
     (** {2 Content creation}
 
-        See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}.
+        See {% <<a_api project="tyxml" | module Html_sigs.T >> %}.
         If you want to create an untyped form, you will have to use {%
-        <<a_api|module Eliom_content.Html5.F.Raw>> %} otherwise, use
+        <<a_api|module Eliom_content.Html.F.Raw>> %} otherwise, use
         Eliom form widgets.  For more information, see
         {{:http://ocsigen.org/howto/forms/}"how to make forms"} *)
 
-    (** See {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
-    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+    (** See {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
+    module Raw : Html_sigs.Make(Xml)(Svg.D.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -355,7 +355,7 @@ module Html5 : sig
 
   end
 
-  (** Creation of HTML5 content from client-side values.  This makes
+  (** Creation of HTML content from client-side values.  This makes
       possible to insert in server side generated pages some nodes
       that will be computed on client side (for example reactive
       nodes).  *)
@@ -374,10 +374,10 @@ module Html5 : sig
   (** Node identifiers *)
   module Id : sig
 
-    (** The type of global HTML5 element identifier. *)
+    (** The type of global HTML element identifier. *)
     type +'a id
 
-    (** The function [new_elt_id ()] creates a new global HTML5 element
+    (** The function [new_elt_id ()] creates a new global HTML element
         identifier (see the Eliom manual for more information on {%
         <<a_manual project="eliom" chapter="clientserver-html"
         fragment="global"|global element>>%}).*)
@@ -403,21 +403,21 @@ module Html5 : sig
 
   end
 
-  (** Creation of HTML5 content from shared reactive signals and data
+  (** Creation of HTML content from shared reactive signals and data
       ({% <<a_api project="eliom" subproject="server"|module Eliom_shared>> %}).
       For the operations provided, see
-      {% <<a_api project="tyxml" | module Html5_sigs.T >> %}. *)
+      {% <<a_api project="tyxml" | module Html_sigs.T >> %}. *)
   module R : sig
 
-    include Html5_sigs.Make(Xml_shared)(Svg.R.Raw).T
+    include Html_sigs.Make(Xml_shared)(Svg.R.Raw).T
       with type 'a elt = 'a elt
        and type 'a attrib = 'a attrib
 
     (** [pcdata s] produces a node of type
-        [\[> Html5_types.span\] elt]
+        [\[> Html_types.span\] elt]
         out of the string signal [s]. *)
     val pcdata :
-      string Eliom_shared.React.S.t -> [> Html5_types.span] elt
+      string Eliom_shared.React.S.t -> [> Html_types.span] elt
 
     (** [node s] produces an ['a elt] out of the shared reactive
         signal [s]. *)
@@ -430,7 +430,7 @@ module Html5 : sig
 
   end
 
-  (** Type-safe custom data for HTML5.
+  (** Type-safe custom data for HTML.
       See the {% <<a_manual chapter="clientserver-html"
       fragment="custom_data"|examples in the manual>> %}. *)
   module Custom_data : sig
@@ -440,21 +440,21 @@ module Html5 : sig
 
     (** Create a custom data field by providing string conversion functions.
         If the [default] is provided, calls to {% <<a_api project="eliom" subproject="client" |
-        val Eliom_content.Html5.Custom_data.get_dom>> %} return that instead of throwing an
+        val Eliom_content.Html.Custom_data.get_dom>> %} return that instead of throwing an
         exception [Not_found].  *)
     val create : name:string -> ?default:'a -> to_string:('a -> string) -> of_string:(string -> 'a) -> unit -> 'a t
 
     (** Create a custom data from a Json-deriving type.  *)
     val create_json : name:string -> ?default:'a -> 'a Deriving_Json.t -> 'a t
 
-    (** [attrib my_data value ] creates a HTML5 attribute for the custom-data
-        type [my_data] with value [value] for injecting it into an a HTML5 tree
-        ({% <<a_api | type Eliom_content.Html5.elt >> %}). *)
+    (** [attrib my_data value ] creates a HTML attribute for the custom-data
+        type [my_data] with value [value] for injecting it into an a HTML tree
+        ({% <<a_api | type Eliom_content.Html.elt >> %}). *)
     val attrib : 'a t -> 'a -> [> | `User_data ] attrib
 
   end
 
-  (** {{:http://dev.w3.org/html5/html-xhtml-author-guide/}"Polyglot"} HTML5 printer.
+  (** {{:http://dev.w3.org/html5/html-xhtml-author-guide/}"Polyglot"} HTML printer.
      See {% <<a_api project="tyxml" | module Xml_sigs.Typed_simple_printer >> %}. *)
   module Printer : Xml_sigs.Typed_simple_printer with type +'a elt := 'a elt
                                                   and type doc := F.doc

--- a/src/lib/eliom_content_.client.ml
+++ b/src/lib/eliom_content_.client.ml
@@ -379,17 +379,17 @@ module Svg = struct
 
 end
 
-module Html5 = struct
+module Html = struct
 
   module F = struct
-    include Html5.F
+    include Html.F
     module Arg = struct
-      include Html5.F
+      include Html.F
       module Svg = Eliom_content_core.Svg.F
       let uri_of_fun = Eliom_content_core.Xml.uri_of_fun
       let attrib_of_service s info =
         Eliom_content_core.
-          (Html5.F.to_attrib
+          (Html.F.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
       let to_elt = toelt
@@ -399,18 +399,18 @@ module Html5 = struct
   end
 
   module R = struct
-    include Html5.R
+    include Html.R
   end
 
   module D = struct
-    include Html5.D
+    include Html.D
     module Arg = struct
-      include Html5.D
+      include Html.D
       module Svg = Eliom_content_core.Svg.D
       let uri_of_fun = Eliom_content_core.Xml.uri_of_fun
       let attrib_of_service s info =
         Eliom_content_core.
-          (Html5.D.to_attrib
+          (Html.D.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
       let to_elt = toelt
@@ -429,9 +429,9 @@ module Html5 = struct
   type uri = F.uri
   type 'a form_param = 'a Eliom_form.param
 
-  module Custom_data = Eliom_content_core.Html5.Custom_data
+  module Custom_data = Eliom_content_core.Html.Custom_data
 
-  module Of_dom = Eliom_content_core.Html5.Of_dom
+  module Of_dom = Eliom_content_core.Html.Of_dom
 
   module To_dom = Tyxml_cast.MakeTo(struct
       type 'a elt = 'a F.elt
@@ -440,7 +440,7 @@ module Html5 = struct
 
   module Id = struct
 
-    include Html5.Id
+    include Html.Id
 
     let get_element' id =
       let id = string_of_id id in
@@ -470,7 +470,7 @@ module Html5 = struct
 
     let raw_addEventListener ?(capture = false) node event handler =
       Dom_html.addEventListener node event
-        (Dom_html.full_handler (fun n e -> Js.bool (handler (Html5.F.tot (Xml.make_dom (n :> Dom.node Js.t))) e)))
+        (Dom_html.full_handler (fun n e -> Js.bool (handler (Html.F.tot (Xml.make_dom (n :> Dom.node Js.t))) e)))
         (Js.bool capture)
 
     let addEventListener ?capture target event handler =

--- a/src/lib/eliom_content_.server.ml
+++ b/src/lib/eliom_content_.server.ml
@@ -47,17 +47,17 @@ module Svg = struct
 
 end
 
-module Html5 = struct
+module Html = struct
 
   module F = struct
-    include Html5.F
+    include Html.F
     module Arg = struct
-      include Html5.F
+      include Html.F
       module Svg = Eliom_content_core.Svg.F
       let uri_of_fun = Eliom_content_core.Xml.uri_of_fun
       let attrib_of_service s info =
         Eliom_content_core.
-          (Html5.F.to_attrib
+          (Html.F.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
       let to_elt = toelt
@@ -67,14 +67,14 @@ module Html5 = struct
   end
 
   module D = struct
-    include Html5.D
+    include Html.D
     module Arg = struct
-      include Html5.D
+      include Html.D
       module Svg = Eliom_content_core.Svg.D
       let uri_of_fun = Eliom_content_core.Xml.uri_of_fun
       let attrib_of_service s info =
         Eliom_content_core.
-          (Html5.D.to_attrib
+          (Html.D.to_attrib
              (Xml.internal_event_handler_attrib
                 s (Xml.internal_event_handler_of_service info)))
       let to_elt = toelt
@@ -83,13 +83,13 @@ module Html5 = struct
     module Form = Eliom_form.Make(Arg)
   end
 
-  module R = Eliom_shared_content.Html5.R
+  module R = Eliom_shared_content.Html.R
 
-  module Custom_data = Eliom_content_core.Html5.Custom_data
+  module Custom_data = Eliom_content_core.Html.Custom_data
 
-  module Id = Html5.Id
+  module Id = Html.Id
 
-  module Printer = Html5.Printer
+  module Printer = Html.Printer
 
   type +'a elt = 'a F.elt
   type 'a wrap = 'a F.wrap

--- a/src/lib/eliom_content_core.client.ml
+++ b/src/lib/eliom_content_core.client.ml
@@ -44,7 +44,7 @@ module Xml = struct
     | ReactNode of elt React.signal
     | ReactChildren of econtent * elt ReactiveData.RList.t
   and elt = {
-    (* See Eliom_content.Html5.To_dom for the 'unwrap' function that convert
+    (* See Eliom_content.Html.To_dom for the 'unwrap' function that convert
        the server's tree representation into the client one. *)
     mutable elt : node lazy_t;
     node_id : node_id;
@@ -175,7 +175,7 @@ end
 
 module Xml_wed =
 struct
-  module W = Tyxml_js.Xml_wrap
+  module W = Tyxml_js.Wrap
   type 'a wrap = 'a W.t
   type 'a list_wrap = 'a W.tlist
   type uri = Xml.uri
@@ -188,7 +188,7 @@ struct
   type attrib = Xml.attrib
 
   let float_attrib name s : attrib =
-    name, Xml.RAReact (Tyxml_js.Xml_wrap.fmap (fun f -> Some (Xml.AFloat f)) s)
+    name, Xml.RAReact (Tyxml_js.Wrap.fmap (fun f -> Some (Xml.AFloat f)) s)
   let int_attrib name s =
     name, Xml.RAReact (React.S.map (fun f -> Some (Xml.AInt f)) s)
   let string_attrib name s =
@@ -299,7 +299,7 @@ module Svg = struct
 
 end
 
-module Html5 = struct
+module Html = struct
 
   module D = struct
     module Xml' = struct
@@ -320,7 +320,7 @@ module Html5 = struct
       let lazy_node ?(a = []) name children =
         make (Node (name, a, Eliom_lazy.force children))
     end
-    module Raw = Html5_f.Make(Xml')(Svg.D.Raw)
+    module Raw = Html_f.Make(Xml')(Svg.D.Raw)
 
     include Raw
 
@@ -340,7 +340,7 @@ module Html5 = struct
 
     let node s = Xml.make_react s
 
-    module Raw = Html5_f.Make(Xml_wed)(Svg.R)
+    module Raw = Html_f.Make(Xml_wed)(Svg.R)
     let filter_attrib (name,a) on =
       let v = match a with
         | Xml.RA a -> Xml.RAReact (React.S.map (function
@@ -365,7 +365,7 @@ module Html5 = struct
   module F = struct
 
     module Xml' = Xml
-    module Raw = Html5_f.Make(Xml')(Svg.F.Raw)
+    module Raw = Html_f.Make(Xml')(Svg.F.Raw)
     include Raw
 
     type ('a, 'b, 'c) lazy_star =

--- a/src/lib/eliom_content_core.client.mli
+++ b/src/lib/eliom_content_core.client.mli
@@ -22,7 +22,10 @@
 
 module Xml : sig
 
-  module W : Xml_wrap.T with type 'a t = 'a and type 'a tlist = 'a list
+  module W : Xml_wrap.T
+    with type 'a t = 'a
+     and type 'a tlist = 'a list
+     and type (-'a, 'b) ft = 'a -> 'b
 
   type uri = string
   val uri_of_string : uri -> string
@@ -160,7 +163,7 @@ end
 
 module Xml_wed : sig
 
-  include Xml_sigs.T with module W = Tyxml_js.Xml_wrap
+  include Xml_sigs.T with module W = Tyxml_js.Wrap
                       and type elt = Xml.elt
                       and type aname = Xml.aname
                       and type attrib = Xml.attrib
@@ -251,13 +254,13 @@ module Svg : sig
     (** The type of global SVG element identifier. *)
     type +'a id
 
-    (** See {!Eliom_content.Html5.Id.new_elt_id} *)
+    (** See {!Eliom_content.Html.Id.new_elt_id} *)
     val new_elt_id: ?global:bool -> unit -> 'a id
-    (** See {!Eliom_content.Html5.Id.create_named_elt} *)
+    (** See {!Eliom_content.Html.Id.create_named_elt} *)
     val create_named_elt: id:'a id -> 'a elt -> 'a elt
-    (** See {!Eliom_content.Html5.Id.create_global_elt} *)
+    (** See {!Eliom_content.Html.Id.create_global_elt} *)
     val create_global_elt: 'a elt -> 'a elt
-    (** See {!Eliom_content.Html5.Id.create_request_elt} *)
+    (** See {!Eliom_content.Html.Id.create_request_elt} *)
     val create_request_elt: ?reset:bool -> 'a elt -> 'a elt
 
     (**/**)
@@ -270,8 +273,8 @@ module Svg : sig
 
 end
 
-(** Building Html5 tree. *)
-module Html5 : sig
+(** Building Html tree. *)
+module Html : sig
 
   (** See the Eliom manual for more information on {% <<a_manual
       chapter="clientserver-html" fragment="unique"| dom semantics vs. functional
@@ -285,14 +288,14 @@ module Html5 : sig
   type uri = Xml.uri
 
   (** Typed interface for building valid HTML5 tree (functional semantics).
-      See {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
+      See {% <<a_api project="tyxml" | module type Html_sigs.T >> %}. *)
   module F : sig
 
-    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+    module Raw : Html_sigs.Make(Xml)(Svg.F.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
-    (** See {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
+    (** See {% <<a_api project="tyxml" | module type Html_sigs.T >> %}. *)
     include module type of Raw (*BB TODO Hide untyped [input]. *)
 
     (**/**)
@@ -300,16 +303,16 @@ module Html5 : sig
       ?a: (('a attrib) list) -> ('b elt) list Eliom_lazy.request -> 'c elt
 
     val lazy_form:
-      ([< Html5_types.form_attrib ], [< Html5_types.form_content_fun ], [> Html5_types.form ]) lazy_star
+      ([< Html_types.form_attrib ], [< Html_types.form_content_fun ], [> Html_types.form ]) lazy_star
 
   end
 
 
   (** Typed interface for building valid HTML5 tree (DOM semantics). See
-      {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
+      {% <<a_api project="tyxml" | module type Html_sigs.T >> %}. *)
   module D: sig
 
-    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+    module Raw : Html_sigs.Make(Xml)(Svg.D.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -320,7 +323,7 @@ module Html5 : sig
       ?a: (('a attrib) list) -> ('b elt) list Eliom_lazy.request -> 'c elt
 
     val lazy_form:
-      ([< Html5_types.form_attrib ], [< Html5_types.form_content_fun ], [> Html5_types.form ]) lazy_star
+      ([< Html_types.form_attrib ], [< Html_types.form_content_fun ], [> Html_types.form ]) lazy_star
 
   end
 
@@ -329,7 +332,7 @@ module Html5 : sig
       HTML5's trees are automatically updated whenever
       corresponding signals change.
 
-      {% <<a_api project="tyxml" | module type Html5_sigs.T >> %}. *)
+      {% <<a_api project="tyxml" | module type Html_sigs.T >> %}. *)
 
   module R: sig
 
@@ -339,7 +342,7 @@ module Html5 : sig
 
     val filter_attrib : 'a attrib -> bool React.signal -> 'a attrib
 
-    module Raw : Html5_sigs.Make(Xml_wed)(Svg.R.Raw).T
+    module Raw : Html_sigs.Make(Xml_wed)(Svg.R.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -384,7 +387,7 @@ module Html5 : sig
 
     (** Create a custom data field by providing string conversion functions.
         If the [default] is provided, calls to {% <<a_api project="eliom" subproject="client" |
-        val Eliom_content.Html5.Custom_data.get_dom>> %} return that instead of throwing an
+        val Eliom_content.Html.Custom_data.get_dom>> %} return that instead of throwing an
         exception [Not_found].  *)
     val create : name:string -> ?default:'a -> to_string:('a -> string) -> of_string:(string -> 'a) -> unit -> 'a t
 
@@ -393,7 +396,7 @@ module Html5 : sig
 
     (** [attrib my_data value ] creates a HTML5 attribute for the custom-data
         type [my_data] with value [value] for injecting it into an a HTML5 tree
-        ({% <<a_api | type Eliom_content.Html5.elt >> %}). *)
+        ({% <<a_api | type Eliom_content.Html.elt >> %}). *)
     val attrib : 'a t -> 'a -> [> | `User_data ] attrib
 
     (** [get_dom element custom_data] gets the [custom_data] from a JavaScript [element]

--- a/src/lib/eliom_content_core.server.ml
+++ b/src/lib/eliom_content_core.server.ml
@@ -290,8 +290,7 @@ module Svg = struct
   module Make
       (Xml : Xml_sigs.T with type elt = Xml.elt
                          and type attrib = Xml.attrib)
-      (C : Svg_sigs.Wrapped_functions
-       with type ('a, 'b) ft = ('a, 'b) Xml.W.ft) =
+      (C : Svg_sigs.Wrapped_functions with module Xml = Xml) =
     Svg_f.Make_with_wrapped_functions(Xml)(C)
 
   type +'a elt = 'a F.elt
@@ -316,7 +315,7 @@ module Svg = struct
 
 end
 
-module Html5 = struct
+module Html = struct
 
   module D = struct
 
@@ -342,7 +341,7 @@ module Html5 = struct
 
     end
 
-    module Raw = Html5_f.Make(Xml')(Svg.D.Raw)
+    module Raw = Html_f.Make(Xml')(Svg.D.Raw)
     let client_attrib ?init (x : 'a Raw.attrib Eliom_client_value.t) =
       Xml.client_attrib ?init x
 
@@ -360,7 +359,7 @@ module Html5 = struct
   module F = struct
 
     module Xml' = Xml
-    module Raw = Html5_f.Make(Xml')(Svg.F.Raw)
+    module Raw = Html_f.Make(Xml')(Svg.F.Raw)
     include Raw
 
     type ('a, 'b, 'c) lazy_star =
@@ -377,10 +376,9 @@ module Html5 = struct
       (Xml : Xml_sigs.T
        with type elt = Xml.elt
         and type attrib = Xml.attrib)
-      (C : Html5_sigs.Wrapped_functions
-       with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
+      (C : Html_sigs.Wrapped_functions with module Xml = Xml)
       (Svg : Svg_sigs.T with module Xml := Xml) =
-    Html5_f.Make_with_wrapped_functions(Xml)(C)(Svg)
+    Html_f.Make_with_wrapped_functions(Xml)(C)(Svg)
 
   type +'a elt = 'a F.elt
   type 'a wrap = 'a

--- a/src/lib/eliom_content_core.server.mli
+++ b/src/lib/eliom_content_core.server.mli
@@ -123,8 +123,7 @@ module Svg : sig
       (Xml : Xml_sigs.T
        with type elt = Xml.elt
         and type attrib = Xml.attrib)
-      (C : Svg_sigs.Wrapped_functions
-       with type ('a, 'b) ft = ('a, 'b) Xml.W.ft) :
+      (C : Svg_sigs.Wrapped_functions with module Xml = Xml) :
     Svg_sigs.Make(Xml).T
     with type +'a elt = 'a elt
      and type +'a attrib = 'a attrib
@@ -148,7 +147,7 @@ module Svg : sig
 
 end
 
-module Html5 : sig
+module Html : sig
 
   (** See the Eliom manual for more information on {% <<a_manual
       chapter="clientserver-html" fragment="unique"| dom semantics vs. functional
@@ -163,7 +162,7 @@ module Html5 : sig
 
   module F : sig
 
-    module Raw : Html5_sigs.Make(Xml)(Svg.F.Raw).T
+    module Raw : Html_sigs.Make(Xml)(Svg.F.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -174,12 +173,12 @@ module Html5 : sig
       ?a: (('a attrib) list) -> ('b elt) list Eliom_lazy.request -> 'c elt
 
     val lazy_form:
-      ([< Html5_types.form_attrib ], [< Html5_types.form_content_fun ], [> Html5_types.form ]) lazy_star
+      ([< Html_types.form_attrib ], [< Html_types.form_content_fun ], [> Html_types.form ]) lazy_star
   end
 
   module D : sig
 
-    module Raw : Html5_sigs.Make(Xml)(Svg.D.Raw).T
+    module Raw : Html_sigs.Make(Xml)(Svg.D.Raw).T
       with type +'a elt = 'a elt
        and type +'a attrib = 'a attrib
 
@@ -193,7 +192,7 @@ module Html5 : sig
       ?a: (('a attrib) list) -> ('b elt) list Eliom_lazy.request -> 'c elt
 
     val lazy_form:
-      ([< Html5_types.form_attrib ], [< Html5_types.form_content_fun ], [> Html5_types.form ]) lazy_star
+      ([< Html_types.form_attrib ], [< Html_types.form_content_fun ], [> Html_types.form ]) lazy_star
 
   end
 
@@ -201,10 +200,9 @@ module Html5 : sig
       (Xml : Xml_sigs.T
        with type elt = Xml.elt
         and type attrib = Xml.attrib)
-      (C : Html5_sigs.Wrapped_functions
-       with type ('a, 'b) ft = ('a, 'b) Xml.W.ft)
+      (C : Html_sigs.Wrapped_functions with module Xml = Xml)
       (Svg : Svg_sigs.T with module Xml := Xml) :
-    Html5_sigs.Make(Xml)(Svg).T
+    Html_sigs.Make(Xml)(Svg).T
     with type +'a elt = 'a elt
      and type +'a attrib = 'a attrib
 

--- a/src/lib/eliom_content_sigs.shared.mli
+++ b/src/lib/eliom_content_sigs.shared.mli
@@ -31,9 +31,9 @@ module type LINKS_AND_FORMS = sig
     'c elt
 
   val lazy_form:
-    ([< Html5_types.form_attrib ],
-     [< Html5_types.form_content_fun ],
-     [> Html5_types.form ]) lazy_star
+    ([< Html_types.form_attrib ],
+     [< Html_types.form_content_fun ],
+     [> Html_types.form ]) lazy_star
 
   include Eliom_form_sigs.LINKS
     with type +'a elt := 'a elt

--- a/src/lib/eliom_cscache.eliom
+++ b/src/lib/eliom_cscache.eliom
@@ -2,8 +2,8 @@
 
 {shared{
 open Eliom_lib
-open Eliom_content.Html5
-open Eliom_content.Html5.F
+open Eliom_content.Html
+open Eliom_content.Html.F
 }}
 
 {shared{

--- a/src/lib/eliom_error_pages.server.ml
+++ b/src/lib/eliom_error_pages.server.ml
@@ -18,7 +18,7 @@
 
 open Eliom_lib
 open Eliom_content_core
-open Html5.F
+open Html.F
 
 let page_error_param_type l =
   let s = match l with

--- a/src/lib/eliom_form.eliomi
+++ b/src/lib/eliom_form.eliomi
@@ -24,9 +24,9 @@ val set_error_handler : (unit -> unit Lwt.t) -> unit
 
 {shared{
 
-module type Html5 = sig
+module type Html = sig
 
-  include Html5_sigs.T
+  include Html_sigs.T
     with type 'a Xml.W.t = 'a
      and type 'a Xml.W.tlist = 'a list
      and type Xml.mouse_event_handler =
@@ -38,9 +38,9 @@ module type Html5 = sig
     'c elt
 
   val lazy_form :
-    ([< Html5_types.form_attrib ],
-     [< Html5_types.form_content_fun ],
-     [> Html5_types.form ]) lazy_star
+    ([< Html_types.form_attrib ],
+     [< Html_types.form_content_fun ],
+     [> Html_types.form ]) lazy_star
 
   val uri_of_fun : (unit -> string) -> Xml.uri
 
@@ -51,7 +51,7 @@ module type Html5 = sig
      * string option
      * Eliom_lib.poly
     ) option Eliom_lazy.request ->
-    Html5_types.form_attrib attrib
+    Html_types.form_attrib attrib
 
   val to_elt : 'a elt -> Eliom_content_core.Xml.elt
 
@@ -59,13 +59,13 @@ end
 
 type 'a param
 
-module Make_links (H : Html5) :
+module Make_links (H : Html) :
   Eliom_form_sigs.LINKS
   with type +'a elt := 'a H.elt
    and type +'a attrib := 'a H.attrib
    and type uri := H.uri
 
-module Make (H : Html5) :
+module Make (H : Html) :
   Eliom_form_sigs.S
   with type +'a elt := 'a H.elt
    and type +'a attrib := 'a H.attrib

--- a/src/lib/eliom_form_sigs.shared.mli
+++ b/src/lib/eliom_form_sigs.shared.mli
@@ -114,7 +114,7 @@ module type LINKS = sig
   (** The function [uri_of_string f] returns a URI whose content is
       equivalent to [f ()].
 
-      For XML tree build with TyXML, like {!Html5} or {!Svg.F}, the
+      For XML tree build with TyXML, like {!Html} or {!Svg.F}, the
       function [f] is applied each time the XML tree is sent to the
       client (either as page content or as a marshalled OCaml
       value). Hence, the function is always evaluated in the context
@@ -135,8 +135,8 @@ module type LINKS = sig
       The optional parameter [~a] allows one to add extra HTML
       attributes to the generated node.  *)
   val css_link :
-    ?a:[< Html5_types.link_attrib] attrib list ->
-    uri:uri -> unit -> [> Html5_types.link] elt
+    ?a:[< Html_types.link_attrib] attrib list ->
+    uri:uri -> unit -> [> Html_types.link] elt
 
   (** The function [js_script ~uri ()] creates a [<script>] node that
       reference a javascript file.
@@ -150,8 +150,8 @@ module type LINKS = sig
       The optional parameter [~a] allows one to add extra HTML
       attributes to the generated node.  *)
   val js_script :
-    ?a:[< Html5_types.script_attrib] attrib list -> uri:uri -> unit ->
-    [> Html5_types.script] elt
+    ?a:[< Html_types.script_attrib] attrib list -> uri:uri -> unit ->
+    [> Html_types.script] elt
 
   (** The function [a service a_content get_params] creates a [<a>]
       node that link to [service] applied to GET parameters
@@ -185,7 +185,7 @@ module type LINKS = sig
     ?absolute:bool ->
     ?absolute_path:bool ->
     ?https:bool ->
-    ?a:[< Html5_types.a_attrib] attrib list ->
+    ?a:[< Html_types.a_attrib] attrib list ->
     service:
       ('get, unit, Eliom_service.get, _, _, _, _,
        _, _, unit, Eliom_service.non_ocaml) Eliom_service.t ->
@@ -197,7 +197,7 @@ module type LINKS = sig
     ?xhr:bool ->
     'a elt list ->
     'get ->
-    [> 'a Html5_types.a] elt
+    [> 'a Html_types.a] elt
 
 end
 
@@ -275,7 +275,7 @@ module type S = sig
     ?absolute:bool ->
     ?absolute_path:bool ->
     ?https:bool ->
-    ?a:[< Html5_types.form_attrib] attrib list ->
+    ?a:[< Html_types.form_attrib] attrib list ->
     service:
       (_, unit, Eliom_service.get, _, _, _, _, _,
        'gn, _, Eliom_service.non_ocaml) Eliom_service.t ->
@@ -285,8 +285,8 @@ module type S = sig
     ?keep_nl_params:[ `All | `Persistent | `None ] ->
     ?nl_params: Eliom_parameter.nl_params_set ->
     ?xhr:bool ->
-    ('gn -> [< Html5_types.form_content] elt list) ->
-    [> Html5_types.form ] elt
+    ('gn -> [< Html_types.form_content] elt list) ->
+    [> Html_types.form ] elt
 
   (** Same as {!get_form} but taking a cooperative function for
       [<form>] content generation. *)
@@ -294,7 +294,7 @@ module type S = sig
     ?absolute:bool ->
     ?absolute_path:bool ->
     ?https:bool ->
-    ?a:[< Html5_types.form_attrib] attrib list ->
+    ?a:[< Html_types.form_attrib] attrib list ->
     service:
       (_, unit, Eliom_service.get, _, _, _, _, _,
        'gn, _, Eliom_service.non_ocaml) Eliom_service.t ->
@@ -304,8 +304,8 @@ module type S = sig
     ?keep_nl_params:[ `All | `Persistent | `None ] ->
     ?nl_params: Eliom_parameter.nl_params_set ->
     ?xhr:bool ->
-    ('gn -> [< Html5_types.form_content] elt list Lwt.t) ->
-    [> Html5_types.form ] elt Lwt.t
+    ('gn -> [< Html_types.form_content] elt list Lwt.t) ->
+    [> Html_types.form ] elt Lwt.t
 
   (** The function [post_form service formgen get_params] creates a
       POST [<form>] to [service] preapplied to the GET parameters
@@ -324,7 +324,7 @@ module type S = sig
     ?absolute:bool ->
     ?absolute_path:bool ->
     ?https:bool ->
-    ?a:[< Html5_types.form_attrib] attrib list ->
+    ?a:[< Html_types.form_attrib] attrib list ->
     service:
       ('get, _, Eliom_service.post, _, _, _, _, _,
        _, 'pn, Eliom_service.non_ocaml) Eliom_service.t ->
@@ -335,9 +335,9 @@ module type S = sig
     ?keep_get_na_params:bool ->
     ?nl_params: Eliom_parameter.nl_params_set ->
     ?xhr:bool ->
-    ('pn -> [< Html5_types.form_content] elt list) ->
+    ('pn -> [< Html_types.form_content] elt list) ->
     'get ->
-    [> Html5_types.form ] elt
+    [> Html_types.form ] elt
 
   (** Same as {!post_form} but taking a cooperative function for
       [<form>] content generation. *)
@@ -345,7 +345,7 @@ module type S = sig
     ?absolute:bool ->
     ?absolute_path:bool ->
     ?https:bool ->
-    ?a:[< Html5_types.form_attrib] attrib list ->
+    ?a:[< Html_types.form_attrib] attrib list ->
     service:
       ('get, _, Eliom_service.post, _, _, _, _, _,
        _, 'pn, Eliom_service.non_ocaml) Eliom_service.t ->
@@ -356,105 +356,105 @@ module type S = sig
     ?keep_get_na_params:bool ->
     ?nl_params: Eliom_parameter.nl_params_set ->
     ?xhr:bool ->
-    ('pn -> [< Html5_types.form_content] elt list Lwt.t) ->
+    ('pn -> [< Html_types.form_content] elt list Lwt.t) ->
     'get ->
-    [> Html5_types.form ] elt Lwt.t
+    [> Html_types.form ] elt Lwt.t
 
   (** Creates an [<input>] tag. *)
   val input :
-    ?a:[< Html5_types.input_attrib] attrib list ->
-    input_type:[< Html5_types.input_type] ->
+    ?a:[< Html_types.input_attrib] attrib list ->
+    input_type:[< Html_types.input_type] ->
     ?name:[< 'a setoneradio] param_name ->
     ?value:'a ->
     'a param ->
-    [> Html5_types.input] elt
+    [> Html_types.input] elt
 
   (** Creates an [<input>] tag for sending a file *)
   val file_input :
-    ?a:[< Html5_types.input_attrib] attrib list ->
+    ?a:[< Html_types.input_attrib] attrib list ->
     name:[< file_info setoneradio ] param_name ->
     unit ->
-    [> Html5_types.input] elt
+    [> Html_types.input] elt
 
   (** Creates an [<input type="image" name="...">] tag. The server
       receives the coordinates that the user clicked on. *)
   val image_input :
-    ?a:[< Html5_types.input_attrib] attrib list ->
+    ?a:[< Html_types.input_attrib] attrib list ->
     name:[< coordinates oneradio ] param_name ->
     ?src:uri ->
     unit ->
-    [> Html5_types.input] elt
+    [> Html_types.input] elt
 
   (** Creates a checkbox [<input>] tag. You can produce several
       checkboxes with the same name (and different values). The
       service must declare a parameter of type [set]. *)
   val checkbox :
-    ?a:[< Html5_types.input_attrib] attrib list -> ?checked:bool ->
+    ?a:[< Html_types.input_attrib] attrib list -> ?checked:bool ->
     name:[ `Set of 'a ] Eliom_parameter.param_name -> value:'a ->
     'a param ->
-    [> Html5_types.input] elt
+    [> Html_types.input] elt
 
   (** Creates a checkbox [<input>] tag of type bool. Only one checkbox
       with the same [name] is allowed. *)
   val bool_checkbox_one :
-    ?a:[< Html5_types.input_attrib] attrib list -> ?checked:bool ->
+    ?a:[< Html_types.input_attrib] attrib list -> ?checked:bool ->
     name:[ `One of bool ] Eliom_parameter.param_name ->
     unit ->
-    [> Html5_types.input] elt
+    [> Html_types.input] elt
 
   (** Creates a radio [<input>] tag. *)
   val radio :
-    ?a:[< Html5_types.input_attrib] attrib list -> ?checked:bool ->
+    ?a:[< Html_types.input_attrib] attrib list -> ?checked:bool ->
     name:[ `Radio of 'a ] param_name ->
     value:'a ->
     'a param ->
-    [> Html5_types.input] elt
+    [> Html_types.input] elt
 
   val string_radio_required :
-    ?a:[< Html5_types.input_attrib] attrib list -> ?checked:bool ->
+    ?a:[< Html_types.input_attrib] attrib list -> ?checked:bool ->
     name:[ `One of string ] param_name ->
     value:string -> unit ->
-    [> Html5_types.input] elt
+    [> Html_types.input] elt
 
   (** Creates a [<button>] tag. *)
   val button :
-    ?a:[< Html5_types.button_attrib] attrib list ->
+    ?a:[< Html_types.button_attrib] attrib list ->
     button_type:[< button_type] ->
     name:[< 'a setone ] param_name ->
     value:'a ->
     'a param ->
-    Html5_types.button_content elt list ->
-    [> Html5_types.button] elt
+    Html_types.button_content elt list ->
+    [> Html_types.button] elt
 
   (** Creates a [<button>] tag with no value. No value is sent. *)
   val button_no_value :
-    ?a:[< Html5_types.button_attrib] attrib list ->
+    ?a:[< Html_types.button_attrib] attrib list ->
     button_type:[< button_type] ->
-    Html5_types.button_content elt list ->
-    [> Html5_types.button] elt
+    Html_types.button_content elt list ->
+    [> Html_types.button] elt
 
   (** Creates a [<textarea>] tag *)
   val textarea :
-    ?a:[< Html5_types.textarea_attrib] attrib list ->
+    ?a:[< Html_types.textarea_attrib] attrib list ->
     name:[< string setoneradio ] param_name -> ?value:string ->
-    unit -> [> Html5_types.textarea] elt
+    unit -> [> Html_types.textarea] elt
 
   type 'a soption =
-    Html5_types.option_attrib attrib list
+    Html_types.option_attrib attrib list
     * 'a (* Content (or value if the following is present) *)
-    * Html5_types.pcdata elt option (* if content different from value *)
+    * Html_types.pcdata elt option (* if content different from value *)
     * bool (* selected *)
 
   (** The type for [<select>] options and groups of options.
 
       - The field of type 'a in [soption] is the value that will be
         sent by the form.
-      - If the [Html5_types.pcdata elt option] is not present it is
+      - If the [Html_types.pcdata elt option] is not present it is
         also the value displayed.
       - The string in [select_opt] is the label *)
   type 'a select_opt =
     | Optgroup of
-        [ Html5_types.common | `Disabled ] attrib list
+        [ Html_types.common | `Disabled ] attrib list
         * string (* label *)
         * 'a soption
         * 'a soption list
@@ -462,22 +462,22 @@ module type S = sig
 
   (** Creates a [<select>] tag. *)
   val select :
-    ?a:[< Html5_types.select_attrib] attrib list ->
-    ?required:Html5_types.pcdata elt ->
+    ?a:[< Html_types.select_attrib] attrib list ->
+    ?required:Html_types.pcdata elt ->
     name:[ `One of 'a ] param_name ->
     'a param ->
     'a select_opt ->
     'a select_opt list ->
-    [> Html5_types.select] elt
+    [> Html_types.select] elt
 
   (** Creates a multiple-selection [<select>] tag. *)
   val multiple_select :
-    ?a:[< Html5_types.select_attrib] attrib list ->
-    ?required:Html5_types.pcdata elt ->
+    ?a:[< Html_types.select_attrib] attrib list ->
+    ?required:Html_types.pcdata elt ->
     name:[ `Set of 'a ] param_name ->
     'a param ->
     'a select_opt ->
     'a select_opt list ->
-    [> Html5_types.select] elt
+    [> Html_types.select] elt
 
 end

--- a/src/lib/eliom_parameter_sigs.shared.mli
+++ b/src/lib/eliom_parameter_sigs.shared.mli
@@ -44,9 +44,9 @@ module type S = sig
       - [ 'c] is the type of the parameter name, usually an instance
         of {!Eliom_parameter.param_name}, as used by forms
         construction functions (e.g., the last parameter of
-        {!Eliom_content.Html5.D.get_form}), and specialized form
+        {!Eliom_content.Html.D.get_form}), and specialized form
         widget (see for example the section
-        {{!section:Eliom_content.Html5.D.form_widgets}Form widget} of
+        {{!section:Eliom_content.Html.D.form_widgets}Form widget} of
         {!Eliom_content.HTML5.D}). ) *)
   type ('a, +'b, 'c) params_type constraint 'b = [< suff]
 

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -6,7 +6,7 @@ module Base = struct
   type return = Eliom_service.non_ocaml
 end
 
-module Html5 = Base
+module Html = Base
 module Block5 = Base
 module Html_text = Base
 module CssText = Base

--- a/src/lib/eliom_registration.client.mli
+++ b/src/lib/eliom_registration.client.mli
@@ -4,7 +4,7 @@ module type Base = sig
   type return = Eliom_service.non_ocaml
 end
 
-module Html5 : Base
+module Html : Base
 module Block5 : Base
 module Html_text : Base
 module CssText : Base

--- a/src/lib/eliom_registration.server.ml
+++ b/src/lib/eliom_registration.server.ml
@@ -58,13 +58,13 @@ let cast_unknown_content_kind (x:unknown_content kind) : 'a kind =
   Result_types.cast_result (Result_types.cast_kind x)
 let cast_http_result = Result_types.cast_result
 
-module Html5_make_reg_base
-  (Html5_content : Ocsigen_http_frame.HTTP_CONTENT
-   with type t = Html5_types.html Eliom_content.Html5.elt
+module Html_make_reg_base
+  (Html_content : Ocsigen_http_frame.HTTP_CONTENT
+   with type t = Html_types.html Eliom_content.Html.elt
     and type options = Http_headers.accept Lazy.t)
   = struct
 
-  type page = Html5_types.html Eliom_content.Html5.elt
+  type page = Html_types.html Eliom_content.Html.elt
   type options = unit
   type result = browser_content kind
 
@@ -77,7 +77,7 @@ module Html5_make_reg_base
       ?content_type ?headers content =
     let accept =
       (Ocsigen_extensions.Ocsigen_request_info.accept (Eliom_request_info.get_ri ())) in
-    lwt r = Html5_content.result_of_content ~options:accept content in
+    lwt r = Html_content.result_of_content ~options:accept content in
     Lwt.return
       (Ocsigen_http_frame.Result.update r
          ~code:(code_of_code_option code)
@@ -95,12 +95,12 @@ module Html5_make_reg_base
 
 end
 
-module Html5 =
+module Html =
   Eliom_mkreg.Make
-    (Html5_make_reg_base
+    (Html_make_reg_base
        (Ocsigen_senders.Make_XML_Content
           (Eliom_content.Xml)
-          (Eliom_content.Html5.D)))
+          (Eliom_content.Html.D)))
 
 module Make_typed_xml_registration
   (Xml: Xml_sigs.Iterable)
@@ -168,9 +168,9 @@ module Make_typed_xml_registration
 module Flow5 =
   Make_typed_xml_registration
     (Eliom_content.Xml)
-    (Eliom_content.Html5.D)
+    (Eliom_content.Html.D)
     (struct
-      type content = Html5_types.flow5
+      type content = Html_types.flow5
     end)
 
 let (<-<) h (n, v) = Http_headers.replace n v h
@@ -1011,15 +1011,15 @@ let global_data_unwrapper =
     (Eliom_wrap.id_of_int Eliom_runtime.global_data_unwrap_id_int)
 
 module Eliom_appl_reg_make_param
-  (Html5_content
+  (Html_content
      : Ocsigen_http_frame.HTTP_CONTENT
-       with type t = [ `Html ] Eliom_content.Html5.elt
+       with type t = [ `Html ] Eliom_content.Html.elt
        and type options = Http_headers.accept Lazy.t)
   (Appl_params : APPL_PARAMS) = struct
 
   type app_id
 
-  type page = Html5_types.html Eliom_content.Html5.elt
+  type page = Html_types.html Eliom_content.Html.elt
   type options = appl_service_options
   type result = app_id application_content kind
 
@@ -1029,30 +1029,30 @@ module Eliom_appl_reg_make_param
     let sp = Eliom_common.get_sp () in
     sp.Eliom_common.sp_client_appl_name <> Some Appl_params.application_name
 
-  let eliom_appl_script_id : [ `Script ] Eliom_content.Html5.Id.id =
-    Eliom_content.Html5.Id.new_elt_id ~global:true ()
+  let eliom_appl_script_id : [ `Script ] Eliom_content.Html.Id.id =
+    Eliom_content.Html.Id.new_elt_id ~global:true ()
   let application_script ?(defer = false) ?(async = false) () =
     let a =
-      (if defer then [Eliom_content.Html5.D.a_defer `Defer] else [])
+      (if defer then [Eliom_content.Html.D.a_defer ()] else [])
         @
-      (if async then [Eliom_content.Html5.D.a_async `Async] else [])
+      (if async then [Eliom_content.Html.D.a_async ()] else [])
     in
-    Eliom_content.Html5.Id.create_named_elt
+    Eliom_content.Html.Id.create_named_elt
       ~id:eliom_appl_script_id
-      (Eliom_content.Html5.D.js_script ~a
-         ~uri:(Eliom_content.Html5.D.make_uri
+      (Eliom_content.Html.D.js_script ~a
+         ~uri:(Eliom_content.Html.D.make_uri
                  ~service:(Eliom_service.static_dir ())
                  [Appl_params.application_name ^ ".js"])
          ())
   let application_script =
     (application_script
-     : ?defer:_ -> ?async:_ -> _ -> [ `Script ] Eliom_content.Html5.elt
-     :> ?defer:_ -> ?async:_ -> _ -> [> `Script ] Eliom_content.Html5.elt)
+     : ?defer:_ -> ?async:_ -> _ -> [ `Script ] Eliom_content.Html.elt
+     :> ?defer:_ -> ?async:_ -> _ -> [> `Script ] Eliom_content.Html.elt)
   let is_eliom_appl_script elt =
-    Eliom_content.Html5.Id.have_id eliom_appl_script_id elt
+    Eliom_content.Html.Id.have_id eliom_appl_script_id elt
 
   let eliom_appl_data_script_id =
-    Eliom_content.Html5.Id.new_elt_id ~global:true ()
+    Eliom_content.Html.Id.new_elt_id ~global:true ()
 
   let make_eliom_appl_data_script ~sp =
 
@@ -1068,7 +1068,7 @@ module Eliom_appl_reg_make_param
     in
 
     Lwt.return
-      Eliom_content.Html5.(
+      Eliom_content.Html.(
         Id.create_named_elt ~id:eliom_appl_data_script_id
           (F.script (F.cdata_script script)))
 
@@ -1123,11 +1123,11 @@ module Eliom_appl_reg_make_param
        create cookies that needs to be sent along the page. Hence,
        cookies should be calculated after wrapping. *)
     let eliom_data =
-      Eliom_content.Xml.wrap (Eliom_content.Html5.D.toelt page) { Eliom_common.
+      Eliom_content.Xml.wrap (Eliom_content.Html.D.toelt page) { Eliom_common.
         ejs_global_data;
         ejs_request_data;
-        ejs_event_handler_table = Eliom_content.Xml.make_event_handler_table (Eliom_content.Html5.D.toelt page);
-        ejs_client_attrib_table = Eliom_content.Xml.make_client_attrib_table (Eliom_content.Html5.D.toelt page);
+        ejs_event_handler_table = Eliom_content.Xml.make_event_handler_table (Eliom_content.Html.D.toelt page);
+        ejs_client_attrib_table = Eliom_content.Xml.make_client_attrib_table (Eliom_content.Html.D.toelt page);
         ejs_sess_info           = Eliommod_cli.client_si sp.Eliom_common.sp_si;
       } in
 
@@ -1149,23 +1149,23 @@ module Eliom_appl_reg_make_param
         (Eliom_lib.jsmarshal tab_cookies)
         (Eliom_lib.jsmarshal (template: string option))
     in
-    Lwt.return Eliom_content.Html5.(F.script (F.cdata_script script))
+    Lwt.return Eliom_content.Html.(F.script (F.cdata_script script))
 
   let split_page page :
-      (Html5_types.html_attrib Eliom_content.Html5.attrib list
-        * (Html5_types.head_attrib Eliom_content.Html5.attrib list
-            * [ Html5_types.title ] Eliom_content.Html5.elt
-            * Html5_types.head_content_fun Eliom_content.Html5.elt list)
-        * Html5_types.body Eliom_content.Html5.elt ) =
+      (Html_types.html_attrib Eliom_content.Html.attrib list
+        * (Html_types.head_attrib Eliom_content.Html.attrib list
+            * [ Html_types.title ] Eliom_content.Html.elt
+            * Html_types.head_content_fun Eliom_content.Html.elt list)
+        * Html_types.body Eliom_content.Html.elt ) =
     match Eliom_content.Xml.content page with
       | Eliom_content.Xml.Node (_, html_attribs, [head; body]) ->
         begin match Eliom_content.Xml.content head with
           | Eliom_content.Xml.Node (_, head_attribs, head_elts) ->
-            ( List.map Eliom_content.Html5.D.to_attrib html_attribs,
-              ( List.map Eliom_content.Html5.D.to_attrib head_attribs,
-                Eliom_content.Html5.D.tot (List.hd head_elts),
-                Eliom_content.Html5.D.totl (List.tl head_elts) ),
-              Eliom_content.Html5.D.tot body )
+            ( List.map Eliom_content.Html.D.to_attrib html_attribs,
+              ( List.map Eliom_content.Html.D.to_attrib head_attribs,
+                Eliom_content.Html.D.tot (List.hd head_elts),
+                Eliom_content.Html.D.totl (List.tl head_elts) ),
+              Eliom_content.Html.D.tot body )
           | _ -> assert false
         end
       | _ -> assert false
@@ -1176,7 +1176,7 @@ module Eliom_appl_reg_make_param
 
     (* First we build a fake page to build the ref_tree... *)
     let (html_attribs, (head_attribs, title, head_elts), body) =
-      split_page (Eliom_content.Html5.D.toelt page) in
+      split_page (Eliom_content.Html.D.toelt page) in
     let encode_slashs = List.map (Eliom_lib.Url.encode ~plus:false) in
     let base_url =
       Eliom_uri.make_proto_prefix
@@ -1202,7 +1202,7 @@ module Eliom_appl_reg_make_param
       *)
       :: if Eliom_request_info.expecting_process_page ()
       then
-        Eliom_content.Html5.(
+        Eliom_content.Html.(
           F.base
             ~a:[F.a_id Eliom_common_base.base_elt_id;
                 F.a_href (Eliom_content.Xml.uri_of_string base_url)]
@@ -1211,8 +1211,8 @@ module Eliom_appl_reg_make_param
       else head_elts
     in
     let fake_page =
-      Eliom_content.Html5.F.html ~a:html_attribs
-        (Eliom_content.Html5.F.head ~a:head_attribs title head_elts)
+      Eliom_content.Html.F.html ~a:html_attribs
+        (Eliom_content.Html.F.head ~a:head_attribs title head_elts)
         body
     in
     lwt data_script = make_eliom_data_script
@@ -1224,17 +1224,17 @@ module Eliom_appl_reg_make_param
     let head_elts =
       List.hd head_elts :: data_script :: (List.tl head_elts) in
     Lwt.return
-      (Eliom_content.Html5.F.html ~a:html_attribs
-         (Eliom_content.Html5.F.head ~a:head_attribs title head_elts)
+      (Eliom_content.Html.F.html ~a:html_attribs
+         (Eliom_content.Html.F.head ~a:head_attribs title head_elts)
          body )
 
   let remove_eliom_scripts page =
     let (html_attribs, (head_attribs, title, head_elts), body) =
-      split_page (Eliom_content.Html5.D.toelt page) in
+      split_page (Eliom_content.Html.D.toelt page) in
     let head_elts = List.filter (fun x -> not (is_eliom_appl_script x)) head_elts in
     Lwt.return
-      (Eliom_content.Html5.F.html ~a:html_attribs
-         (Eliom_content.Html5.F.head ~a:head_attribs title head_elts)
+      (Eliom_content.Html.F.html ~a:html_attribs
+         (Eliom_content.Html.F.head ~a:head_attribs title head_elts)
          body )
 
   let send_appl_content = Eliom_service.XSame_appl (Appl_params.application_name, None)
@@ -1261,7 +1261,7 @@ module Eliom_appl_reg_make_param
 
     let ri = Eliom_request_info.get_ri () in
     let accept = Ocsigen_extensions.Ocsigen_request_info.accept ri in
-    lwt r = Html5_content.result_of_content ~options:accept page in
+    lwt r = Html_content.result_of_content ~options:accept page in
 
     let headers =
       match headers with
@@ -1313,11 +1313,11 @@ module type ELIOM_APPL = sig
     ('a -> 'b -> unit Lwt.t) Eliom_client_value.t ->
     unit
   val application_script :
-    ?defer:bool -> ?async:bool -> unit -> [> `Script ] Eliom_content.Html5.elt
+    ?defer:bool -> ?async:bool -> unit -> [> `Script ] Eliom_content.Html.elt
   val application_name : string
   val is_initial_request : unit -> bool
   type app_id
-  type page = Html5_types.html Eliom_content.Html5.elt
+  type page = Html_types.html Eliom_content.Html.elt
   type options = appl_service_options
   type return = Eliom_service.non_ocaml
   type result = app_id application_content kind
@@ -1335,7 +1335,7 @@ module App (Appl_params : APPL_PARAMS) : ELIOM_APPL = struct
     Eliom_appl_reg_make_param
       (Ocsigen_senders.Make_XML_Content
          (Eliom_content.Xml)
-         (Eliom_content.Html5.D))
+         (Eliom_content.Html.D))
       (Appl_params)
 
   type app_id = P.app_id
@@ -1377,7 +1377,7 @@ end
 module type TMPL_PARAMS = sig
   type t
   val name: string
-  val make_page: t -> Html5_types.html Eliom_content.Html5.elt Lwt.t
+  val make_page: t -> Html_types.html Eliom_content.Html.elt Lwt.t
   val update: t -> unit Eliom_client_value.t
 end
 

--- a/src/lib/eliom_registration.server.mli
+++ b/src/lib/eliom_registration.server.mli
@@ -19,7 +19,7 @@
  *)
 
 (** Eliom services registration for various kinds of page content:
-    Eliom application, valid {!Html5}, actions, redirections, static
+    Eliom application, valid {!Html}, actions, redirections, static
     files, … *)
 
 (** {b Please read the Eliom manual before this page to learn how to
@@ -49,7 +49,7 @@ type 'a kind
     parameter for {!Eliom_registration.kind}. It means the returned
     content must be interpreted in the browser as stated by the
     content-type header. This is most common return type for an eliom
-    service, see for example {!Html5}, {!CssText}, {!File},
+    service, see for example {!Html}, {!CssText}, {!File},
     {!Redirection}. *)
 type browser_content = [ `Browser ]
 
@@ -87,8 +87,8 @@ type 'a ocaml_content
 
 (** Eliom service registration for services that return HTML5
     pages. *)
-module Html5 : Eliom_reg_sigs.S
-  with type page = Html5_types.html Eliom_content.Html5.elt
+module Html : Eliom_reg_sigs.S
+  with type page = Html_types.html Eliom_content.Html.elt
    and type options = unit
    and type return = Eliom_service.non_ocaml
    and type result = browser_content kind
@@ -141,7 +141,7 @@ module type ELIOM_APPL = sig
       will be automatically added at the end of the [<head>] node. *)
   val application_script :
     ?defer:bool -> ?async:bool -> unit ->
-    [> `Script ] Eliom_content.Html5.elt
+    [> `Script ] Eliom_content.Html.elt
 
   (** Unique identifier for this application. Currently, it is just
       the application name as defined by
@@ -162,7 +162,7 @@ module type ELIOM_APPL = sig
   type app_id
 
   include Eliom_reg_sigs.S
-    with type page = Html5_types.html Eliom_content.Html5.elt
+    with type page = Html_types.html Eliom_content.Html.elt
      and type options = appl_service_options
      and type return = Eliom_service.non_ocaml
      and type result = app_id application_content kind
@@ -178,7 +178,7 @@ module App (Appl_params : APPL_PARAMS) : ELIOM_APPL
 module type TMPL_PARAMS = sig
   type t
   val name: string
-  val make_page: t -> Html5_types.html Eliom_content.Html5.elt Lwt.t
+  val make_page: t -> Html_types.html Eliom_content.Html.elt Lwt.t
   val update: t -> unit Eliom_client_value.t
 end
 
@@ -198,7 +198,7 @@ module Eliom_tmpl (Appl : ELIOM_APPL) (Tmpl_param : TMPL_PARAMS):
     For Eliom application, prefers {!Ocaml} services to send page
     fragments. *)
 module Flow5 : Eliom_reg_sigs.S
-  with type page = Html5_types.flow5 Eliom_content.Html5.elt list
+  with type page = Html_types.flow5 Eliom_content.Html.elt list
    and type options = unit
    and type return = Eliom_service.non_ocaml
    and type result = block_content kind
@@ -375,7 +375,7 @@ module Ocaml : Eliom_reg_sigs.S_poly_with_send
 
 (** Eliom service registration for services that choose dynamically
     what they want to send. The content is created using for example
-    {!Html5.send} or {!String.send} functions. See the Eliom manual
+    {!Html.send} or {!String.send} functions. See the Eliom manual
     for more information about {% <<a_manual chapter="server-outputs"
     fragment="any"|services that choose dynamically what they want to
     send>>%} *)

--- a/src/lib/eliom_service.server.mli
+++ b/src/lib/eliom_service.server.mli
@@ -54,7 +54,7 @@ val register_eliom_module : string -> (unit -> unit) -> unit
 
 (** The function [unregister service] unregister the service handler
     previously associated to [service] with
-    {!Eliom_registration.Html5.register},
+    {!Eliom_registration.Html.register},
     {!Eliom_registration.App.register} or any other
     {!Eliom_registration}[.*.register] functions. See the
     documentation of those functions for a description of the [~scope]

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -284,10 +284,10 @@ let set_send_appl_content s n = s.send_appl_content <- n
 type clvpreapp = {
   mutable clvpreapp_f :
     'a 'b.
-         (('a -> 'b -> [ `Html ] Eliom_content_core.Html5.elt Lwt.t)
+         (('a -> 'b -> [ `Html ] Eliom_content_core.Html.elt Lwt.t)
             Eliom_client_value.t ->
           'a ->
-          (unit -> 'b -> [ `Html ] Eliom_content_core.Html5.elt Lwt.t)
+          (unit -> 'b -> [ `Html ] Eliom_content_core.Html.elt Lwt.t)
             Eliom_client_value.t)
 }
 

--- a/src/lib/eliom_shared_content.eliom
+++ b/src/lib/eliom_shared_content.eliom
@@ -56,9 +56,11 @@ module Xml = struct
 
   type uri = Eliom_content_core.Xml.uri
 
-  let string_of_uri = Eliom_content_core.Xml.string_of_uri
+  let string_of_uri () =
+    {shared#{ Eliom_content_core.Xml.string_of_uri }}
 
-  let uri_of_string = Eliom_content_core.Xml.uri_of_string
+  let uri_of_string () =
+    {shared#{ Eliom_content_core.Xml.uri_of_string }}
 
   type aname = Eliom_content_core.Xml.aname
 
@@ -201,77 +203,83 @@ module Xml = struct
 
 end
 
+{shared{
+module Raw_wrapped_functions_svg =
+  Svg_f.Wrapped_functions(Eliom_content_core.Xml)
+}}
+
 module Svg = struct
 
   module Wrapped_functions :
 
-    Svg_sigs.Wrapped_functions
-    with type (-'a, 'b) ft = ('a, 'b) Xml.W.ft =
+    Svg_sigs.Wrapped_functions with module Xml = Xml =
 
   struct
+
+    module Xml = Xml
 
     type (-'a, 'b) ft = ('a, 'b) Xml.W.ft
 
     let string_of_alignment_baseline () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_alignment_baseline }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_alignment_baseline }}
 
     let string_of_big_variant () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_big_variant }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_big_variant }}
 
     let string_of_bool () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_bool }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_bool }}
 
     let string_of_coords () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_coords }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_coords }}
 
     let string_of_dominant_baseline () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_dominant_baseline }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_dominant_baseline }}
 
     let string_of_fourfloats () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_fourfloats }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_fourfloats }}
 
     let string_of_in_value () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_in_value }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_in_value }}
 
     let string_of_int () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_int }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_int }}
 
     let string_of_length () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_length }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_length }}
 
     let string_of_lengths () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_lengths }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_lengths }}
 
     let string_of_number () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_number }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_number }}
 
     let string_of_number_optional_number () =
       {shared#{
-         Svg_f.Wrapped_functions.string_of_number_optional_number }}
+         Raw_wrapped_functions_svg.string_of_number_optional_number }}
 
     let string_of_numbers () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_numbers }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_numbers }}
 
     let string_of_numbers_semicolon () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_numbers_semicolon }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_numbers_semicolon }}
 
     let string_of_offset () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_offset }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_offset }}
 
     let string_of_orient () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_orient }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_orient }}
 
     let string_of_paint () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_paint }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_paint }}
 
     let string_of_strokedasharray () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_strokedasharray }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_strokedasharray }}
 
     let string_of_transform () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_transform }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_transform }}
 
     let string_of_transforms () =
-      {shared#{ Svg_f.Wrapped_functions.string_of_transforms }}
+      {shared#{ Raw_wrapped_functions_svg.string_of_transforms }}
 
   end
 
@@ -282,7 +290,7 @@ module Svg = struct
 
   module R = struct
 
-    (* Same as the HTML version, with Html5 -> SVG and `HTML5 ->
+    (* Same as the HTML version, with Html -> SVG and `HTML5 ->
        `SVG. Hard to functorize. Make sure they stay synced! *)
     let node s =
       let e =
@@ -317,74 +325,88 @@ module Svg = struct
 
   end
 
-end
+end ;;
 
-module Html5 = struct
+{shared{
+module Raw_wrapped_functions =
+  Html_f.Wrapped_functions(Eliom_content_core.Xml)
+}}
+
+module Html = struct
 
   module Wrapped_functions :
 
-    Html5_sigs.Wrapped_functions
-    with type (-'a, 'b) ft = ('a, 'b) Xml.W.ft =
+    Html_sigs.Wrapped_functions with module Xml = Xml =
 
   struct
 
+    module Xml = Xml
+
     type (-'a, 'b) ft = ('a, 'b) Xml.W.ft
 
+    type image_candidate =
+      [ `Url of Xml.uri
+      | `Url_width of Xml.uri * Html_types.number
+      | `Url_pixel of Xml.uri * Html_types.float_number ]
+
+    let onoff_of_bool () =
+      {shared#{ Raw_wrapped_functions.onoff_of_bool }}
+
     let string_of_big_variant () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_big_variant }}
+      {shared#{ Raw_wrapped_functions.string_of_big_variant }}
 
     let string_of_bool () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_bool }}
+      {shared#{ Raw_wrapped_functions.string_of_bool }}
 
     let string_of_character () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_character }}
+      {shared#{ Raw_wrapped_functions.string_of_character }}
 
     let string_of_input_type () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_input_type }}
+      {shared#{ Raw_wrapped_functions.string_of_input_type }}
 
     let string_of_linktypes () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_linktypes }}
+      {shared#{ Raw_wrapped_functions.string_of_linktypes }}
 
     let string_of_mediadesc () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_mediadesc }}
+      {shared#{ Raw_wrapped_functions.string_of_mediadesc }}
 
-    let string_of_multilength () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_multilength }}
-
-    let string_of_multilengths () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_multilengths }}
+    let string_of_number_or_datetime () =
+      {shared#{ Raw_wrapped_functions.string_of_number_or_datetime }}
 
     let string_of_numbers () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_numbers }}
+      {shared#{ Raw_wrapped_functions.string_of_numbers }}
 
     let string_of_sandbox () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_sandbox }}
+      {shared#{ Raw_wrapped_functions.string_of_sandbox }}
 
     let string_of_sizes () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_sizes }}
+      {shared#{ Raw_wrapped_functions.string_of_sizes }}
+
+    let string_of_srcset () =
+      {shared#{ Raw_wrapped_functions.string_of_srcset }}
 
     let string_of_step () =
-      {shared#{ Html5_f.Wrapped_functions.string_of_step }}
+      {shared#{ Raw_wrapped_functions.string_of_step }}
 
     let unoption_string () =
-      {shared#{ Html5_f.Wrapped_functions.unoption_string }}
+      {shared#{ Raw_wrapped_functions.unoption_string }}
 
   end
 
   module R = struct
 
-    (* Same as the SVG version, with Svg -> Html5 and `SVG ->
+    (* Same as the SVG version, with Svg -> Html and `SVG ->
        `HTML5. Hard to functorize. Make sure they stay synced! *)
     let node s =
       let e =
         local_value s |>
-        Eliom_content_core.Html5.D.toelt |>
+        Eliom_content_core.Html.D.toelt |>
         Eliom_content_core.Xml.make_request_node ~reset:false
       and synced = React.S.synced s in
       let _ = {unit{
         let s =
           %s >|= (fun s ->
-            Eliom_content_core.Html5.
+            Eliom_content_core.Html.
               (Id.create_request_elt s ~reset:false |> D.toelt) |>
             Eliom_client_core.rebuild_node' `HTML5)
         in
@@ -402,15 +424,15 @@ module Html5 = struct
         else
           f (React.S.value s) |> ignore
       }} in
-      e |> Eliom_content_core.Html5.D.tot
+      e |> Eliom_content_core.Html.D.tot
 
     let filter_attrib a s =
       let init = if local_value s then Some a else None
-      and c = {{ Eliom_content_core.Html5.R.filter_attrib %a %s }} in
-      Eliom_content_core.Html5.D.client_attrib ?init c
+      and c = {{ Eliom_content_core.Html.R.filter_attrib %a %s }} in
+      Eliom_content_core.Html.D.client_attrib ?init c
 
     include
-      Eliom_content_core.Html5.Make(Xml)(Wrapped_functions)(Svg.R)
+      Eliom_content_core.Html.Make(Xml)(Wrapped_functions)(Svg.R)
 
     let pcdata x = pcdata x |> Unsafe.coerce_elt
 

--- a/src/lib/eliom_shared_content.eliomi
+++ b/src/lib/eliom_shared_content.eliomi
@@ -42,17 +42,17 @@ module Svg : sig
 
 end
 
-module Html5 : sig
+module Html : sig
 
   module R : sig
 
-    include Html5_sigs.Make(Xml)(Svg.R).T
-      with type 'a elt = 'a Eliom_content_core.Html5.elt
-       and type 'a attrib = 'a Eliom_content_core.Html5.attrib
+    include Html_sigs.Make(Xml)(Svg.R).T
+      with type 'a elt = 'a Eliom_content_core.Html.elt
+       and type 'a attrib = 'a Eliom_content_core.Html.attrib
 
     val pcdata :
       string Eliom_shared.React.S.t ->
-      [> | Html5_types.span] elt
+      [> | Html_types.span] elt
 
     val node : 'a elt Eliom_shared.React.S.t -> 'a elt
 

--- a/src/lib/eliom_tools.eliom
+++ b/src/lib/eliom_tools.eliom
@@ -69,17 +69,17 @@ module type HTML5_TOOLS = sig
       corresponding attributes in the generated [<ul>] node. The
       default class for the [<ul>] node is [eliomtools_menu]. *)
   val menu :
-    ?classe:Html5_types.nmtoken list ->
+    ?classe:Html_types.nmtoken list ->
     ?id:string ->
     ((unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
       unit, unit, Eliom_service.non_ocaml) Eliom_service.t *
-     [< Html5_types.flow5_without_interactive] Html5.elt list)
+     [< Html_types.flow5_without_interactive] Html.elt list)
       list ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Ul ] Html5.elt
+    [> `Ul ] Html.elt
 
   (** {2 Hierchical sites } *)
 
@@ -98,15 +98,15 @@ module type HTML5_TOOLS = sig
       See {!menu} for a description of the optional parameters [id]
       and [classe]. *)
   val hierarchical_menu_depth_first :
-    ?classe:Html5_types.nmtoken list ->
+    ?classe:Html_types.nmtoken list ->
     ?id:string ->
     ?whole_tree:bool ->
-    [< Html5_types.a_content ] Html5.elt list hierarchical_site ->
+    [< Html_types.a_content ] Html.elt list hierarchical_site ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Ul ] Html5.elt list
+    [> `Ul ] Html.elt list
 
   (** The function [hierarchical_menu_breadth_first site ()]
       constructs a hierarchical menu by exploring the hierarchical
@@ -121,14 +121,14 @@ module type HTML5_TOOLS = sig
       See {!menu} for a description of the optional parameters [id]
       and [classe].  *)
   val hierarchical_menu_breadth_first :
-    ?classe:Html5_types.nmtoken list ->
+    ?classe:Html_types.nmtoken list ->
     ?id:string ->
-    [< Html5_types.a_content ] Html5.elt list hierarchical_site ->
+    [< Html_types.a_content ] Html.elt list hierarchical_site ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Ul ] Html5.elt list
+    [> `Ul ] Html.elt list
 
   (** The function [structure_links site ()] returns the tags [<link
       rel="subsection" ...>] and [<link rev="subsection" ...>] for the
@@ -138,12 +138,12 @@ module type HTML5_TOOLS = sig
       url. The optional parameter [service] allow to override the
       current service. *)
   val structure_links :
-    [< Html5_types.a_content ] Html5.elt list hierarchical_site ->
+    [< Html_types.a_content ] Html.elt list hierarchical_site ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Link ] Html5.elt list
+    [> `Link ] Html.elt list
 
   (** An auxiliary function for creating an HTML head
       elements. Resources (JS, CSS) are taken from the static
@@ -152,18 +152,18 @@ module type HTML5_TOOLS = sig
     title:string ->
     ?css:string list list ->
     ?js:string list list ->
-    ?other:[< Html5_types.head_content_fun ] Html5.elt list ->
+    ?other:[< Html_types.head_content_fun ] Html.elt list ->
     unit ->
-    [`Head] Html5.elt
+    [`Head] Html.elt
 
   val html :
     title:string ->
-    ?a:[< Html5_types.html_attrib ] Html5.attrib list ->
+    ?a:[< Html_types.html_attrib ] Html.attrib list ->
     ?css:string list list ->
     ?js:string list list ->
-    ?other_head:[< Html5_types.head_content_fun ] Html5.elt list ->
-    Html5_types.body Html5.elt ->
-    Html5_types.html Html5.elt
+    ?other_head:[< Html_types.head_content_fun ] Html.elt list ->
+    Html_types.body Html.elt ->
+    Html_types.html Html.elt
 
 end
 
@@ -187,9 +187,9 @@ let get_css_files () = let f = !css_files in css_files := []; f
 let get_js_files () = let f = !js_files in js_files := []; f
 }}
 {shared{
-module Make(DorF : module type of Eliom_content.Html5.F) : HTML5_TOOLS = struct
-  open Html5_types
-  open Html5.F
+module Make(DorF : module type of Eliom_content.Html.F) : HTML5_TOOLS = struct
+  open Html_types
+  open Html.F
 
   let make_string_uri = Eliom_uri.make_string_uri
 
@@ -477,7 +477,7 @@ module Make(DorF : module type of Eliom_content.Html5.F) : HTML5_TOOLS = struct
       css_link ~uri () in
     let mk_js_script path =
       let uri = make_uri  (Eliom_service.static_dir ()) path in
-      js_script ~a:[a_defer `Defer] ~uri () in
+      js_script ~a:[a_defer ()] ~uri () in
     DorF.head
       (title (pcdata ttl))
       List.(map mk_css_link css @ map mk_js_script js @
@@ -492,8 +492,8 @@ module Make(DorF : module type of Eliom_content.Html5.F) : HTML5_TOOLS = struct
 end
 
 
-module F = Make(Html5.F)
-module D = Make(Html5.D)
+module F = Make(Html.F)
+module D = Make(Html.D)
 
 let wrap_handler information none some =
   fun get post ->
@@ -507,26 +507,26 @@ let wrap_handler information none some =
 {client{
 let add_js_file path =
   let uri =
-    Html5.F.make_uri
+    Html.F.make_uri
       (Eliom_service.static_dir () )
       path
   in
   let script =
-    Html5.F.js_script ~a:[Html5.F.a_defer `Defer] ~uri ()
+    Html.F.js_script ~a:[Html.F.a_defer ()] ~uri ()
   in
   ignore
-    Dom_html.document##head##appendChild (Html5.To_dom.of_node script)
+    Dom_html.document##head##appendChild (Html.To_dom.of_node script)
 
 let add_css_file path =
   let uri =
-    Html5.F.make_uri
+    Html.F.make_uri
       (Eliom_service.static_dir () )
       path
   in
   let link =
-    Html5.F.css_link ~uri ()
+    Html.F.css_link ~uri ()
   in
   ignore
     Dom_html.document##head##appendChild
-      (Html5.To_dom.of_node link)
+      (Html.To_dom.of_node link)
 }}

--- a/src/lib/eliom_tools.eliomi
+++ b/src/lib/eliom_tools.eliomi
@@ -80,17 +80,17 @@ module type HTML5_TOOLS = sig
       corresponding attributes in the generated [<ul>] node. The
       default class for the [<ul>] node is [eliomtools_menu]. *)
   val menu :
-    ?classe:Html5_types.nmtoken list ->
+    ?classe:Html_types.nmtoken list ->
     ?id:string ->
     ((unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
       unit, unit, Eliom_service.non_ocaml) Eliom_service.t *
-     [< Html5_types.flow5_without_interactive] Html5.elt list)
+     [< Html_types.flow5_without_interactive] Html.elt list)
       list ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Ul ] Html5.elt
+    [> `Ul ] Html.elt
 
   (** {2 Hierchical sites } *)
 
@@ -109,15 +109,15 @@ module type HTML5_TOOLS = sig
       See {!menu} for a description of the optional parameters [id]
       and [classe]. *)
   val hierarchical_menu_depth_first :
-    ?classe:Html5_types.nmtoken list ->
+    ?classe:Html_types.nmtoken list ->
     ?id:string ->
     ?whole_tree:bool ->
-    [< Html5_types.a_content ] Html5.elt list hierarchical_site ->
+    [< Html_types.a_content ] Html.elt list hierarchical_site ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Ul ] Html5.elt list
+    [> `Ul ] Html.elt list
 
   (** The function [hierarchical_menu_breadth_first site ()]
       constructs a hierarchical menu by exploring the hierarchical
@@ -132,14 +132,14 @@ module type HTML5_TOOLS = sig
       See {!menu} for a description of the optional parameters [id]
       and [classe].  *)
   val hierarchical_menu_breadth_first :
-    ?classe:Html5_types.nmtoken list ->
+    ?classe:Html_types.nmtoken list ->
     ?id:string ->
-    [< Html5_types.a_content ] Html5.elt list hierarchical_site ->
+    [< Html_types.a_content ] Html.elt list hierarchical_site ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Ul ] Html5.elt list
+    [> `Ul ] Html.elt list
 
   (** The function [structure_links site ()] returns the tags [<link
       rel="subsection" ...>] and [<link rev="subsection" ...>] for the
@@ -149,12 +149,12 @@ module type HTML5_TOOLS = sig
       url. The optional parameter [service] allow to override the
       current service. *)
   val structure_links :
-    [< Html5_types.a_content ] Html5.elt list hierarchical_site ->
+    [< Html_types.a_content ] Html.elt list hierarchical_site ->
     ?service:
       (unit, unit, Eliom_service.get, _, _, _, _, [ `WithoutSuffix ],
        unit, unit, Eliom_service.non_ocaml) Eliom_service.t ->
     unit ->
-    [> `Link ] Html5.elt list
+    [> `Link ] Html.elt list
 
   (** An auxiliary function for creating an HTML head
       elements. Resources (JS, CSS) are taken from the static
@@ -163,18 +163,18 @@ module type HTML5_TOOLS = sig
     title:string ->
     ?css:string list list ->
     ?js:string list list ->
-    ?other:[< Html5_types.head_content_fun] Html5.elt list ->
+    ?other:[< Html_types.head_content_fun] Html.elt list ->
     unit ->
-    [`Head] Html5.elt
+    [`Head] Html.elt
 
   val html :
     title:string ->
-    ?a:[< Html5_types.html_attrib] Html5.attrib list ->
+    ?a:[< Html_types.html_attrib] Html.attrib list ->
     ?css:string list list ->
     ?js:string list list ->
-    ?other_head:[< Html5_types.head_content_fun] Html5.elt list ->
-    [`Body] Html5.elt ->
-    [`Html] Html5.elt
+    ?other_head:[< Html_types.head_content_fun] Html.elt list ->
+    [`Body] Html.elt ->
+    [`Html] Html.elt
 
 end
 

--- a/src/lib/eliom_uri.shared.mli
+++ b/src/lib/eliom_uri.shared.mli
@@ -35,8 +35,8 @@ open Eliom_parameter
 
     To define {e global} link (i.e. outside of a service handler) and
     recompute a relative URL at each request, use
-    {!Eliom_registration.Html5.a} or other specialized functions from
-    {!Eliom_registration.Html5}.
+    {!Eliom_registration.Html.a} or other specialized functions from
+    {!Eliom_registration.Html}.
 
 *)
 
@@ -44,7 +44,7 @@ open Eliom_parameter
     string corresponding to the URL of the service [service] applied
     to the GET parameters [get_params].
 
-    See {!Eliom_registration.Html5.make_string_uri} or any other
+    See {!Eliom_registration.Html.make_string_uri} or any other
     {!Eliom_registration}[.*.make_string_uri] for a detailled
     description of optional parameters.
 
@@ -75,7 +75,7 @@ val make_string_uri :
     of the URL of [service] applied to the GET parameters
     [get_params].
 
-    See {!Eliom_registration.Html5.make_uri_components} or any other
+    See {!Eliom_registration.Html.make_uri_components} or any other
     {!Eliom_registration}[.*.make_uri_components] for a detailled
     description. *)
 val make_uri_components :

--- a/src/lib/server/eliommod_pagegen.ml
+++ b/src/lib/server/eliommod_pagegen.ml
@@ -24,7 +24,7 @@ open Eliom_lib
 open Eliom_content_core
 open Lwt
 
-module Html5_content = Ocsigen_senders.Make_XML_Content(Xml)(Html5.F)
+module Html_content = Ocsigen_senders.Make_XML_Content(Xml)(Html.F)
 
 (*****************************************************************************)
 (* Exception handler for the site                                            *)
@@ -323,7 +323,7 @@ let gen is_eliom_extension sitedata = function
             )
             (function
                | Eliom_common.Eliom_Typing_Error l ->
-                   Html5_content.result_of_content
+                   Html_content.result_of_content
                      (Eliom_error_pages.page_error_param_type l)
                    >>= fun r ->
                    Lwt.return
@@ -342,7 +342,7 @@ let gen is_eliom_extension sitedata = function
                         ri.request_config.Ocsigen_extensions.maxuploadfilesize)
                  in
                  ripp >>= fun ripp ->
-                Html5_content.result_of_content
+                Html_content.result_of_content
                    (Eliom_error_pages.page_bad_param
                       (try
                          ignore (Polytables.get

--- a/src/lib/server/extensions/atom_feed.ml
+++ b/src/lib/server/extensions/atom_feed.ml
@@ -23,7 +23,7 @@ open Eliom_lib
 (*
  * types {{{
  *)
-type uri = Xml.uri
+type uri = Tyxml_xml.uri
 type lang = string
 type base = uri
 type ncname = string
@@ -31,7 +31,7 @@ type dateConstruct = string
 type emailAddress = string
 type mediaType = string
 type length = int
-type href = Xml.uri
+type href = Tyxml_xml.uri
 type hrefLang = string
 type rel = string
 type ltitle = string
@@ -40,21 +40,21 @@ type label = string
 type term = string
 type metaAttr = [ `Base of base | `Lang of lang ]
 type personConstruct = [ `Uri of uri | `Email of emailAddress ]
-type author = Xml.elt
-type contributor = Xml.elt
-type generator = Xml.elt
-type id = Xml.elt
-type icon = Xml.elt
-type category = Xml.elt
-type link = Xml.elt
-type logo = Xml.elt
-type published = Xml.elt
-type updated = Xml.elt
-type source = Xml.elt
-type entry = Xml.elt
-type feed = Xml.elt
-type content = Xml.elt
-type textConstruct = Xml.attrib list * Xml.elt list
+type author = Tyxml_xml.elt
+type contributor = Tyxml_xml.elt
+type generator = Tyxml_xml.elt
+type id = Tyxml_xml.elt
+type icon = Tyxml_xml.elt
+type category = Tyxml_xml.elt
+type link = Tyxml_xml.elt
+type logo = Tyxml_xml.elt
+type published = Tyxml_xml.elt
+type updated = Tyxml_xml.elt
+type source = Tyxml_xml.elt
+type entry = Tyxml_xml.elt
+type feed = Tyxml_xml.elt
+type content = Tyxml_xml.elt
+type textConstruct = Tyxml_xml.attrib list * Tyxml_xml.elt list
 type linkOAttr = [ metaAttr
    | `Type of string
    | `Rel of rel
@@ -106,18 +106,18 @@ let xml_of_feed f = f
 (*
  * attr converters {{{
  *)
-let a_base = Xml.uri_attrib "base"
-let a_lang = Xml.string_attrib "lang"
-let a_scheme = Xml.string_attrib "scheme"
-let a_label = Xml.string_attrib "label"
-let a_href = Xml.uri_attrib "href"
-let a_rel = Xml.string_attrib "rel"
-let a_hreflang = Xml.string_attrib "hreflang"
-let a_medtype = Xml.string_attrib "mediatype"
-let a_title = Xml.string_attrib "title"
-let a_length = Xml.int_attrib "length"
-let a_term = Xml.string_attrib "term"
-let a_type = Xml.string_attrib "type"
+let a_base = Tyxml_xml.uri_attrib "base"
+let a_lang = Tyxml_xml.string_attrib "lang"
+let a_scheme = Tyxml_xml.string_attrib "scheme"
+let a_label = Tyxml_xml.string_attrib "label"
+let a_href = Tyxml_xml.uri_attrib "href"
+let a_rel = Tyxml_xml.string_attrib "rel"
+let a_hreflang = Tyxml_xml.string_attrib "hreflang"
+let a_medtype = Tyxml_xml.string_attrib "mediatype"
+let a_title = Tyxml_xml.string_attrib "title"
+let a_length = Tyxml_xml.int_attrib "length"
+let a_term = Tyxml_xml.string_attrib "term"
+let a_type = Tyxml_xml.string_attrib "type"
 (*
  * }}}
  *)
@@ -128,43 +128,43 @@ let rec metaAttr_extract l = match l with
    | `Lang a :: r    -> a_lang a :: metaAttr_extract r | _ :: r          ->
    metaAttr_extract r
 
-let rec c_pcdata l = match l with | [] -> [] | a::r -> Xml.pcdata a :: c_pcdata
+let rec c_pcdata l = match l with | [] -> [] | a::r -> Tyxml_xml.pcdata a :: c_pcdata
 r
 
 let print_html5 l =
   let buffer = Buffer.create 500 in
   let output = Buffer.add_string buffer in
   let encode x = fst (Xml_print.Utf8.normalize_html x) in
-  Eliom_content.Html5.Printer.print_list ~encode ~output l;
+  Eliom_content.Html.Printer.print_list ~encode ~output l;
   Buffer.contents buffer
 
-let inlineC ?(meta = []) ?(html = false) c = `Content (Xml.node ~a:(a_type (if
+let inlineC ?(meta = []) ?(html = false) c = `Content (Tyxml_xml.node ~a:(a_type (if
             html then "html" else "text") :: metaAttr_extract meta) "content"
       (c_pcdata c))
 
 let html5C ?meta c =
-  inlineC ?meta ~html:true [print_html5 [Eliom_content.Html5.F.div c]]
+  inlineC ?meta ~html:true [print_html5 [Eliom_content.Html.F.div c]]
 
-let inlineOtherC ?(meta = []) (a,b) = `Content (Xml.node ~a:(a_medtype a ::
+let inlineOtherC ?(meta = []) (a,b) = `Content (Tyxml_xml.node ~a:(a_medtype a ::
          metaAttr_extract meta) "content" b)
 
-let outOfLineC ?(meta = []) (a,b) = `Content (Xml.node ~a:(a_medtype a ::
-         Xml.uri_attrib "src" b :: metaAttr_extract meta) "content" [])
+let outOfLineC ?(meta = []) (a,b) = `Content (Tyxml_xml.node ~a:(a_medtype a ::
+         Tyxml_xml.uri_attrib "src" b :: metaAttr_extract meta) "content" [])
 
 (*
  * Extraction functions {{{
  *)
 let rec personConstruct_extract l = match l with
    | []              -> []
-   |`Email a :: r   -> Xml.node ~a:[] "email" [(Xml.pcdata a)] ::
+   |`Email a :: r   -> Tyxml_xml.node ~a:[] "email" [(Tyxml_xml.pcdata a)] ::
       personConstruct_extract r
-   | `Uri a :: r     -> Xml.node ~a:[] "uri" [(Xml.pcdata (Xml.string_of_uri a))] ::
+   | `Uri a :: r     -> Tyxml_xml.node ~a:[] "uri" [(Tyxml_xml.pcdata (Tyxml_xml.string_of_uri a))] ::
       personConstruct_extract r
    | _ :: r          -> personConstruct_extract r
 
 let rec linkOAttr_extract l = match l with
    | []              -> []
-   | `Type a :: r    -> Xml.string_attrib "type" a :: linkOAttr_extract r
+   | `Type a :: r    -> Tyxml_xml.string_attrib "type" a :: linkOAttr_extract r
    | `Rel a :: r     -> a_rel a :: linkOAttr_extract r
    | `Medtype a :: r -> a_medtype a :: linkOAttr_extract r
    | `Hrefl a :: r   -> a_hreflang a :: linkOAttr_extract r
@@ -181,8 +181,8 @@ let rec sourceOAttr_extract l = match l with
    | `Gen a :: r
    | `Icon a :: r
    | `Logo a :: r       -> a :: sourceOAttr_extract r
-   | `Rights (a,b) :: r -> Xml.node ~a "rights" b :: sourceOAttr_extract r
-   | `Sub (a,b) :: r    -> Xml.node ~a "subtitle" b :: sourceOAttr_extract r
+   | `Rights (a,b) :: r -> Tyxml_xml.node ~a "rights" b :: sourceOAttr_extract r
+   | `Sub (a,b) :: r    -> Tyxml_xml.node ~a "subtitle" b :: sourceOAttr_extract r
    | _ :: r             -> sourceOAttr_extract r
 
 let rec entryOAttr_extract l = match l with
@@ -194,8 +194,8 @@ let rec entryOAttr_extract l = match l with
    | `Content a :: r
    | `Pub a :: r
    | `Source a :: r     -> a :: entryOAttr_extract r
-   | `Rights (a,b) :: r -> Xml.node ~a "rights" b :: entryOAttr_extract r
-   | `Sum (a,b) :: r    -> Xml.node ~a "summary" b :: entryOAttr_extract r
+   | `Rights (a,b) :: r -> Tyxml_xml.node ~a "rights" b :: entryOAttr_extract r
+   | `Sum (a,b) :: r    -> Tyxml_xml.node ~a "summary" b :: entryOAttr_extract r
    | _ :: r             -> entryOAttr_extract r
 
 let rec feedOAttr_extract l = match l with
@@ -207,8 +207,8 @@ let rec feedOAttr_extract l = match l with
    | `Gen a :: r
    | `Icon a :: r
    | `Logo a :: r       -> a :: feedOAttr_extract r
-   | `Rights (a,b) :: r -> Xml.node ~a "rights" b :: feedOAttr_extract r
-   | `Sub (a,b) :: r    -> Xml.node ~a "subtitle" b :: feedOAttr_extract r
+   | `Rights (a,b) :: r -> Tyxml_xml.node ~a "rights" b :: feedOAttr_extract r
+   | `Sub (a,b) :: r    -> Tyxml_xml.node ~a "subtitle" b :: feedOAttr_extract r
    | _ :: r          -> feedOAttr_extract r
  (*
  * }}}
@@ -217,8 +217,8 @@ let rec feedOAttr_extract l = match l with
 (*
  * Textconstructs [Rights, Subtitle, Summary, Title] {{{
  *)
-let plain ?(meta = []) ?(html = false) content = (Xml.string_attrib "type"
-    (if html then "html" else "text"):: metaAttr_extract meta, [Xml.pcdata
+let plain ?(meta = []) ?(html = false) content = (Tyxml_xml.string_attrib "type"
+    (if html then "html" else "text"):: metaAttr_extract meta, [Tyxml_xml.pcdata
     content])
 
 let html5 ?meta content =
@@ -234,30 +234,30 @@ let summary t = `Sum t
  *)
 
 let feed ~updated ~id ~title:(a,b) ?(fields = []) entries =
-   Xml.node ~a:(Xml.string_attrib "xmlns" "http://www.w3.org/2005/Atom" ::
+   Tyxml_xml.node ~a:(Tyxml_xml.string_attrib "xmlns" "http://www.w3.org/2005/Atom" ::
          metaAttr_extract fields)
          "feed"
-         (Xml.node ~a:[] "updated" [ Xml.pcdata (date updated) ] ::
-            Xml.node ~a:[] "id" [ Xml.pcdata (Xml.string_of_uri id) ] :: Xml.node ~a "title" b ::
+         (Tyxml_xml.node ~a:[] "updated" [ Tyxml_xml.pcdata (date updated) ] ::
+            Tyxml_xml.node ~a:[] "id" [ Tyxml_xml.pcdata (Tyxml_xml.string_of_uri id) ] :: Tyxml_xml.node ~a "title" b ::
             feedOAttr_extract fields @ entries)
 
 let entry ~updated ~id ~title:(a,b) elt =
-   Xml.node ~a:(metaAttr_extract elt)
+   Tyxml_xml.node ~a:(metaAttr_extract elt)
          "entry"
-         (Xml.node ~a:[] "updated" [ Xml.pcdata (date updated) ] ::
-            Xml.node ~a:[] "id" [ Xml.pcdata (Xml.string_of_uri id) ] ::
-            Xml.node ~a "title" b ::
+         (Tyxml_xml.node ~a:[] "updated" [ Tyxml_xml.pcdata (date updated) ] ::
+            Tyxml_xml.node ~a:[] "id" [ Tyxml_xml.pcdata (Tyxml_xml.string_of_uri id) ] ::
+            Tyxml_xml.node ~a "title" b ::
             entryOAttr_extract elt)
 
 let source ~updated ~id ~title:(a,b) elt = `Source (
-   Xml.node ~a:(metaAttr_extract elt)
+   Tyxml_xml.node ~a:(metaAttr_extract elt)
          "source"
-         (Xml.node ~a:[] "updated" [ Xml.pcdata (date updated) ] ::
-            Xml.node ~a:[] "id" [ Xml.pcdata (Xml.string_of_uri id) ] ::
-	       Xml.node ~a "title" b :: sourceOAttr_extract elt)
+         (Tyxml_xml.node ~a:[] "updated" [ Tyxml_xml.pcdata (date updated) ] ::
+            Tyxml_xml.node ~a:[] "id" [ Tyxml_xml.pcdata (Tyxml_xml.string_of_uri id) ] ::
+	       Tyxml_xml.node ~a "title" b :: sourceOAttr_extract elt)
 	 )
 
-let link ?(elt = []) href = Xml.leaf ~a:(a_href href :: (linkOAttr_extract elt)
+let link ?(elt = []) href = Tyxml_xml.leaf ~a:(a_href href :: (linkOAttr_extract elt)
       @ (metaAttr_extract elt)) "link"
 
 let links l = `Links l
@@ -266,34 +266,34 @@ let email s = `Email s
 
 let uri s = `Uri s
 
-let author ?(elt = []) name = Xml.node ~a:[] "author" (Xml.node ~a:[] "name"
-      [Xml.pcdata name] :: personConstruct_extract elt)
+let author ?(elt = []) name = Tyxml_xml.node ~a:[] "author" (Tyxml_xml.node ~a:[] "name"
+      [Tyxml_xml.pcdata name] :: personConstruct_extract elt)
 
 let authors l = `Authors l
 
-let contributor ?(elt = []) name = Xml.node ~a:[] "contributor" (Xml.node ~a:[]
-      "name" [Xml.pcdata name] :: personConstruct_extract elt)
+let contributor ?(elt = []) name = Tyxml_xml.node ~a:[] "contributor" (Tyxml_xml.node ~a:[]
+      "name" [Tyxml_xml.pcdata name] :: personConstruct_extract elt)
 
 let contributors l = `Contribs l
 
-let icon address = `Icon (Xml.node ~a:[] "icon" [ Xml.pcdata (Xml.string_of_uri address) ])
+let icon address = `Icon (Tyxml_xml.node ~a:[] "icon" [ Tyxml_xml.pcdata (Tyxml_xml.string_of_uri address) ])
 
-let logo address = `Logo (Xml.node ~a:[] "icon" [ Xml.pcdata (Xml.string_of_uri address) ])
+let logo address = `Logo (Tyxml_xml.node ~a:[] "icon" [ Tyxml_xml.pcdata (Tyxml_xml.string_of_uri address) ])
 
 let category ?(meta = []) ?(scheme = "") ?(label = "") term content =
-   Xml.node ~a:(a_scheme scheme :: a_label label ::
+   Tyxml_xml.node ~a:(a_scheme scheme :: a_label label ::
                a_term term :: metaAttr_extract meta)
          "category"
          content
 
 let categories l = `Cats l
 
-let published d = `Pub (Xml.node ~a:[] "published" [ Xml.pcdata (date d) ])
+let published d = `Pub (Tyxml_xml.node ~a:[] "published" [ Tyxml_xml.pcdata (date d) ])
 
 (*
  * }}}
  *)
 
-let insert_hub_links hubs feed = match Xml.content feed with
-   | Xml.Node (b, a, c)  -> Xml.node ~a b (List.map
+let insert_hub_links hubs feed = match Tyxml_xml.content feed with
+   | Tyxml_xml.Node (b, a, c)  -> Tyxml_xml.node ~a b (List.map
          (fun uri -> link ~elt:[`Rel ("hub")] uri) hubs @ c) | _ -> assert false

--- a/src/lib/server/extensions/atom_feed.mli
+++ b/src/lib/server/extensions/atom_feed.mli
@@ -23,7 +23,7 @@
 (*
  * types {{{
  *)
-type uri = Xml.uri
+type uri = Tyxml_xml.uri
 type lang = string
 type base = uri
 type ncname = string
@@ -31,7 +31,7 @@ type dateConstruct = string
 type emailAddress = string
 type mediaType = string
 type length = int
-type href = Xml.uri
+type href = Tyxml_xml.uri
 type hrefLang = string
 type rel = string
 type ltitle = string
@@ -113,22 +113,22 @@ type feedOAttr = [ metaAttr
  * Constructors {{{
  *)
 
-val xml_of_feed : feed -> Xml.elt
+val xml_of_feed : feed -> Tyxml_xml.elt
 
 (*
  * attr converters {{{
-val a_base : base -> Xml.attrib
-val a_lang : lang -> Xml.attrib
-val a_scheme : scheme -> Xml.attrib
-val a_label : label -> Xml.attrib
-val a_href : href -> Xml.attrib
-val a_rel : rel -> Xml.attrib
-val a_hreflang : hrefLang -> Xml.attrib
-val a_medtype : mediaType -> Xml.attrib
-val a_title : ltitle -> Xml.attrib
-val a_length : length -> Xml.attrib
-val a_term : term -> Xml.attrib
-val a_type : string -> Xml.attrib
+val a_base : base -> Tyxml_xml.attrib
+val a_lang : lang -> Tyxml_xml.attrib
+val a_scheme : scheme -> Tyxml_xml.attrib
+val a_label : label -> Tyxml_xml.attrib
+val a_href : href -> Tyxml_xml.attrib
+val a_rel : rel -> Tyxml_xml.attrib
+val a_hreflang : hrefLang -> Tyxml_xml.attrib
+val a_medtype : mediaType -> Tyxml_xml.attrib
+val a_title : ltitle -> Tyxml_xml.attrib
+val a_length : length -> Tyxml_xml.attrib
+val a_term : term -> Tyxml_xml.attrib
+val a_type : string -> Tyxml_xml.attrib
  * }}}
  *)
 
@@ -140,12 +140,12 @@ val inlineC : ?meta:[> metaAttr ] list
 
 (** An html5 content, embedded in a div *)
 val html5C : ?meta:[> metaAttr ] list
-   -> ([ `PCDATA | Html5_types.flow5 ] Eliom_content.Html5.elt list)
+   -> ([ `PCDATA | Html_types.flow5 ] Eliom_content.Html.elt list)
    -> [> `Content of content ]
 
 (** Inline content from another kind *)
 val inlineOtherC : ?meta:[> metaAttr ] list
-   -> string * Xml.elt list
+   -> string * Tyxml_xml.elt list
    -> [> `Content of content ]
 
 (** Every other content *)
@@ -161,7 +161,7 @@ val plain : ?meta:[> metaAttr ] list
 
 (** HTML5 text construct *)
 val html5 : ?meta:[> metaAttr ] list
-   -> [ `PCDATA | Html5_types.flow5 ] Eliom_content.Html5.elt list
+   -> [ `PCDATA | Html_types.flow5 ] Eliom_content.Html.elt list
    -> textConstruct
 
 (** Rights tag *)
@@ -240,7 +240,7 @@ val logo : uri -> [> `Logo of logo ]
 val category :
   ?meta:[> metaAttr ] list ->
   ?scheme:scheme -> ?label:label ->
-  term -> Xml.elt list -> category
+  term -> Tyxml_xml.elt list -> category
 
 (** We need a list of categories, this is only a converter from category list
  to `Categories *)

--- a/src/lib/server/extensions/eliom_atom.ml
+++ b/src/lib/server/extensions/eliom_atom.ml
@@ -33,7 +33,7 @@ module Atom_info = struct
   let emptytags = []
 end
 
-module Format = Xml_print.Make_simple(Xml)(Atom_info)
+module Format = Xml_print.Make_simple(Tyxml_xml)(Atom_info)
 
 let result_of_content feed headers =
   let b = Buffer.create 10 in
@@ -117,7 +117,7 @@ let rec ping_hub u address t =
 
 let rec nfu_s hubs address = match hubs with
    | []     -> ()
-   | s :: r -> let u = Neturl.parse_url (Xml.string_of_uri s) in ignore (ping_hub u address 1.) ;
+   | s :: r -> let u = Neturl.parse_url (Tyxml_xml.string_of_uri s) in ignore (ping_hub u address 1.) ;
       nfu_s r address
 
 let notify_feed_updates address hubs s =

--- a/src/lib/server/monitor/eliom_monitor.ml
+++ b/src/lib/server/monitor/eliom_monitor.ml
@@ -31,7 +31,7 @@ let fd ~pid =
     `Ok a
   with e -> `Error (Printexc.to_string e)
 
-let ppf fmt = Printf.ksprintf Eliom_content.Html5.D.pcdata fmt
+let ppf fmt = Printf.ksprintf Eliom_content.Html.D.pcdata fmt
 
 let format_duration t =
   let open Unix in
@@ -46,7 +46,7 @@ let format_duration t =
   let sec = (string_of_int (tm.tm_sec))^" seconds" in
   year^days^hour^min^sec
 
-open Eliom_content.Html5.F
+open Eliom_content.Html.F
 
 let general_stats () =
   let pid = pid () in

--- a/src/lib/server/monitor/eliom_monitor.mli
+++ b/src/lib/server/monitor/eliom_monitor.mli
@@ -23,5 +23,5 @@ val pid : unit -> int
 
 val fd : pid:int -> [`Ok of int | `Error of string]
 
-val content_div : unit -> [> Html5_types.div ] Eliom_content.Html5.elt Lwt.t
-val content_html : unit -> [> Html5_types.html ] Eliom_content.Html5.elt Lwt.t
+val content_div : unit -> [> Html_types.div ] Eliom_content.Html.elt Lwt.t
+val content_html : unit -> [> Html_types.html ] Eliom_content.Html.elt Lwt.t

--- a/src/lib/server/monitor/eliom_monitor_main.ml
+++ b/src/lib/server/monitor/eliom_monitor_main.ml
@@ -18,7 +18,7 @@
  *)
 
 let _ =
-  Eliom_registration.Html5.create
+  Eliom_registration.Html.create
     ~meth:(Eliom_service.Get Eliom_parameter.unit)
     ~id:(Eliom_service.Path [])
     (fun _ _ -> Eliom_monitor.content_html ())

--- a/tests/miniwiki/miniwiki.ml
+++ b/tests/miniwiki/miniwiki.ml
@@ -20,7 +20,7 @@
 
 open Eliom_lib
 open Eliom_content
-open Eliom_content.Html5.F
+open Eliom_content.Html.F
 open Eliom_service
 open Eliom_parameter
 open Eliom_state
@@ -190,7 +190,7 @@ let parse_lines lines =
     else (* External link *)
       let url = scheme^":"^page in
       let t = if text = "" then url else text in
-      Html5.F.Raw.a ~a:[a_href (Html5.F.uri_of_string (fun () -> url))]
+      Html.F.Raw.a ~a:[a_href (Html.F.uri_of_string (fun () -> url))]
         [pcdata t]
   in
 
@@ -343,7 +343,7 @@ let view_page page =
 
 (* Save page as a result of /edit?p=Page *)
 let service_save_page_post =
-  Eliom_registration.Html5.create
+  Eliom_registration.Html.create
     ~id:(Eliom_service.Path [""])
     ~meth:
       (Eliom_service.Post
@@ -356,7 +356,7 @@ let service_save_page_post =
 
 (* /edit?p=Page *)
 let _ =
-  Eliom_registration.Html5.register wiki_edit_page
+  Eliom_registration.Html.register wiki_edit_page
     (fun page () ->
       (if wiki_page_exists page then
         load_wiki_page page >>= fun s -> return (String.concat "\n" s)
@@ -376,7 +376,7 @@ let _ =
 
 (* /view?p=Page *)
 let _ =
-  Eliom_registration.Html5.register wiki_view_page
+  Eliom_registration.Html.register wiki_view_page
     (fun page () ->
        if not (wiki_page_exists page) then
          let f =

--- a/tests/testsuite/atom_example.eliom
+++ b/tests/testsuite/atom_example.eliom
@@ -18,8 +18,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *)
 
-module M = Html5.M
-module Html5 = Eliom_content.Html5.F
+module M = Tyxml.Html
+module Html = Eliom_content.Html.F
 open Atom_feed
 open CalendarLib
 
@@ -30,7 +30,7 @@ let f () = Lwt.return (
       (* let's build the feed *)
       feed ~updated:r2 ~id:"http://test.org" ~title:(plain "Un flux Atom")
          (* the optional fields *)
-         ~fields:[ authors [author "Tyruiop"]; subtitle (html5 [Html5.pcdata "Voilà un exemple du flux atom généré avec Ocsigen !"]);
+         ~fields:[ authors [author "Tyruiop"]; subtitle (html5 [Html.pcdata "Voilà un exemple du flux atom généré avec Ocsigen !"]);
                links [link ~elt:[`Rel ("alternate"); `Type ("text/html") ] "http://test.org"]]
          (* the entry list *)
          [entry ~updated:r2 ~id:"http://test.org/1" ~title:(plain "Article 1")
@@ -43,20 +43,20 @@ let f () = Lwt.return (
             [authors [author "Tyruiop"];
             summary (plain "Un petit résumé de l'article 2");
             published d2;
-            html5C [Html5.pcdata "un exemple de content en xHTML !"]];
+            html5C [Html.pcdata "un exemple de content en xHTML !"]];
          entry ~updated:d3 ~id:"http://test.org/3" ~title:(plain "Article 3")
             [authors [author "bépo"];
              summary
                (html5
-                  [Html5.pcdata "Un petit résumé de l'article 3 en ";
-                   Html5.a
+                  [Html.pcdata "Un petit résumé de l'article 3 en ";
+                   Html.a
                      ~service:Eliom_testsuite_base.main
-                     [Html5.pcdata "Html5"]
+                     [Html.pcdata "Html"]
                      ();
                   ]
                );
             published d3;
-            html5C [Html5.pcdata "un exemple de content en HTML5 !"]];
+            html5C [Html.pcdata "un exemple de content en HTML5 !"]];
    ]
    )
 

--- a/tests/testsuite/eliom_testsuite.eliom
+++ b/tests/testsuite/eliom_testsuite.eliom
@@ -4,7 +4,7 @@ let (>|=) = Lwt.(>|=)
 
 open Eliom_lib
 open Eliom_content
-open Html5.D
+open Html.D
 
 open Eliom_testsuite1
 open Eliom_testsuite2
@@ -14,19 +14,19 @@ open Eliom_testsuite3
 let _ = Eliom_testsuite6.mainservice
 let _ = Eliom_testsuite7.mainservice
 (* Main page for the test suite *)
-let _ = Eliom_registration.Html5.register Eliom_testsuite_base.main
+let _ = Eliom_registration.Html.register Eliom_testsuite_base.main
   (fun () () ->
     Lwt.return
      (html
        (head
           (title (pcdata "Examples from the manual"))
-          [Html5.D.css_link
-              (Html5.D.make_uri
+          [Html.D.css_link
+              (Html.D.make_uri
                  ~service:(Eliom_service.static_dir ()) ["style.css"]) ()])
        (body
           [
             h1 [img ~alt:"Ocsigen"
-                   ~src:(Html5.D.make_uri
+                   ~src:(Html.D.make_uri
                            ~service:(Eliom_service.static_dir ()) ["ocsigen5.png"]) ()];
 
             Eliom_testsuite_base.testsuite ~name:"Test suite 4" Eliom_testsuite4.tests;

--- a/tests/testsuite/eliom_testsuite1.eliom
+++ b/tests/testsuite/eliom_testsuite1.eliom
@@ -11,12 +11,12 @@ module Eliom_registration = Eliom_testsuite_base.Registration
 
 open Eliom_content
 open Lwt
-open Html5.F
+open Html.F
 open Ocsigen_cookies
 open Eliom_service
 open Eliom_parameter
 open Eliom_state
-open Eliom_registration.Html5
+open Eliom_registration.Html
 
 let coucou =
   register_service
@@ -33,7 +33,7 @@ let coucou1 =
     ~path:["coucou1"]
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-      let module Html5 = Eliom_content.Html5.F in
+      let module Html = Eliom_content.Html.F in
       return
         << <html>
              <head><title></title></head>
@@ -55,11 +55,11 @@ let coucou_xhtml =
 
 (*
 let coucou1_xthml =
-  Eliom_output.Html5.register_service
+  Eliom_output.Html.register_service
     ~path:["coucou1_xhtml"]
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-      let module Html5 = Eliom_content.Html5.F in
+      let module Html = Eliom_content.Html.F in
       return
         <:xhtml< <html>
              <head><title></title></head>
@@ -204,7 +204,7 @@ let string_of_mysum = function
   | B -> "B"
 
 let mytype =
-  Eliom_registration.Html5.register_service
+  Eliom_registration.Html.register_service
     ~path:["mytype"]
     ~get_params:
       (Eliom_parameter.user_type mysum_of_string string_of_mysum "valeur")
@@ -223,13 +223,13 @@ let raw_serv =
     ~path:["any"]
     ~get_params:Eliom_parameter.any
   (fun l () ->
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun (a,s) -> <:html5< <strong>($str:a$, $str:s$)</strong> >>) l
+        (fun (a,s) -> <:html< <strong>($str:a$, $str:s$)</strong> >>) l
     in
     return
-     <:html5< <html>
+     <:html< <html>
           <head><title></title></head>
           <body>
           <p>
@@ -267,17 +267,17 @@ let links = register_service ["rep";"links"] unit
      (head (title (pcdata "Links")) [])
      (body
        [p
-        [Html5.D.a coucou [pcdata "coucou"] (); br ();
-         Html5.D.a hello [pcdata "hello"] (); br ();
-         Html5.D.a default
+        [Html.D.a coucou [pcdata "coucou"] (); br ();
+         Html.D.a hello [pcdata "hello"] (); br ();
+         Html.D.a default
            [pcdata "default page of the dir"] (); br ();
-         Html5.D.a uasuffix
+         Html.D.a uasuffix
            [pcdata "uasuffix"] (2007,06); br ();
-         Html5.D.a coucou_params
+         Html.D.a coucou_params
            [pcdata "coucou_params"] (42,(22,"ciao")); br ();
-         Html5.D.a raw_serv
+         Html.D.a raw_serv
            [pcdata "raw_serv"] [("sun","yellow");("sea","blue and pink")]; br ();
-         Html5.D.a
+         Html.D.a
            (Eliom_service.create
               ~id:
                 (Eliom_service.External
@@ -286,7 +286,7 @@ let links = register_service ["rep";"links"] unit
               ())
            [pcdata "OCaml on wikipedia"]
            ["OCaml"]; br ();
-         Html5.F.Raw.a
+         Html.F.Raw.a
            ~a:[a_href (Xml.uri_of_string "http://en.wikipedia.org/wiki/OCaml")]
            [pcdata "OCaml on wikipedia"]
        ]])))
@@ -301,7 +301,7 @@ let links = register_service ["rep";"links"] unit
 *wiki*)
 let linkrec = Eliom_service.Http.service ["linkrec"] unit ()
 
-let _ = Eliom_registration.Html5.register linkrec
+let _ = Eliom_registration.Html.register linkrec
     (fun () () ->
       return
        (html
@@ -323,21 +323,21 @@ let essai =
 let create_form =
   (fun (number_name, (number2_name, string_name)) ->
     [p [pcdata "Write an int: ";
-        Html5.D.Form.input ~input_type:`Text ~name:number_name
-          Html5.D.Form.int;
+        Html.D.Form.input ~input_type:`Text ~name:number_name
+          Html.D.Form.int;
         pcdata "Write another int: ";
-        Html5.D.Form.input ~input_type:`Text ~name:number2_name
-          Html5.D.Form.int;
+        Html.D.Form.input ~input_type:`Text ~name:number2_name
+          Html.D.Form.int;
         pcdata "Write a string: ";
-        Html5.D.Form.input ~input_type:`Text ~name:string_name
-          Html5.D.Form.string;
-        Html5.D.Form.input ~input_type:`Submit ~value:"Click"
-          Html5.D.Form.string;
+        Html.D.Form.input ~input_type:`Text ~name:string_name
+          Html.D.Form.string;
+        Html.D.Form.input ~input_type:`Submit ~value:"Click"
+          Html.D.Form.string;
        ]])
 
 let form = register_service ["form"] unit
   (fun () () ->
-    let f = Html5.D.Form.get_form coucou_params create_form in
+    let f = Html.D.Form.get_form coucou_params create_form in
      return
        (html
          (head (title (pcdata "")) [])
@@ -354,18 +354,18 @@ let raw_form = register_service
            (head (title (pcdata "")) [])
            (body
               [h1 [pcdata "Any Form"];
-               Html5.D.Form.get_form raw_serv
+               Html.D.Form.get_form raw_serv
                  (fun () ->
                    [p [pcdata "Form to raw_serv: ";
-                       Html5.D.(
+                       Html.D.(
                          input ~a:[a_input_type `Text; a_name "plop"] ());
-                       Html5.D.(
+                       Html.D.(
                          input ~a:[a_input_type `Text; a_name "plip"] ());
-                       Html5.D.(
+                       Html.D.(
                          input ~a:[a_input_type `Text; a_name "plap"] ());
-                       Html5.D.Form.input
+                       Html.D.Form.input
                          ~input_type:`Submit ~value:"Click"
-                         Html5.D.Form.string]])
+                         Html.D.Form.string]])
                 ])))
 (*wiki*
 
@@ -431,7 +431,7 @@ POST forms
 let form2 = register_service ["form2"] unit
   (fun () () ->
      let f =
-       (Html5.D.Form.post_form my_service_with_post_params
+       (Html.D.Form.post_form my_service_with_post_params
           (fun chaine ->
             [p [pcdata "Write a string: ";
                 Form.input ~input_type:`Text ~name:chaine Form.string]]) ()) in
@@ -442,23 +442,23 @@ let form2 = register_service ["form2"] unit
 
 let form3 = register_service ["form3"] unit
   (fun () () ->
-     let module Html5 = Eliom_content.Html5.F in
+     let module Html = Eliom_content.Html.F in
      let f  =
-       (Eliom_content.Html5.D.Form.post_form my_service_with_get_and_post
+       (Eliom_content.Html.D.Form.post_form my_service_with_get_and_post
           (fun chaine ->
-            <:html5list< <p> Write a string:
+            <:htmllist< <p> Write a string:
                     $Form.input ~input_type:`Text ~name:chaine Form.string$ </p> >>)
           222) in
      return
-       <:html5< <html>
+       <:html< <html>
             <head><title></title></head>
             <body>$f$</body></html> >>)
 
 let form4 = register_service ["form4"] unit
   (fun () () ->
-      let module Html5 = Eliom_content.Html5.F in
+      let module Html = Eliom_content.Html.F in
      let f  =
-       (Eliom_content.Html5.D.Form.post_form
+       (Eliom_content.Html.D.Form.post_form
           (Eliom_service.create
              ~id:(Eliom_service.External
                     ("http://www.petizomverts.com",
@@ -466,7 +466,7 @@ let form4 = register_service ["form4"] unit
              ~meth:(Eliom_service.Post (int "i", string "chaine"))
              ())
           (fun chaine ->
-            <:html5list< <p> Write a string:
+            <:htmllist< <p> Write a string:
                      $Form.input ~input_type:`Text ~name:chaine Form.string$ </p> >>)
           222) in
      return
@@ -574,18 +574,18 @@ let session_data_example_handler _ _  =
            | Eliom_state.Data name ->
                p [pcdata ("Hello "^name);
                   br ();
-                  Html5.D.a
+                  Html.D.a
                     session_data_example_close
                     [pcdata "close session"] ()]
            | Eliom_state.Data_session_expired
            | Eliom_state.No_data ->
-               Html5.D.Form.post_form
+               Html.D.Form.post_form
                  session_data_example_with_post_params
                  (fun login ->
                    [p [pcdata "login: ";
-                       Html5.D.Form.input
+                       Html.D.Form.input
                          ~input_type:`Text ~name:login
-                         Html5.D.Form.string]]) ()
+                         Html.D.Form.string]]) ()
          ]))
 
 (* -------------------------------------------------------- *)
@@ -601,7 +601,7 @@ let session_data_example_with_post_params_handler _ login =
        (body
           [p [pcdata ("Welcome " ^ login ^ ". You are now connected.");
               br ();
-              Html5.D.a session_data_example
+              Html.D.a session_data_example
                 [pcdata "Try again"] ()
             ]]))
 
@@ -621,18 +621,18 @@ let session_data_example_close_handler () () =
         | Eliom_state.Data_session_expired -> p [pcdata "Your session has expired."]
         | Eliom_state.No_data -> p [pcdata "You were not connected."]
         | Eliom_state.Data _ -> p [pcdata "You have been disconnected."]);
-        p [Html5.D.a session_data_example [pcdata "Retry"] () ]]))
+        p [Html.D.a session_data_example [pcdata "Retry"] () ]]))
 
 
 (* -------------------------------------------------------- *)
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     session_data_example_close session_data_example_close_handler;
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     session_data_example session_data_example_handler;
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     session_data_example_with_post_params
     session_data_example_with_post_params_handler
 
@@ -683,7 +683,7 @@ let session_services_example_close =
 
 let session_services_example_handler () () =
   let f =
-    Html5.D.Form.post_form
+    Html.D.Form.post_form
       session_services_example_with_post_params
       (fun login ->
         [p [pcdata "login: ";
@@ -744,13 +744,13 @@ let launch_session () login =
 
   (* Now we register new versions of main services in the
      session service table: *)
-  Eliom_registration.Html5.register ~scope:session
+  Eliom_registration.Html.register ~scope:session
     ~service:session_services_example
     (* service is any public service already registered,
        here the main page of our site *)
     new_main_page;
 
-  Eliom_registration.Html5.register ~scope:session
+  Eliom_registration.Html.register ~scope:session
     ~service:coucou
     (fun () () ->
       return
@@ -760,7 +760,7 @@ let launch_session () login =
                    pcdata login;
                    pcdata "!"]])));
 
-  Eliom_registration.Html5.register ~scope:session
+  Eliom_registration.Html.register ~scope:session
     ~service:hello
     (fun () () ->
       return
@@ -776,13 +776,13 @@ let launch_session () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     ~service:session_services_example
     session_services_example_handler;
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     ~service:session_services_example_close
     session_services_example_close_handler;
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     ~service:session_services_example_with_post_params
     launch_session
 (*zap* Registering for session during initialisation is forbidden:
@@ -829,17 +829,17 @@ let coservices_example_get =
 let _ =
   let c = ref 0 in
   let page () () =
-    let l3 = Html5.D.Form.post_form coservices_example_post
-        (fun _ -> [p [Html5.D.Form.input
+    let l3 = Html.D.Form.post_form coservices_example_post
+        (fun _ -> [p [Html.D.Form.input
                         ~input_type:`Submit
                         ~value:"incr i (post)"
-                        Html5.D.Form.string]]) ()
+                        Html.D.Form.string]]) ()
     in
-    let l4 = Html5.D.Form.get_form coservices_example_get
-        (fun _ -> [p [Html5.D.Form.input
+    let l4 = Html.D.Form.get_form coservices_example_get
+        (fun _ -> [p [Html.D.Form.input
                         ~input_type:`Submit
                         ~value:"incr i (get)"
-                        Html5.D.Form.string]])
+                        Html.D.Form.string]])
     in
     return
       (html
@@ -851,10 +851,10 @@ let _ =
               l3;
               l4]))
   in
-  Eliom_registration.Html5.register coservices_example page;
+  Eliom_registration.Html.register coservices_example page;
   let f () () = c := !c + 1; page () () in
-  Eliom_registration.Html5.register coservices_example_post f;
-  Eliom_registration.Html5.register coservices_example_get f
+  Eliom_registration.Html.register coservices_example_post f;
+  Eliom_registration.Html.register coservices_example_get f
 (*wiki*
 
 
@@ -949,13 +949,13 @@ let calc_i =
 let calc_handler () () =
   let create_form intname =
     [p [pcdata "Write a number: ";
-        Html5.D.Form.input ~input_type:`Text ~name:intname
-          Html5.D.Form.int;
+        Html.D.Form.input ~input_type:`Text ~name:intname
+          Html.D.Form.int;
         br ();
-        Html5.D.Form.input ~input_type:`Submit ~value:"Send"
-          Html5.D.Form.string]]
+        Html.D.Form.input ~input_type:`Submit ~value:"Send"
+          Html.D.Form.string]]
   in
-  let f = Html5.D.Form.get_form calc_i create_form in
+  let f = Html.D.Form.get_form calc_i create_form in
   return
     (html
        (head (title (pcdata "")) [])
@@ -1002,8 +1002,8 @@ let calc_i_handler i () =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register calc   calc_handler;
-  Eliom_registration.Html5.register calc_i calc_i_handler
+  Eliom_registration.Html.register calc   calc_handler;
+  Eliom_registration.Html.register calc_i calc_i_handler
 (*wiki*
 
 
@@ -1048,19 +1048,19 @@ let disconnect_action =
 (* login ang logout boxes:                                  *)
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
                     ~input_type:`Submit ~value:s
-                    Html5.D.Form.string]]) ()
+                    Html.D.Form.string]]) ()
 
 let login_box () =
-  Html5.D.Form.post_form connect_action
+  Html.D.Form.post_form connect_action
     (fun loginname ->
       [p
          (let l = [pcdata "login: ";
-                   Html5.D.Form.input
+                   Html.D.Form.input
                      ~input_type:`Text ~name:loginname
-                     Html5.D.Form.string]
+                     Html.D.Form.string]
          in l)
      ])
     ()
@@ -1097,7 +1097,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:connect_example3 connect_example3_handler;
+  Eliom_registration.Html.register ~service:connect_example3 connect_example3_handler;
   Eliom_registration.Action.register ~service:connect_action connect_action_handler
 (*wiki*
 
@@ -1142,7 +1142,7 @@ let send_any =
     (fun s () ->
        if s = "valid"
        then
-         Eliom_registration.Html5.send
+         Eliom_registration.Html.send
            (html
               (head (title (pcdata "")) [])
               (body [p [pcdata
@@ -1161,7 +1161,7 @@ let cookiename = "mycookie"
 
 let cookies = Http.service ["cookies"] unit ()
 
-let _ = Eliom_registration.Html5.register cookies
+let _ = Eliom_registration.Html.register cookies
   (fun () () ->
     Eliom_state.set_cookie
       ~name:cookiename ~value:(string_of_int (Random.int 100)) ();
@@ -1260,10 +1260,10 @@ let disconnect_action =
       Eliom_state.discard ~scope:session ())
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
                     ~input_type:`Submit ~value:s
-                    Html5.D.Form.string]]) ()
+                    Html.D.Form.string]]) ()
 
 let bad_user_key = Polytables.make_key ()
 let get_bad_user table =
@@ -1273,7 +1273,7 @@ let get_bad_user table =
 (* new login box:                                           *)
 
 let login_box session_expired action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
@@ -1328,7 +1328,7 @@ let persist_session_connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     ~service:persist_session_example
     persist_session_example_handler;
   Eliom_registration.Action.register
@@ -1373,8 +1373,8 @@ let disconnect_action =
       Eliom_state.discard (*zap* *) ~scope:session (* *zap*) ())
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
                     ~input_type:`Submit ~value:s Form.string]]) ()
 
 
@@ -1386,7 +1386,7 @@ let get_bad_user table =
 (* new login box:                                           *)
 
 let login_box session_expired action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
@@ -1447,7 +1447,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:connect_example6 connect_example6_handler;
+  Eliom_registration.Html.register ~service:connect_example6 connect_example6_handler;
   Eliom_registration.Action.register ~service:connect_action connect_action_handler
 
 (*wiki*
@@ -1546,13 +1546,13 @@ let _ =
 let _ = Eliom_registration.set_exn_handler
    (fun e -> match e with
     | Eliom_common.Eliom_404 ->
-        Eliom_registration.Html5.send ~code:404
+        Eliom_registration.Html.send ~code:404
           (html
              (head (title (pcdata "")) [])
              (body [h1 [pcdata "Eliom tutorial"];
                     p [pcdata "Page not found"]]))
 (*    | Eliom_common.Eliom_Wrong_parameter ->
-        Eliom_registration.Html5.send
+        Eliom_registration.Html.send
           (html
              (head (title (pcdata "")) [])
              (body [h1 [pcdata "Eliom tutorial"];
@@ -1588,10 +1588,10 @@ let make_body () =
      )
      (fun iname ->
        [p [pcdata "form with hidden nl params";
-           Html5.D.Form.input
-             ~input_type:`Text ~name:iname Html5.D.Form.int;
-           Html5.D.Form.input
-             ~input_type:`Submit ~value:"Send" Html5.D.Form.string]]);
+           Html.D.Form.input
+             ~input_type:`Text ~name:iname Html.D.Form.int;
+           Html.D.Form.input
+             ~input_type:`Submit ~value:"Send" Html.D.Form.string]]);
    Form.get_form
      ~service:nlparams
      (fun iname ->
@@ -1599,14 +1599,14 @@ let make_body () =
          Eliom_parameter.get_nl_params_names my_nl_params
        in
        [p [pcdata "form with nl params fiels";
-           Html5.D.Form.input
-             ~input_type:`Text ~name:iname Html5.D.Form.int;
-           Html5.D.Form.input
-             ~input_type:`Text ~name:aname Html5.D.Form.int;
-           Html5.D.Form.input
-             ~input_type:`Text ~name:sname Html5.D.Form.string;
-           Html5.D.Form.input
-             ~input_type:`Submit ~value:"Send" Html5.D.Form.string]]);
+           Html.D.Form.input
+             ~input_type:`Text ~name:iname Html.D.Form.int;
+           Html.D.Form.input
+             ~input_type:`Text ~name:aname Html.D.Form.int;
+           Html.D.Form.input
+             ~input_type:`Text ~name:sname Html.D.Form.string;
+           Html.D.Form.input
+             ~input_type:`Submit ~value:"Send" Html.D.Form.string]]);
   ]
 
 let _ = register
@@ -1691,19 +1691,19 @@ let disconnect_action =
 (* login ang logout boxes:                                  *)
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
                     ~input_type:`Submit ~value:s
-                    Html5.D.Form.string]]) ()
+                    Html.D.Form.string]]) ()
 
 let login_box () =
-  Html5.D.Form.post_form connect_action
+  Html.D.Form.post_form connect_action
     (fun loginname ->
       [p
          (let l = [pcdata "login: ";
-                   Html5.D.Form.input
+                   Html.D.Form.input
                      ~input_type:`Text ~name:loginname
-                     Html5.D.Form.string]
+                     Html.D.Form.string]
          in l)
      ])
     ()
@@ -1739,7 +1739,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:connect_example5 connect_example5_handler;
+  Eliom_registration.Html.register ~service:connect_example5 connect_example5_handler;
   Eliom_registration.Action.register ~service:connect_action connect_action_handler
 (*wiki*
 
@@ -1794,24 +1794,24 @@ let disconnect_g_action =
 
 let disconnect_box () =
   div [
-    Html5.D.Form.post_form disconnect_action
-      (fun _ -> [p [Html5.D.Form.input
+    Html.D.Form.post_form disconnect_action
+      (fun _ -> [p [Html.D.Form.input
                       ~input_type:`Submit ~value:"Close session"
-                      Html5.D.Form.string]]) ();
-    Html5.D.Form.post_form disconnect_g_action
-      (fun _ -> [p [Html5.D.Form.input
+                      Html.D.Form.string]]) ();
+    Html.D.Form.post_form disconnect_g_action
+      (fun _ -> [p [Html.D.Form.input
                       ~input_type:`Submit ~value:"Close group"
-                      Html5.D.Form.string]]) ()
+                      Html.D.Form.string]]) ()
   ]
 
 let login_box () =
-  Html5.D.Form.post_form connect_action
+  Html.D.Form.post_form connect_action
     (fun loginname ->
       [p
          (let l = [pcdata "login: ";
-                   Html5.D.Form.input
+                   Html.D.Form.input
                      ~input_type:`Text ~name:loginname
-                     Html5.D.Form.string]
+                     Html.D.Form.string]
          in l)
      ])
     ()
@@ -1869,7 +1869,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:group_tables_example group_tables_example_handler;
+  Eliom_registration.Html.register ~service:group_tables_example group_tables_example_handler;
   Eliom_registration.Action.register ~service:connect_action connect_action_handler
 
 
@@ -1928,24 +1928,24 @@ let disconnect_g_action =
 
 let disconnect_box () =
   div [
-    Html5.D.Form.post_form disconnect_action
-      (fun _ -> [p [Html5.D.Form.input
+    Html.D.Form.post_form disconnect_action
+      (fun _ -> [p [Html.D.Form.input
                       ~input_type:`Submit ~value:"Close session"
-                      Html5.D.Form.string]]) ();
-    Html5.D.Form.post_form disconnect_g_action
-      (fun _ -> [p [Html5.D.Form.input
+                      Html.D.Form.string]]) ();
+    Html.D.Form.post_form disconnect_g_action
+      (fun _ -> [p [Html.D.Form.input
                       ~input_type:`Submit ~value:"Close group"
-                      Html5.D.Form.string]]) ()
+                      Html.D.Form.string]]) ()
   ]
 
 let login_box () =
-  Html5.D.Form.post_form connect_action
+  Html.D.Form.post_form connect_action
     (fun loginname ->
       [p
          (let l = [pcdata "login: ";
-                   Html5.D.Form.input
+                   Html.D.Form.input
                      ~input_type:`Text ~name:loginname
-                     Html5.D.Form.string]
+                     Html.D.Form.string]
          in l)
      ])
     ()
@@ -2004,7 +2004,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:pgroup_tables_example group_tables_example_handler;
+  Eliom_registration.Html.register ~service:pgroup_tables_example group_tables_example_handler;
   Eliom_registration.Action.register ~service:connect_action connect_action_handler
 
 (* *zap*)
@@ -2035,10 +2035,10 @@ let csrfsafe_example_post =
 
 let _ =
   let page () () =
-    let l3 = Html5.D.Form.post_form csrfsafe_example_post
-        (fun _ -> [p [Html5.D.Form.input
+    let l3 = Html.D.Form.post_form csrfsafe_example_post
+        (fun _ -> [p [Html.D.Form.input
                         ~input_type:`Submit
-                        ~value:"Click" Html5.D.Form.string]]) ()
+                        ~value:"Click" Html.D.Form.string]]) ()
     in
     return
       (html
@@ -2046,8 +2046,8 @@ let _ =
        (body [p [pcdata "A new coservice will be created each time this form is displayed"];
               l3]))
   in
-  Eliom_registration.Html5.register csrfsafe_example page;
-  Eliom_registration.Html5.register csrfsafe_example_post
+  Eliom_registration.Html.register csrfsafe_example page;
+  Eliom_registration.Html.register csrfsafe_example_post
     (fun () () ->
        Lwt.return
          (html
@@ -2062,7 +2062,7 @@ let _ =
 let r = Netstring_pcre.regexp "\\\\[(.*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)\\\\]"
 
 let regexp =
-  Eliom_registration.Html5.register_service
+  Eliom_registration.Html.register_service
     ~path:["regexp"]
     ~get_params:(regexp r "$1" "myparam")
     (fun g () ->
@@ -2095,9 +2095,9 @@ let bool_params = register_service
     ~path:["bool"]
     ~get_params:(bool "case")
   (fun case () ->
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
     return
-    <:html5< <html>
+    <:html< <html>
          <head><title></title></head>
          <body>
          <p>
@@ -2107,16 +2107,16 @@ let bool_params = register_service
        </html> >>)
 
 let create_form_bool casename =
-    let module Html5 = Eliom_content.Html5.F in
-    <:html5list< <p>check? $Form.bool_checkbox_one ~name:casename ()$ <br/>
+    let module Html = Eliom_content.Html.F in
+    <:htmllist< <p>check? $Form.bool_checkbox_one ~name:casename ()$ <br/>
       $Form.input ~input_type:`Submit ~value:"Click" Form.string$</p> >>
 
 let form_bool = register_service ["formbool"] unit
   (fun () () ->
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
      let f = Form.get_form bool_params create_form_bool in
      return
-     <:html5< <html>
+     <:html< <html>
           <head><title></title></head>
           <body> $f$ </body>
         </html> >>)
@@ -2131,14 +2131,14 @@ let set = register_service
     ~path:["set"]
     ~get_params:(set string "s")
   (fun l () ->
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun s -> <:html5< <strong>$str:s$ </strong> >>) l
+        (fun s -> <:html< <strong>$str:s$ </strong> >>) l
     in
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
     return
-    <:html5< <html>
+    <:html< <html>
          <head><title></title></head>
          <body>
          <p>
@@ -2189,29 +2189,29 @@ let select_example_result = register_service
 let create_select_form =
   (fun select_name ->
     [p [pcdata "Select something: ";
-        Html5.D.Form.select ~name:select_name
-          Html5.D.Form.string
-          (Html5.D.Form.Option ([] (* attributes *),
+        Html.D.Form.select ~name:select_name
+          Html.D.Form.string
+          (Html.D.Form.Option ([] (* attributes *),
                                         "Bob" (* value *),
                                         None (* Content, if different from value *),
                                         false (* not selected *))) (* first line *)
-          [Html5.D.Form.Option ([], "Marc", None, false);
-          (Html5.D.Form.Optgroup
+          [Html.D.Form.Option ([], "Marc", None, false);
+          (Html.D.Form.Optgroup
           ([],
            "Girls",
            ([], "Karin", None, false),
-           [([a_disabled `Disabled], "Juliette", None, false);
+           [([a_disabled ()], "Juliette", None, false);
             ([], "Alice", None, true);
             ([], "Germaine", Some (pcdata "Bob's mother"), false)]))]
           ;
-          Html5.D.Form.input
+          Html.D.Form.input
             ~input_type:`Submit ~value:"Send"
-            Html5.D.Form.string]])
+            Html.D.Form.string]])
 
 let select_example = register_service ["select"] unit
   (fun () () ->
      let f =
-       Html5.D.Form.get_form
+       Html.D.Form.get_form
          select_example_result create_select_form
      in
      return
@@ -2226,9 +2226,9 @@ let coord = register_service
     ~path:["coord"]
     ~get_params:(coordinates "coord")
   (fun c () ->
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -2262,9 +2262,9 @@ let coord2 = register_service
     ~path:["coord2"]
     ~get_params:(coordinates "coord")
   (fun c () ->
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -2283,11 +2283,11 @@ let coucou_list = register_service
     ~path:["coucou"]
     ~get_params:(list "a" (string "str"))
   (fun l () ->
-    let module Html5 = Eliom_content.Html5.F in
+    let module Html = Eliom_content.Html.F in
     let ll =
-      List.map (fun s -> <:html5< <strong>$str:s$</strong> >>) l in
+      List.map (fun s -> <:html< <strong>$str:s$</strong> >>) l in
       return
-        <:html5< <html>
+        <:html< <html>
              <head><title></title></head>
              <body>
              <p>
@@ -2315,19 +2315,19 @@ let create_listform f =
      The last parameter of f.it is the code that must be appended at the
      end of the list created
    *)
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
   f.it (fun stringname v init ->
-    <:html5list< <p>Write the value for $str:v$:
+    <:htmllist< <p>Write the value for $str:v$:
       $Form.input ~input_type:`Text ~name:stringname Form.string$ </p> >>@init)
     ["one";"two";"three";"four"]
-    <:html5list< <p>$Form.input ~input_type:`Submit ~value:"Click" Form.string$</p> >>
+    <:htmllist< <p>$Form.input ~input_type:`Submit ~value:"Click" Form.string$</p> >>
 
 let listform = register_service ["listform"] unit
   (fun () () ->
-     let module Html5 = Eliom_content.Html5.F in
+     let module Html = Eliom_content.Html.F in
      let f = Form.get_form coucou_list create_listform in
      return
-      <:html5< <html>
+      <:html< <html>
            <head><title></title></head>
            <body> $f$ </body>
          </html> >>)
@@ -2338,8 +2338,8 @@ let listform = register_service ["listform"] unit
 *wiki*)
 (* Form for service with suffix: *)
 (* let create_suffixform ((suff, endsuff),i) = *)
-(*   let module Html5 = Eliom_content.Html5.F in *)
-(*   <:html5list< *)
+(*   let module Html = Eliom_content.Html.F in *)
+(*   <:htmllist< *)
 (*     <p> *)
 (*       Write the suffix (integer): *)
 (*       $Form.input ~input_type:`Text ~name:suff Form.int$ *)
@@ -2356,9 +2356,9 @@ let listform = register_service ["listform"] unit
 (* let suffixform = register_service ["suffixform"] unit *)
 (*   (fun () () -> *)
 (*      let f = Form.get_form isuffix create_suffixform in *)
-(*      let module Html5 = Eliom_content.Html5.F in *)
+(*      let module Html = Eliom_content.Html.F in *)
 (*      return *)
-(*       <:html5< <html> *)
+(*       <:html< <html> *)
 (*            <head><title></title></head> *)
 (*            <body> $f$ </body> *)
 (*          </html> >>) *)

--- a/tests/testsuite/eliom_testsuite2.eliom
+++ b/tests/testsuite/eliom_testsuite2.eliom
@@ -25,7 +25,7 @@ module Eliom_registration = Eliom_testsuite_base.Registration
 
 open Eliom_lib
 open Eliom_content
-open Html5.F
+open Html.F
 open Lwt
 open Eliom_parameter
 open Ocsigen_cookies
@@ -35,7 +35,7 @@ open Ocsigen_cookies
 (* Test for raw_post_data *)
 
 let raw_post_example =
-  Eliom_registration.Html5.register_service
+  Eliom_registration.Html.register_service
     ~path:["rawpost"]
     ~get_params:unit
     (fun () () ->
@@ -51,7 +51,7 @@ Content-length: 124"];
     )
 
 let raw_post_service =
-  Eliom_registration.Html5.register_post_service
+  Eliom_registration.Html.register_post_service
     ~fallback:raw_post_example
     ~post_params:raw_post_data
     (fun () (ct, stream) ->
@@ -112,8 +112,8 @@ let disconnect_action =
       Eliom_state.discard ~scope:session ())
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
                     ~input_type:`Submit ~value:s Form.string]]) ()
 
 (* The following eref is true if the connection has action failed: *)
@@ -126,12 +126,12 @@ let user = Eliom_reference.eref ~scope:session None
 (* new login box:                                           *)
 
 let login_box session_expired bad_u action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
-         Html5.D.Form.input ~input_type:`Text ~name:loginname
-           Html5.D.Form.string]
+         Html.D.Form.input ~input_type:`Text ~name:loginname
+           Html.D.Form.string]
       in
       [p (if bad_u
         then (pcdata "Wrong user")::(br ())::l
@@ -181,7 +181,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:connect_example connect_example_handler;
+  Eliom_registration.Html.register ~service:connect_example connect_example_handler;
   Eliom_registration.Action.register ~service:connect_action connect_action_handler
 
 
@@ -221,9 +221,9 @@ let disconnect_action =
       Eliom_state.discard ~scope:session ())
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
-                    ~input_type:`Submit ~value:s Html5.D.Form.string]]) ()
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
+                    ~input_type:`Submit ~value:s Html.D.Form.string]]) ()
 
 (* The following eref is true if the connection has action failed: *)
 let bad_user = Eliom_reference.eref ~scope:Eliom_common.request_scope false
@@ -232,12 +232,12 @@ let bad_user = Eliom_reference.eref ~scope:Eliom_common.request_scope false
 (* new login box:                                           *)
 
 let login_box session_expired bad_u action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
-         Html5.D.Form.input ~input_type:`Text ~name:loginname
-           Html5.D.Form.string]
+         Html.D.Form.input ~input_type:`Text ~name:loginname
+           Html.D.Form.string]
       in
       [p (if bad_u
         then (pcdata "Wrong user")::(br ())::l
@@ -298,7 +298,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:connect_example connect_example_handler;
+  Eliom_registration.Html.register ~service:connect_example connect_example_handler;
   Eliom_registration.Any.register ~service:connect_action connect_action_handler
 
 
@@ -318,16 +318,16 @@ let count3 =
       Lwt_mutex.unlock mutex;
       Lwt.return newc)
   in
-  Eliom_registration.Html5.register_service
+  Eliom_registration.Html.register_service
     ~path:["count3"]
     ~get_params:unit
     (fun () () ->
       next () >>=
       (fun n ->
         Lwt.return
-         (Html5.F.html
-          (Html5.F.head (Html5.F.title (Html5.F.pcdata "counter")) [])
-          (Html5.F.body [Html5.F.p [Html5.F.pcdata (string_of_int n)]]))))
+         (Html.F.html
+          (Html.F.head (Html.F.title (Html.F.pcdata "counter")) [])
+          (Html.F.body [Html.F.p [Html.F.pcdata (string_of_int n)]]))))
 
 
 (*****************************)
@@ -335,7 +335,7 @@ let count3 =
 
 let volatile_references =
   let page elts =
-    Html5.D.(
+    Html.D.(
       html
         (head
            (title (pcdata "Volatile reference"))
@@ -355,45 +355,45 @@ let volatile_references =
       ()
   in
   let set_service =
-    Eliom_registration.Html5.register_post_coservice
+    Eliom_registration.Html.register_post_coservice
       ~fallback:service
       ~post_params:(Eliom_parameter.int "n")
       (fun () n ->
          lwt () = Eliom_reference.set (eref :> _ Eliom_reference.eref) n in
          Lwt.return
-           (page Html5.D.([
+           (page Html.D.([
              pcdata "Reference was set.";
-             Html5.D.a ~service [pcdata "back"] ();
+             Html.D.a ~service [pcdata "back"] ();
            ])))
   in
   let unset_service =
-    Eliom_registration.Html5.register_post_coservice
+    Eliom_registration.Html.register_post_coservice
       ~fallback:service
       ~post_params:Eliom_parameter.unit
       (fun () () ->
          let () = Eliom_reference.Volatile.unset eref in
          Lwt.return
-           (page Html5.F.([
+           (page Html.F.([
              pcdata "Reference was unset.";
-             Html5.D.a ~service [pcdata "back"] ();
+             Html.D.a ~service [pcdata "back"] ();
            ])))
   in
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     ~service
     (fun () () ->
        let v = Eliom_reference.Volatile.get eref in
        Lwt.return
-         (page Html5.D.([
+         (page Html.D.([
              h2 [pcdata "Volatile reference"];
              p [pcdata "Value is "; pcdata (string_of_int v)];
-             Html5.D.(
+             Html.D.(
                Form.post_form ~service:set_service
                  (fun name -> [
                    Form.input ~input_type:`Text ~name Form.int;
                    Form.input ~input_type:`Submit ~value:"Set" Form.string;
                  ]) ()
              );
-             Html5.D.(
+             Html.D.(
                Form.post_form ~service:unset_service
                  (fun () -> [
                    Form.input ~input_type:`Submit ~value:"Unset" Form.string;
@@ -409,7 +409,7 @@ let volatile_references =
 
 let reference_from_fun =
   let page elts =
-    Html5.D.(
+    Html.D.(
       html
         (head
            (title (pcdata "Reference from fun"))
@@ -431,45 +431,45 @@ let reference_from_fun =
       ()
   in
   let set_service =
-    Eliom_registration.Html5.register_post_coservice
+    Eliom_registration.Html.register_post_coservice
       ~fallback:service
       ~post_params:(Eliom_parameter.int "n")
       (fun () n ->
          lwt () = Eliom_reference.set eref n in
          Lwt.return
-           (page Html5.D.([
+           (page Html.D.([
              pcdata "Reference was set.";
-             Html5.D.a ~service [pcdata "back"] ();
+             Html.D.a ~service [pcdata "back"] ();
            ])))
   in
   let unset_service =
-    Eliom_registration.Html5.register_post_coservice
+    Eliom_registration.Html.register_post_coservice
       ~fallback:service
       ~post_params:Eliom_parameter.unit
       (fun () () ->
          lwt () = Eliom_reference.unset eref in
          Lwt.return
-           (page Html5.D.([
+           (page Html.D.([
              pcdata "Reference was unset.";
-             Html5.D.a ~service [pcdata "back"] ();
+             Html.D.a ~service [pcdata "back"] ();
            ])))
   in
-  Eliom_registration.Html5.register
+  Eliom_registration.Html.register
     ~service
     (fun () () ->
        lwt v = Eliom_reference.get eref in
        Lwt.return
-         (page Html5.D.([
+         (page Html.D.([
              h2 [pcdata "Reference from fun"];
              p [pcdata "Value is "; pcdata (string_of_int v)];
-             Html5.D.(
+             Html.D.(
                Form.post_form ~service:set_service
                  (fun name -> [
                    Form.input ~input_type:`Text ~name Form.int;
                    Form.input ~input_type:`Submit ~value:"Set" Form.string;
                  ]) ()
              );
-             Html5.D.(
+             Html.D.(
                Form.post_form ~service:unset_service
                  (fun () -> [
                       Form.input ~input_type:`Submit ~value:"Unset" Form.string;
@@ -483,7 +483,7 @@ let reference_from_fun =
 (*****************************************************************************)
 
 open Eliom_testsuite1
-open Eliom_registration.Html5
+open Eliom_registration.Html
 open Eliom_service
 open Eliom_state
 
@@ -514,7 +514,7 @@ let create_form f =
 
 let () = register lilists
   (fun () () ->
-     let f = Html5.D.Form.get_form lilists2 create_form in
+     let f = Html.D.Form.get_form lilists2 create_form in
      return
        (html
          (head (title (pcdata "")) [])
@@ -560,20 +560,20 @@ let sumserv = register_service
 let create_form =
   (fun (name1, (name2, name3)) ->
     [p [
-       Html5.D.Form.input
+       Html.D.Form.input
          ~name:name1 ~input_type:`Submit ~value:48
-         Html5.D.Form.int;
-       Html5.D.Form.input
+         Html.D.Form.int;
+       Html.D.Form.input
          ~name:name2 ~input_type:`Submit ~value:55
-         Html5.D.Form.int;
-       Html5.D.Form.input
+         Html.D.Form.int;
+       Html.D.Form.input
          ~name:name3 ~input_type:`Submit ~value:"plop"
-         Html5.D.Form.string;
+         Html.D.Form.string;
      ]])
 
 let sumform = register_service ["sumform"] unit
   (fun () () ->
-     let f = Html5.D.Form.get_form sumserv create_form in
+     let f = Html.D.Form.get_form sumserv create_form in
      return
        (html
          (head (title (pcdata "")) [])
@@ -598,7 +598,7 @@ let sumserv = register_post_service
 
 let () = register sumform2
   (fun () () ->
-    let f = Html5.D.Form.post_form sumserv create_form () in
+    let f = Html.D.Form.post_form sumserv create_form () in
     return
       (html
          (head (title (pcdata "")) [])
@@ -608,25 +608,25 @@ let () = register sumform2
 (******)
 (* unregistering services *)
 let unregister_example =
-  Eliom_registration.Html5.register_service
+  Eliom_registration.Html.register_service
     ~path:["unregister"]
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-       let s1 = Eliom_registration.Html5.register_service
+       let s1 = Eliom_registration.Html.register_service
          ~path:["unregister1"]
          ~get_params:Eliom_parameter.unit
          (fun () () -> failwith "s1")
        in
-       let s2 = Eliom_registration.Html5.register_coservice
+       let s2 = Eliom_registration.Html.register_coservice
          ~fallback:s1
          ~get_params:Eliom_parameter.unit
          (fun () () -> failwith "s2")
        in
-       let s3 = Eliom_registration.Html5.register_coservice'
+       let s3 = Eliom_registration.Html.register_coservice'
          ~get_params:Eliom_parameter.unit
          (fun () () -> failwith "s3")
        in
-       Eliom_registration.Html5.register ~scope:Eliom_common.default_session_scope
+       Eliom_registration.Html.register ~scope:Eliom_common.default_session_scope
          ~service:s1
          (fun () () -> failwith "s4");
        Eliom_service.unregister s1;
@@ -668,8 +668,8 @@ let csrfsafe_example_get =
 
 let _ =
   let page () () =
-    let l3 = Html5.D.Form.get_form csrfsafe_example_get
-        (fun _ -> [p [Html5.D.Form.input
+    let l3 = Html.D.Form.get_form csrfsafe_example_get
+        (fun _ -> [p [Html.D.Form.input
                         ~input_type:`Submit
                         ~value:"Click" Form.string]])
     in
@@ -679,8 +679,8 @@ let _ =
        (body [p [pcdata "A new coservice will be created each time this form is displayed. Your server must be running with HTTPS enabled."];
               l3]))
   in
-  Eliom_registration.Html5.register csrfsafe_get_example page;
-  Eliom_registration.Html5.register csrfsafe_example_get
+  Eliom_registration.Html.register csrfsafe_get_example page;
+  Eliom_registration.Html.register csrfsafe_example_get
     (fun () () ->
        Lwt.return
          (html
@@ -709,10 +709,10 @@ let csrfsafe_example_post =
 
 let _ =
   let page () () =
-    let l3 = Html5.D.Form.post_form csrfsafe_example_post
-        (fun _ -> [p [Html5.D.Form.input
+    let l3 = Html.D.Form.post_form csrfsafe_example_post
+        (fun _ -> [p [Html.D.Form.input
                         ~input_type:`Submit
-                        ~value:"Click" Html5.D.Form.string]]) ()
+                        ~value:"Click" Html.D.Form.string]]) ()
     in
     return
       (html
@@ -720,8 +720,8 @@ let _ =
        (body [p [pcdata "A new coservice will be created each time this form is displayed"];
               l3]))
   in
-  Eliom_registration.Html5.register csrfsafe_postget_example page;
-  Eliom_registration.Html5.register csrfsafe_example_post
+  Eliom_registration.Html.register csrfsafe_postget_example page;
+  Eliom_registration.Html.register csrfsafe_example_post
     (fun () () ->
        Lwt.return
          (html
@@ -751,7 +751,7 @@ let csrfsafe_example_session =
 
 let _ =
   let page () () =
-    Eliom_registration.Html5.register ~scope:myscope
+    Eliom_registration.Html.register ~scope:myscope
       ~secure_session:true
       ~service:csrfsafe_example_session
       (fun () () ->
@@ -759,11 +759,11 @@ let _ =
            (html
               (head (title (pcdata "CSRF safe service")) [])
               (body [p [pcdata "This is a POST CSRF safe service"]])));
-    let l3 = Html5.D.Form.post_form csrfsafe_example_session
-        (fun _ -> [p [Html5.D.Form.input
+    let l3 = Html.D.Form.post_form csrfsafe_example_session
+        (fun _ -> [p [Html.D.Form.input
                         ~input_type:`Submit
                         ~value:"Click"
-                        Html5.D.Form.string]])
+                        Html.D.Form.string]])
         ()
     in
     return
@@ -772,7 +772,7 @@ let _ =
        (body [p [pcdata "A new coservice will be created each time this form is displayed"];
               l3]))
   in
-  Eliom_registration.Html5.register csrfsafe_session_example page
+  Eliom_registration.Html.register csrfsafe_session_example page
 
 
 
@@ -886,37 +886,37 @@ let nlpost_with_nlp =
     my_nl_params nlpost
 
 let create_form_nl s =
-  (fun () -> [Html5.F.p [Html5.D.Form.input
+  (fun () -> [Html.F.p [Html.D.Form.input
                            ~input_type:`Submit ~value:s
-                           Html5.D.Form.string]])
+                           Html.D.Form.string]])
 
-let () = Eliom_registration.Html5.register nlpost
+let () = Eliom_registration.Html.register nlpost
   (fun () () ->
     let nlp =
       match Eliom_parameter.get_non_localized_get_parameters my_nl_params with
         | None -> "no non localised parameter"
         | Some _ -> "some non localised parameter" in
      Lwt.return
-       Html5.F.(html
+       Html.F.(html
           (head (title (pcdata "")) [])
           (body [div [
             pcdata nlp; br();
-            Html5.D.Form.post_form
+            Html.D.Form.post_form
               nlpost_with_nlp (create_form_nl "with nl param") ((),(12, "ab"));
-            Html5.D.Form.post_form
+            Html.D.Form.post_form
               nlpost (create_form_nl "without nl param") ();
           ]])))
 
-let () = Eliom_registration.Html5.register nlpost_entry
+let () = Eliom_registration.Html.register nlpost_entry
   (fun () () ->
      Lwt.return
-       Html5.F.(html
+       Html.F.(html
           (head (title (pcdata "")) [])
           (body [div [
-             Html5.D.Form.post_form
+             Html.D.Form.post_form
                nlpost_with_nlp (create_form_nl "with nl param")
                ((),(12, "ab"));
-             Html5.D.Form.post_form
+             Html.D.Form.post_form
                nlpost (create_form_nl "without nl param") ();
           ]])))
 
@@ -1003,8 +1003,8 @@ let headers =
 
 (* form towards a suffix service with constants *)
 let create_form (n1, (_, n2)) =
-  let module Html5 = Eliom_content.Html5.F in
-  <:html5list< <p>
+  let module Html = Eliom_content.Html.F in
+  <:htmllist< <p>
       $Form.input ~input_type:`Text ~name:n1 Form.string$
       $Form.input ~input_type:`Text ~name:n2 Form.string$
       $Form.input ~input_type:`Submit ~value:"Click" Form.string$</p> >>
@@ -1066,8 +1066,8 @@ let su4 =
                  p [pcdata "I am a suffix service with a constant part, registered after the generic suffix service, but I have a priority, so that you can see me!"]])))
 
 let create_suffixform_su2 s =
-  let module Html5 = Eliom_content.Html5.F in
-    <:html5list< <p>Write a string:
+  let module Html = Eliom_content.Html.F in
+    <:htmllist< <p>Write a string:
       $Form.input ~input_type:`Text ~name:s Form.string$ <br/>
       $Form.input ~input_type:`Submit ~value:"Click" Form.string$</p> >>
 
@@ -1106,16 +1106,16 @@ let optform =
     ~get_params:unit
     (fun () () ->
 (* testing lwt_get_form *)
-       Html5.D.Form.lwt_get_form
+       Html.D.Form.lwt_get_form
          ~service:optparam
          (fun (an, bn) ->
             Lwt.return
               [p [
                  Form.input ~input_type:`Text ~name:an Form.string;
                  Form.input ~input_type:`Text ~name:bn Form.string;
-                 Html5.D.Form.input
+                 Html.D.Form.input
                    ~input_type:`Submit
-                   ~value:"Click" Html5.D.Form.string]])
+                   ~value:"Click" Html.D.Form.string]])
       >>= fun form ->
       return
         (html
@@ -1164,18 +1164,18 @@ let preappliedsuffix =
 (* URL with ? or / in data or paths *)
 
 let url_encoding =
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
   register_service
     ~path:["urlencoding&à/=é?abl<ah"]
     ~get_params:(suffix_prod (all_suffix "s//\\à") any)
     (fun (suf, l) () ->
       let ll =
         List.map
-          (fun (a,s) -> <:html5< <strong>($str:a$, $str:s$) </strong> >>) l
+          (fun (a,s) -> <:html< <strong>($str:a$, $str:s$) </strong> >>) l
       in
       let sl =
         List.map
-          (fun s -> <:html5< <strong>$str:s$ </strong> >>) suf
+          (fun s -> <:html< <strong>$str:s$ </strong> >>) suf
       in
       return
         (html
@@ -1423,7 +1423,7 @@ let cookiename = "c"
 
 let cookies2 = Http.service ["c";""] (suffix (all_suffix_string "s")) ()
 
-let _ = Eliom_registration.Html5.register cookies2
+let _ = Eliom_registration.Html.register cookies2
     (fun s () ->
       let now = Unix.time () in
       Eliom_state.set_cookie
@@ -1545,8 +1545,8 @@ let suffix3 =
                                   a^", "^(string_of_int b))]]])))
 
 let create_suffixform2 (suf1, (ii, ee)) =
-  let module Html5 = Eliom_content.Html5.F in
-  <:html5list< <p>Write a string:
+  let module Html = Eliom_content.Html.F in
+  <:htmllist< <p>Write a string:
       $Form.input ~input_type:`Text ~name:suf1 Form.string$ <br/>
       Write an int: $Form.input ~input_type:`Text ~name:ii Form.int$ <br/>
       $Form.input ~input_type:`Submit ~value:"Click" Form.string$</p> >>
@@ -1564,8 +1564,8 @@ let suffixform2 = register_service ["suffixform2"] unit
                  f ])))
 
 let create_suffixform3 ((suf1, (ii, ee)), (a, b)) =
-  let module Html5 = Eliom_content.Html5.F in
-    <:html5list< <p>Write a string:
+  let module Html = Eliom_content.Html.F in
+    <:htmllist< <p>Write a string:
       $Form.input ~input_type:`Text ~name:suf1 Form.string$ <br/>
       Write an int: $Form.input ~input_type:`Text ~name:ii Form.int$ <br/>
       Write an int: $Form.input ~input_type:`Text ~name:ee Form.int$ <br/>
@@ -1648,8 +1648,8 @@ let sendfile2 =
 *)
 
 let create_suffixform4 n =
-  let module Html5 = Eliom_content.Html5.F in
-    <:html5list< <p>Write the name of the file:
+  let module Html = Eliom_content.Html.F in
+    <:htmllist< <p>Write the name of the file:
       $Form.input ~input_type:`Text ~name:n Form.string$
       $Form.input ~input_type:`Submit ~value:"Click" Form.string$</p> >>
 
@@ -1668,13 +1668,13 @@ let any2 = register_service
     ~path:["any2"]
     ~get_params:(int "i" ** any)
   (fun (i,l) () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun (a,s) -> <:html5< <strong>($str:a$, $str:s$)</strong> >>) l
+        (fun (a,s) -> <:html< <strong>($str:a$, $str:s$)</strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1691,13 +1691,13 @@ let any3 = register_service
     ~path:["any3"]
     ~get_params:(int "i" ** any ** string "s")
   (fun (i,(l,s)) () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun (a,s) -> <:html5< <strong>($str:a$, $str:s$)</strong> >>) l
+        (fun (a,s) -> <:html< <strong>($str:a$, $str:s$)</strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1717,13 +1717,13 @@ let any4 = register_service
     ~path:["any4"]
     ~get_params:(suffix any)
   (fun l () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun (a,s) -> <:html5< <strong>($str:a$, $str:s$)</strong> >>) l
+        (fun (a,s) -> <:html< <strong>($str:a$, $str:s$)</strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1738,13 +1738,13 @@ let any5 = register_service
     ~path:["any5"]
     ~get_params:(suffix_prod (string "s") any)
   (fun (s, l) () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun (a,s) -> <:html5< <strong>($str:a$, $str:s$)</strong> >>) l
+        (fun (a,s) -> <:html< <strong>($str:a$, $str:s$)</strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1762,13 +1762,13 @@ let sufli = Http.service
 
 let _ = register sufli
   (fun l () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun (s, i) -> <:html5< <strong> $str:(s^string_of_int i)$ </strong> >>) l
+        (fun (s, i) -> <:html< <strong> $str:(s^string_of_int i)$ </strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1815,10 +1815,10 @@ let sufli2 = service
 let _ = register sufli2
   (fun (l, j) () ->
     let ll =
-      List.map (fun i -> <:html5< <strong> $str:(string_of_int i)$ </strong> >>) l
+      List.map (fun i -> <:html< <strong> $str:(string_of_int i)$ </strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1842,14 +1842,14 @@ let sufliopt = Http.service
 
 let _ = register sufliopt
   (fun l () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
         (function None -> pcdata "<none>"
-           | Some s -> <:html5< <strong> $str:s$ </strong> >>) l
+           | Some s -> <:html< <strong> $str:s$ </strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1873,14 +1873,14 @@ let sufliopt2 = Http.service
 
 let _ = register sufliopt2
   (fun l () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
         (function None -> pcdata "<none>"
-           | Some (s, ss) -> <:html5< <strong> ($str:s$, $str:ss$) </strong> >>) l
+           | Some (s, ss) -> <:html< <strong> ($str:s$, $str:ss$) </strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1902,13 +1902,13 @@ let sufset = register_service
     ~path:["sufset"]
     ~get_params:(suffix (Eliom_parameter.set string "s"))
   (fun l () ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun s -> <:html5< <strong>$str:s$</strong> >>) l
+        (fun s -> <:html< <strong>$str:s$</strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -1999,13 +1999,13 @@ let any = register_post_service
     ~fallback:coucoucou
     ~post_params:any
   (fun () l ->
-  let module Html5 = Eliom_content.Html5.F in
+  let module Html = Eliom_content.Html.F in
     let ll =
       List.map
-        (fun (a,s) -> <:html5< <strong>($str:a$, $str:s$)</strong> >>) l
+        (fun (a,s) -> <:html< <strong>($str:a$, $str:s$)</strong> >>) l
     in
     return
-  <:html5< <html>
+  <:html< <html>
        <head><title></title></head>
        <body>
        <p>
@@ -2061,8 +2061,8 @@ let get_param_service =
 let uploadgetform = register_service ["uploadget"] unit
   (fun () () ->
     let f =
-(* ARG        (post_form ~a:[(Html5.F.a_enctype "multipart/form-data")] fichier2 *)
-     (Form.get_form ~a:[(Html5.F.a_enctype "multipart/form-data")] ~service:get_param_service
+(* ARG        (post_form ~a:[(Html.F.a_enctype "multipart/form-data")] fichier2 *)
+     (Form.get_form ~a:[(Html.F.a_enctype "multipart/form-data")] ~service:get_param_service
      (*post_form my_service_with_post_params        *)
         (fun (str, file) ->
           [p [pcdata "Write a string: ";
@@ -2142,23 +2142,23 @@ register_service
 let create_form =
   (fun (number_name, (bool1name, bool2name)) ->
     [p [pcdata "New timeout: ";
-        Html5.D.Form.input ~input_type:`Text ~name:number_name
-          Html5.D.Form.int;
+        Html.D.Form.input ~input_type:`Text ~name:number_name
+          Html.D.Form.int;
         br ();
         pcdata "Check the box if you want to recompute all timeouts: ";
-        Html5.D.Form.bool_checkbox_one ~name:bool1name ();
+        Html.D.Form.bool_checkbox_one ~name:bool1name ();
         br ();
         pcdata "Check the box if you want to override configuration file: ";
-        Html5.D.Form.bool_checkbox_one ~name:bool2name ();
-        Html5.D.Form.input ~input_type:`Submit ~value:"Submit"
-          Html5.D.Form.string]])
+        Html.D.Form.bool_checkbox_one ~name:bool2name ();
+        Html.D.Form.input ~input_type:`Submit ~value:"Submit"
+          Html.D.Form.string]])
 
 let set_timeout_form =
   register_service
     ["set_timeout"]
     unit
     (fun () () ->
-      let f = Html5.D.Form.get_form set_timeout create_form in
+      let f = Html.D.Form.get_form set_timeout create_form in
       return
         (html
            (head (title (pcdata "")) [])
@@ -2186,7 +2186,7 @@ let sfail =
 (* 2011/08/02 Vincent - Volatile group data
    removing group data or not when no session in the group?*)
 (*zap* *)
-open Html5.F
+open Html.F
 
 (*zap* *)
 let scope_hierarchy = Eliom_common.create_scope_hierarchy "session_group_data_example_state"
@@ -2219,9 +2219,9 @@ let disconnect_action =
     (fun () () -> Eliom_state.discard ~scope:session ())
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
-                    ~input_type:`Submit ~value:s Html5.D.Form.string]]) ()
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
+                    ~input_type:`Submit ~value:s Html.D.Form.string]]) ()
 
 (* The following eref is true if the connection has action failed: *)
 let bad_user = Eliom_reference.eref ~scope:Eliom_common.request_scope false
@@ -2239,12 +2239,12 @@ let change_gd =
 (* new login box:                                           *)
 
 let login_box session_expired bad_u action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
-         Html5.D.Form.input ~input_type:`Text ~name:loginname
-           Html5.D.Form.string]
+         Html.D.Form.input ~input_type:`Text ~name:loginname
+           Html.D.Form.string]
       in
       [p (if bad_u
         then (pcdata "Wrong user")::(br ())::l
@@ -2277,11 +2277,11 @@ let connect_example_handler () () =
                   (match my_group_data with
                     | None -> pcdata "You have no group data."
                     | Some i -> pcdata ("Your group data is "^string_of_int i^"."))];
-               Html5.D.Form.post_form change_gd
-                 (fun () -> [p [Html5.D.Form.input
+               Html.D.Form.post_form change_gd
+                 (fun () -> [p [Html.D.Form.input
                                   ~input_type:`Submit
                                    ~value:"Change group data"
-                                   Html5.D.Form.string]]) ();
+                                   Html.D.Form.string]]) ();
                p [pcdata "Check that several sessions have the same group data."];
                p [pcdata "Volatile group data are currently discarded when all group disappear. This is weird and not coherent with persistent group data. But I don't really see a correct use of volatile group data. Is there any? And there is a risk of memory leak if we keep them. Besides, volatile sessions are (hopefully) going to disappear soon."];
                disconnect_box "Close session"]
@@ -2317,7 +2317,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:connect_example_gd connect_example_handler;
+  Eliom_registration.Html.register ~service:connect_example_gd connect_example_handler;
   Eliom_registration.Any.register ~service:connect_action connect_action_handler
 
 
@@ -2326,7 +2326,7 @@ let () =
 (* 2011/08/02 Vincent - Persistent group data
    removing group data or not when no session in the group? *)
 (*zap* *)
-open Html5.F
+open Html.F
 
 (*zap* *)
 let scope_hierarchy = Eliom_common.create_scope_hierarchy "pers_session_group_data_example_state"
@@ -2359,10 +2359,10 @@ let disconnect_action =
     (fun () () -> Eliom_state.discard ~scope:session ())
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action
-    (fun _ -> [p [Html5.D.Form.input
+  Html.D.Form.post_form disconnect_action
+    (fun _ -> [p [Html.D.Form.input
                     ~input_type:`Submit ~value:s
-                    Html5.D.Form.string]]) ()
+                    Html.D.Form.string]]) ()
 
 (* The following eref is true if the connection has action failed: *)
 let bad_user = Eliom_reference.eref ~scope:Eliom_common.request_scope false
@@ -2381,12 +2381,12 @@ let change_gd =
 (* new login box:                                           *)
 
 let login_box session_expired bad_u action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
-         Html5.D.Form.input ~input_type:`Text ~name:loginname
-           Html5.D.Form.string]
+         Html.D.Form.input ~input_type:`Text ~name:loginname
+           Html.D.Form.string]
       in
       [p (if bad_u
         then (pcdata "Wrong user")::(br ())::l
@@ -2420,11 +2420,11 @@ let connect_example_handler () () =
                     | None -> pcdata "You have no group data."
                     | Some i -> pcdata ("Your group data is "^string_of_int i^"."));
                  ];
-               Html5.D.Form.post_form change_gd
-                 (fun () -> [p [Html5.D.Form.input
+               Html.D.Form.post_form change_gd
+                 (fun () -> [p [Html.D.Form.input
                                    ~input_type:`Submit
                                    ~value:"Change group data"
-                                   Html5.D.Form.string]]) ();
+                                   Html.D.Form.string]]) ();
                p [pcdata "Check that several sessions have the same group data."];
                p [pcdata "Check that persistent group data do not disappear when all sessions from the group are closed."];
                p [pcdata "Persistent group data are used as a basic database, for example to store user information (email, etc)."];
@@ -2461,7 +2461,7 @@ let connect_action_handler () login =
 (* Registration of main services:                           *)
 
 let () =
-  Eliom_registration.Html5.register ~service:connect_example_pgd connect_example_handler;
+  Eliom_registration.Html.register ~service:connect_example_pgd connect_example_handler;
   Eliom_registration.Any.register ~service:connect_action connect_action_handler
 
 
@@ -2485,7 +2485,7 @@ let noreload =
         (html
          (head (title (pcdata "counter")) [])
          (body [p [pcdata (string_of_int (!noreload_ref)); br ();
-                   Html5.D.a ~service:noreload_action
+                   Html.D.a ~service:noreload_action
                      [pcdata "Click to increment the counter."] ();
                    br ();
                    pcdata "You should not see the result if you do not reload the page."
@@ -2510,7 +2510,7 @@ let neopt_handler ((a, b), (c, d)) () =
 
 
 let neopt_service =
-  Eliom_registration.Html5.register_service
+  Eliom_registration.Html.register_service
     ~path: ["neopt"]
     ~get_params: (suffix_prod
       (Eliom_parameter.string "a" ** neopt (Eliom_parameter.int "b"))
@@ -2522,27 +2522,27 @@ let neopt_form ((e_a, e_b), (e_c, e_d)) =
   [
   fieldset
     [
-    label ~a:[a_for "e_a"] [pcdata "Enter string 'a':"];
-    Html5.D.Form.input ~a:[a_id "e_a"] ~input_type:`Text ~name:e_a
-      Html5.D.Form.string;
+    label ~a:[a_label_for "e_a"] [pcdata "Enter string 'a':"];
+    Html.D.Form.input ~a:[a_id "e_a"] ~input_type:`Text ~name:e_a
+      Html.D.Form.string;
     br ();
 
-    label ~a:[a_for "e_b"] [pcdata "Enter int 'b' (neopt):"];
-    Html5.D.Form.input ~a:[a_id "e_b"] ~input_type:`Text ~name:e_b
-      Html5.D.Form.int;
+    label ~a:[a_label_for "e_b"] [pcdata "Enter int 'b' (neopt):"];
+    Html.D.Form.input ~a:[a_id "e_b"] ~input_type:`Text ~name:e_b
+      Html.D.Form.int;
     br ();
 
-    label ~a:[a_for "e_c"] [pcdata "Enter float 'c' (neopt):"];
-    Html5.D.Form.input ~a:[a_id "e_c"] ~input_type:`Text ~name:e_c
-      Html5.D.Form.float;
+    label ~a:[a_label_for "e_c"] [pcdata "Enter float 'c' (neopt):"];
+    Html.D.Form.input ~a:[a_id "e_c"] ~input_type:`Text ~name:e_c
+      Html.D.Form.float;
     br ();
 
-    label ~a:[a_for "e_d"] [pcdata "Enter string 'd' (neopt):"];
-    Html5.D.Form.input ~a:[a_id "e_d"] ~input_type:`Text ~name:e_d
-      Html5.D.Form.string;
+    label ~a:[a_label_for "e_d"] [pcdata "Enter string 'd' (neopt):"];
+    Html.D.Form.input ~a:[a_id "e_d"] ~input_type:`Text ~name:e_d
+      Html.D.Form.string;
     br ();
 
-    Html5.D.Form.button_no_value ~button_type:`Submit [pcdata "Apply"];
+    Html.D.Form.button_no_value ~button_type:`Submit [pcdata "Apply"];
     ]
   ]
 
@@ -2554,29 +2554,29 @@ let main_neopt_handler () () =
       (body  [
         p  [
           pcdata "Here's a ";
-          Html5.D.a neopt_service [pcdata "link"] (("foo", None), (None, None));
+          Html.D.a neopt_service [pcdata "link"] (("foo", None), (None, None));
           pcdata " to the neopt service"
           ];
         p  [
           pcdata "Here's another ";
-          Html5.D.a neopt_service [pcdata "link"] (("foo", Some 1), (None, None));
+          Html.D.a neopt_service [pcdata "link"] (("foo", Some 1), (None, None));
           pcdata " to the neopt service"
           ];
         p  [
           pcdata "Here's yet another ";
-          Html5.D.a neopt_service [pcdata "link"] (("foo", None), (Some 2.0, Some "Olá!"));
+          Html.D.a neopt_service [pcdata "link"] (("foo", None), (Some 2.0, Some "Olá!"));
           pcdata " to the neopt service"
           ];
         p  [
           pcdata "Here's the final ";
-          Html5.D.a neopt_service [pcdata "link"] (("foo", Some 1), (Some 2.0, Some "Olá!"));
+          Html.D.a neopt_service [pcdata "link"] (("foo", Some 1), (Some 2.0, Some "Olá!"));
           pcdata " to the neopt service"
           ];
-        Html5.D.Form.get_form neopt_service neopt_form;
+        Html.D.Form.get_form neopt_service neopt_form;
         ]))
 
 let main_neopt_service =
-  Eliom_registration.Html5.register_service
+  Eliom_registration.Html.register_service
     ~path: ["neopt0"]
     ~get_params: Eliom_parameter.unit
     main_neopt_handler

--- a/tests/testsuite/eliom_testsuite3.eliom
+++ b/tests/testsuite/eliom_testsuite3.eliom
@@ -54,7 +54,7 @@ whole application.
 (* for client side only, one can use : {client{ ... }} and for shared code, one
 * can place {shared{ ... }} *)
 {shared{
-open Html5.F
+open Html.F
 }}
 
 (****** server only *******)
@@ -104,10 +104,10 @@ let register_ocaml_post_coservice' ?scope ~post_params f =
 
 (*wiki* Now I can define my first service belonging to that application: *wiki*)
 
-let header_id : Html5_types.body_content_fun Html5.Id.id =
-  Html5.Id.new_elt_id ~global:true ()
+let header_id : Html_types.body_content_fun Html.Id.id =
+  Html.Id.new_elt_id ~global:true ()
 let header () =
-  Html5.Id.create_named_elt ~id:header_id
+  Html.Id.create_named_elt ~id:header_id
     (p [pcdata "Random value in the container: ";
         (span [pcdata (string_of_int (Random.int 1000))]);
         br ();
@@ -128,7 +128,7 @@ let make_page ?(css = []) content =
         div content ] )
 
 {client{
-  module My_appl = Eliom_registration.Html5
+  module My_appl = Eliom_registration.Html
 }}
 
 {server{ (* note that {server{ ... }} is optional. *)
@@ -181,7 +181,7 @@ let eliom_caml_tree =
     ~post_params:unit
     (fun () () ->
       Lwt.return
-        Html5.F.(([div [p [pcdata "Coucou, voici un Div construit avec TyXML sur le serveur"];
+        Html.F.(([div [p [pcdata "Coucou, voici un Div construit avec TyXML sur le serveur"];
                         ul [li [pcdata "item1"];
                             li [pcdata "item2"];
                             li [pcdata "item3"];
@@ -191,7 +191,7 @@ let eliom_caml_tree =
                         p ~a:[a_onclick
                                  {{ fun _ -> Dom_html.window##alert(Js.string "clicked!") }}]
                           [pcdata "I am a clickable paragraph"];
-                       ]] : Html5_types.div elt list)))
+                       ]] : Html_types.div elt list)))
 
 ;; (* This ";;" is necessary in order to have the "shared" following entry being
       parsed as "str_item" (instead of "expr"). This is Camlp4 related, it may
@@ -306,7 +306,7 @@ where and {{{id}}} an identifier for the value.
                             () () >|= fun blocks ->
                               List.iter
                                 (Dom.appendChild Dom_html.document##body)
-                                (List.map Html5.To_dom.of_element blocks)
+                                (List.map Html.To_dom.of_element blocks)
                           with
                             | e -> Dom_html.window##alert(Js.string (Printexc.to_string e));
                               Lwt.return ()
@@ -320,13 +320,13 @@ where and {{{id}}} an identifier for the value.
 ====Refering to parts of the page in client side code
 *wiki*)
 
-          (let container = Html5.D.ul [ item () ; item () ; item ()] in
+          (let container = Html.D.ul [ item () ; item () ; item ()] in
            div [p ~a:[(*zap* *)a_class ["clickable"];(* *zap*)
                                a_onclick {{
                                  fun _ ->
                                    Dom.appendChild
-                                     (Html5.To_dom.of_ul %container) (* node is the wrapper keyword for HTML5.M nodes. *)
-                                     (Html5.To_dom.of_li (item ()))
+                                     (Html.To_dom.of_ul %container) (* node is the wrapper keyword for HTML5.M nodes. *)
+                                     (Html.To_dom.of_li (item ()))
                                }}
                   ]
                   [pcdata "Click here to add an item below with the current version of OCaml."];
@@ -362,13 +362,13 @@ where and {{{id}}} an identifier for the value.
                   let eliomclient1 = %eliomclient1 in
                   (Dom.appendChild
                      (Dom_html.document##body)
-                     (Html5.To_dom.of_p
-                        (p [Html5.D.a
+                     (Html.To_dom.of_p
+                        (p [Html.D.a
                               ~service:coucou
                               [pcdata "An external link generated client side"]
                               ();
                             pcdata ", ";
-                            Html5.D.a
+                            Html.D.a
                               (*zap* *)~a:[a_class ["clickable"]](* *zap*)
                               ~service:eliomclient1
                               [pcdata "another, inside the application, "]
@@ -559,8 +559,8 @@ let default_no_appl =
         let global_data_path = None
       end)
   in
-  let open Html5.D in
-  let id = Html5.Id.new_elt_id ~global:true () in
+  let open Html.D in
+  let id = Html.Id.new_elt_id ~global:true () in
   let unique_content =
     let counter = ref 0 in
     fun () ->
@@ -576,14 +576,14 @@ let default_no_appl =
          Eliom_config.(set_default_links_xhr (not (get_default_links_xhr ())));
          Lwt.return ()) in
   let handler () () =
-    let global_elt = Html5.Id.create_named_elt ~id (div [pcdata "Named unique content: "; unique_content ()]) in
+    let global_elt = Html.Id.create_named_elt ~id (div [pcdata "Named unique content: "; unique_content ()]) in
     Lwt.return
       (html
         (head (title (pcdata "default_link_xhr")) [])
         (body [
           global_elt;
           div [pcdata "Unique content: "; unique_content ()];
-          div Html5.D.([
+          div Html.D.([
             a ~service:get_service [pcdata "Link to self"] ();
             Form.get_form ~service:get_service
               (fun () -> [
@@ -678,7 +678,7 @@ let uri_test =
     ~get_params:unit
     (fun () () ->
       let div =
-        Html5.D.div [
+        Html.D.div [
           p [pcdata "The following URLs are computed either on server or client side. They should be equal."];
           p [pcdata (Eliom_uri.make_string_uri ~service:eliomclient1 ())];
         ]
@@ -686,8 +686,8 @@ let uri_test =
       ignore {unit{
         Eliom_client.onload
           (fun _->
-             Dom.appendChild (Html5.To_dom.of_div %div)
-               (Html5.To_dom.of_p
+             Dom.appendChild (Html.To_dom.of_div %div)
+               (Html.To_dom.of_p
                  (p [pcdata (Eliom_uri.make_string_uri ~service:%eliomclient1 ())])))
       }};
       Lwt.return (make_page [div])
@@ -696,13 +696,13 @@ let uri_test =
 {client{
   let put n f =
     Printf.ksprintf (fun s ->
-      Dom.appendChild (Html5.To_dom.of_element n)
-        (Html5.To_dom.of_p (p [pcdata s; br ()]))) f
+      Dom.appendChild (Html.To_dom.of_element n)
+        (Html.To_dom.of_p (p [pcdata s; br ()]))) f
 
   let put_li n f =
     Printf.ksprintf (fun s ->
-      Dom.appendChild (Html5.To_dom.of_element n)
-        (Html5.To_dom.of_li (li [pcdata s]))) f
+      Dom.appendChild (Html.To_dom.of_element n)
+        (Html.To_dom.of_li (li [pcdata s]))) f
 }}
 
 let wrapping_big_values = My_appl.register_service
@@ -710,7 +710,7 @@ let wrapping_big_values = My_appl.register_service
   ~get_params:(int "size")
   (fun size () ->
     let div =
-      Html5.D.div
+      Html.D.div
         [pcdata (Printf.sprintf "there should be a line with: list length: %i"
                    size);
          br ()] in
@@ -751,8 +751,8 @@ let e' = React.E.map (fun i -> Printf.printf "event: %i\n%!" i) e
 let rec rec_list_react = (react_up,42)::rec_list_react
 
 
-let global_div = Html5.Id.create_global_elt (div [pcdata "global div"])
-let other_global_div = Html5.Id.create_global_elt (div [pcdata "other global div"])
+let global_div = Html.Id.create_global_elt (div [pcdata "global div"])
+let other_global_div = Html.Id.create_global_elt (div [pcdata "other global div"])
 
 let wrapping1 = Eliom_service.App.service
     ~path:["wrapping1"]
@@ -770,7 +770,7 @@ let gc_service =
 let () =
   My_appl.register wrapping1
     (fun () () ->
-      let list = Html5.D.ul [] in
+      let list = Html.D.ul [] in
 
       (* Simple unwrapping *)
       ignore {unit{
@@ -788,7 +788,7 @@ let () =
       }};
 
       (* Node unwrapping and Caml servive *)
-      let content = Html5.D.div [] in
+      let content = Html.D.div [] in
       let unwrapping_div =
 	div ~a:[ a_onclick {{
                    fun _ ->
@@ -799,7 +799,7 @@ let () =
                             ~service:v.Wrapping_test.v_service
                             () ()
                         in
-                        List.iter (Html5.Manip.appendChild %content) blocks;
+                        List.iter (Html.Manip.appendChild %content) blocks;
                         Lwt.return ())
 	          }} ]
           [pcdata "Click here to append some content ";
@@ -852,15 +852,15 @@ let entity =
     ~path:["entity"]
     ~get_params:unit
     (fun () () ->
-       let d = Eliom_content.Html5.D.div [] in
+       let d = Eliom_content.Html.D.div [] in
        ignore {unit{
-           Eliom_content.Html5.Manip.appendChild %d (Eliom_content.Html5.F.entity "#947")
+           Eliom_content.Html.Manip.appendChild %d (Eliom_content.Html.F.entity "#947")
          }} ;
        Lwt.return
          (Eliom_tools.F.html
             ~title:"bug_entity"
             ~css:[["css";"bug_entity.css"]]
-            Html5.F.(body [
+            Html.F.(body [
                 h2 [pcdata "Welcome from Eliom's distillery!"];
                 entity "#946" ;
                 d
@@ -925,7 +925,7 @@ let comet1 =
            div
              [pcdata "To fully understand the meaning of the public channel, \
                       use a couple browsers on this page."; br ();
-              Html5.D.a ~service:Eliom_testsuite_base.main [pcdata "go outside of application"] ()] ;
+              Html.D.a ~service:Eliom_testsuite_base.main [pcdata "go outside of application"] ()] ;
          ])
     )
 
@@ -1106,37 +1106,37 @@ let comet_wrapping =
     ~path:["comet_wrapping"]
     ~get_params:unit
     (fun () () ->
-      let node = Html5.D.div [pcdata "node created on server side"] in
+      let node = Html.D.div [pcdata "node created on server side"] in
       let service_stream,push_service = Lwt_stream.create () in
       push_service (Some Eliom_testsuite1.coucou);
       let c_service = Eliom_comet.Channel.create service_stream in
       let xml_stream,push_xml = Lwt_stream.create () in
       push_xml (Some (div [pcdata "basic xml wrapping";node]));
       push_xml (Some
-                  (div [Html5.D.a ~service:Eliom_testsuite1.coucou
+                  (div [Html.D.a ~service:Eliom_testsuite1.coucou
                      [pcdata "xml external link wrapping"] ()]));
       push_xml (Some
-                  (div [Html5.D.a ~service:comet1
+                  (div [Html.D.a ~service:comet1
                            [pcdata "xml internal link wrapping"] ();
                         br ();
                         pcdata "this link must not stop the process! (same random number in the container)."]));
       let c_xml = Eliom_comet.Channel.create xml_stream in
-      let div_link = Html5.D.div [] in
+      let div_link = Html.D.div [] in
 
       ignore {unit{
         Eliom_client.onload
          (fun _ ->
             ignore (Lwt_stream.iter
             (fun service ->
-              Dom.appendChild (Html5.To_dom.of_element %div_link)
-                (Html5.To_dom.of_element
-                   ( Html5.D.a ~service
+              Dom.appendChild (Html.To_dom.of_element %div_link)
+                (Html.To_dom.of_element
+                   ( Html.D.a ~service
                        [pcdata "service wrapping"] ()))
             ) %c_service);
             ignore (Lwt_stream.iter
                       (fun xml ->
-                        Dom.appendChild (Html5.To_dom.of_element %div_link)
-                          (Html5.To_dom.of_element xml)
+                        Dom.appendChild (Html.To_dom.of_element %div_link)
+                          (Html.To_dom.of_element xml)
                       ) %c_xml))
         }};
 
@@ -1153,12 +1153,12 @@ let comet_signal_maker name time =
     ~path:[name]
     ~get_params:unit
     (fun () () ->
-      let time_div = Html5.D.div [] in
+      let time_div = Html.D.div [] in
       ignore {unit{
       Eliom_client.onload
           (fun _ ->
             Lwt_react.S.keep
-            (React.S.map (fun t -> (Html5.To_dom.of_div %time_div)##innerHTML <-
+            (React.S.map (fun t -> (Html.To_dom.of_div %time_div)##innerHTML <-
               Js.string (string_of_float t)) %time))
         }};
        Lwt.return (make_page [
@@ -1188,8 +1188,8 @@ let comet_message_board_maker name message_bus cb =
     (fun () () ->
        cb ();
        Lwt.return (
-         let container = Html5.D.ul [li [em [pcdata "This is the message board"]]] in
-         let field = Html5.D.input ~a:[a_id "msg"; a_name "message"; a_input_type `Text] () in
+         let container = Html.D.ul [li [em [pcdata "This is the message board"]]] in
+         let field = Html.D.input ~a:[a_id "msg"; a_name "message"; a_input_type `Text] () in
          ignore {unit{
          Eliom_client.onload
              (fun _ ->
@@ -1199,14 +1199,14 @@ let comet_message_board_maker name message_bus cb =
                  Lwt.catch (fun () ->
                    Lwt_stream.iter_s
                      (fun msg ->
-                       Dom.appendChild (Html5.To_dom.of_element %container)
-                         (Html5.To_dom.of_li (li [pcdata msg]));
+                       Dom.appendChild (Html.To_dom.of_element %container)
+                         (Html.To_dom.of_li (li [pcdata msg]));
                        Lwt.return ())
                      (Eliom_bus.stream %message_bus))
                    (function
                      | Eliom_comet.Channel_full ->
-                       Dom.appendChild (Html5.To_dom.of_element %container)
-                         (Html5.To_dom.of_li (li [pcdata "channel full, no more messages"]));
+                       Dom.appendChild (Html.To_dom.of_element %container)
+                         (Html.To_dom.of_li (li [pcdata "channel full, no more messages"]));
                        Lwt.return ()
                      | exn ->
                        Lwt_log.ign_debug ~exn "comet exception";
@@ -1241,7 +1241,7 @@ let comet_message_board_maker name message_bus cb =
          (make_page [ h2 [pcdata "Message board"];
            form ~a:[a_action (Xml.uri_of_string "")] [div [field; go]];
            container; br ();
-           Html5.D.a ~service:Eliom_testsuite_base.main [pcdata "go outside of application"] ();
+           Html.D.a ~service:Eliom_testsuite_base.main [pcdata "go outside of application"] ();
          ]))
     )
 
@@ -1283,7 +1283,7 @@ let bus_multiple_times =
     ~path:["multiple_bus"]
     ~get_params:unit
     (fun () () ->
-      let container = Html5.D.ul [li [em [pcdata "there will be lines"]]] in
+      let container = Html.D.ul [li [em [pcdata "there will be lines"]]] in
       let onload s message_bus =
         ignore {unit{
           Eliom_client.onload
@@ -1292,14 +1292,14 @@ let bus_multiple_times =
                 try_lwt
                   Lwt_stream.iter_s
                     (fun msg ->
-                      Dom.appendChild (Html5.To_dom.of_element %container)
-                        (Html5.To_dom.of_li (li [pcdata (Printf.sprintf "stream %s: %i" %s msg)]));
+                      Dom.appendChild (Html.To_dom.of_element %container)
+                        (Html.To_dom.of_li (li [pcdata (Printf.sprintf "stream %s: %i" %s msg)]));
                       Lwt.return ())
                     (Eliom_bus.stream %message_bus)
                  with
                    | Eliom_comet.Channel_full ->
-                     Dom.appendChild (Html5.To_dom.of_element %container)
-                       (Html5.To_dom.of_li (li [pcdata "channel full, no more messages"]));
+                     Dom.appendChild (Html.To_dom.of_element %container)
+                       (Html.To_dom.of_li (li [pcdata "channel full, no more messages"]));
                      Lwt.return ()
                    | e -> Lwt.fail e;
               in ())
@@ -1431,17 +1431,17 @@ let service_no_style =
     ()
 
 let page_css_test () =
-  [Html5.D.a ~service:service_style1
+  [Html.D.a ~service:service_style1
       [pcdata "same page with style 1"] (); br ();
-   Html5.D.a ~service:service_style2
+   Html.D.a ~service:service_style2
      [pcdata "same page with style 2"] (); br ();
-   Html5.D.a ~service:service_no_style
+   Html.D.a ~service:service_no_style
      [pcdata "same page with no style"] (); br ();
    div ~a:[a_class ["some_class"];] [pcdata "div with style"]]
 
 let make_css_link file =
-  Html5.D.css_link
-    (Html5.D.make_uri
+  Html.D.css_link
+    (Html.D.make_uri
        ~service:(Eliom_service.static_dir ()) [file]) ()
 
 let () =
@@ -1471,7 +1471,7 @@ let event2_service =
     ~get_params:Eliom_parameter.unit
     (fun () () ->
 
-      let make_target s = Html5.D.p [Html5.F.Raw.a [pcdata s]] in
+      let make_target s = Html.D.p [Html.F.Raw.a [pcdata s]] in
       let target1 = make_target "Un seul clic" in
       let target2 = make_target "Annuler le précédent" in
       let target3 = make_target "Drag vers la ligne au dessus une seule fois" in
@@ -1489,69 +1489,69 @@ let event2_service =
       let target15 = make_target "Annuler le précédent" in
       let target16 = make_target "Mouse over change color" in
       let target17 = make_target "Mouse wheel (browser dependant - test in several browsers)" in
-      let target18 = Html5.D.textarea ~a:[a_name "a"] (pcdata "") in
+      let target18 = Html.D.textarea ~a:[a_name "a"] (pcdata "") in
       let target19 = make_target "If you click very quickly after having entered a letter below, my handler (short) will occure, and the long handler for the keypress will be cancelled (event if it already started)." in
-      let target20 = Html5.D.textarea ~a:[a_name "b"] (pcdata "") in
+      let target20 = Html.D.textarea ~a:[a_name "b"] (pcdata "") in
       let target21 = make_target "If you click very quickly after having entered a letter below, my handler will not occure because the long handler for the keypress below is detached." in
 
-      let targetresult = Html5.D.p [] in
+      let targetresult = Html.D.p [] in
       ignore {unit{
         Eliom_client.onload
           (fun _ ->
-            let targetresult = (Html5.To_dom.of_p %targetresult) in
+            let targetresult = (Html.To_dom.of_p %targetresult) in
 
             let handler ev =
               ignore (targetresult##appendChild
-                        ((Html5.To_dom.of_element (Html5.F.pcdata " plip") :> Dom.node Js.t)));
+                        ((Html.To_dom.of_element (Html.F.pcdata " plip") :> Dom.node Js.t)));
               Lwt.return ()
             in
             let handler_long ev =
               Lwt_js.sleep 0.7 >>= fun () ->
               ignore (targetresult##appendChild
-                        ((Html5.To_dom.of_element (Html5.F.pcdata " plop") :> Dom.node Js.t)));
+                        ((Html.To_dom.of_element (Html.F.pcdata " plop") :> Dom.node Js.t)));
               Lwt.return ()
             in
             let handler1 ev _ = handler ev in
             let handler_long1 ev _ = handler_long ev in
-            let c = click (Html5.To_dom.of_p %target1) >>= handler in
-            ignore (click (Html5.To_dom.of_p %target2) >|= fun _ ->
+            let c = click (Html.To_dom.of_p %target1) >>= handler in
+            ignore (click (Html.To_dom.of_p %target2) >|= fun _ ->
                            Lwt.cancel c);
             ignore
-              (mousedown (Html5.To_dom.of_p %target3) >>= fun ev ->
+              (mousedown (Html.To_dom.of_p %target3) >>= fun ev ->
                Dom.preventDefault ev;
-               mouseup (Html5.To_dom.of_p %target2) >>= handler);
-            let c = clicks (Html5.To_dom.of_p %target4) handler_long1 in
+               mouseup (Html.To_dom.of_p %target2) >>= handler);
+            let c = clicks (Html.To_dom.of_p %target4) handler_long1 in
             ignore
-              (click (Html5.To_dom.of_p %target5) >|= fun _ ->
+              (click (Html.To_dom.of_p %target5) >|= fun _ ->
                Lwt.cancel c);
             ignore
-              (click (Html5.To_dom.of_p %target6) >>= handler >>= fun () ->
-               click (Html5.To_dom.of_p %target6) >>= handler);
+              (click (Html.To_dom.of_p %target6) >>= handler >>= fun () ->
+               click (Html.To_dom.of_p %target6) >>= handler);
             ignore
-              (clicks (Html5.To_dom.of_p %target7)
-                 (fun _ _ -> click (Html5.To_dom.of_p %target7) >>= handler));
+              (clicks (Html.To_dom.of_p %target7)
+                 (fun _ _ -> click (Html.To_dom.of_p %target7) >>= handler));
             ignore
-              (click (Html5.To_dom.of_p %target8) >>= fun _ ->
-               clicks (Html5.To_dom.of_p %target8) handler1);
+              (click (Html.To_dom.of_p %target8) >>= fun _ ->
+               clicks (Html.To_dom.of_p %target8) handler1);
             let c =
-              Lwt.pick [click (Html5.To_dom.of_p %target9) >>= handler;
-                        click (Html5.To_dom.of_p %target10) >>= handler]
+              Lwt.pick [click (Html.To_dom.of_p %target9) >>= handler;
+                        click (Html.To_dom.of_p %target10) >>= handler]
             in
-            ignore (click (Html5.To_dom.of_p %target11) >|= fun _ ->
+            ignore (click (Html.To_dom.of_p %target11) >|= fun _ ->
                     Lwt.cancel c);
-            let c = mousedowns (Html5.To_dom.of_p %target12)
+            let c = mousedowns (Html.To_dom.of_p %target12)
               (fun _ _ -> Lwt.pick [(mouseup Dom_html.document >|= fun _ -> ());
                                      mousemoves Dom_html.document handler1])
             in
-            ignore (click (Html5.To_dom.of_p %target13) >|= fun _ ->
+            ignore (click (Html.To_dom.of_p %target13) >|= fun _ ->
                     Lwt.cancel c);
-            let c = mousedowns (Html5.To_dom.of_p %target14)
+            let c = mousedowns (Html.To_dom.of_p %target14)
               (fun _ _ -> Lwt.pick [(mouseup Dom_html.document >|= fun _ -> ());
                                      mousemoves Dom_html.document handler_long1])
             in
-            ignore (click (Html5.To_dom.of_p %target15) >|= fun _ ->
+            ignore (click (Html.To_dom.of_p %target15) >|= fun _ ->
                     Lwt.cancel c);
-            let t16 = Html5.To_dom.of_p %target16 in
+            let t16 = Html.To_dom.of_p %target16 in
             ignore (mouseovers t16
                       (fun _ _ ->
                         t16##style##backgroundColor <- Js.string "red";
@@ -1560,21 +1560,21 @@ let event2_service =
                       (fun _ _ ->
                         t16##style##backgroundColor <- Js.string "";
                         Lwt.return ()));
-            ignore (mousewheels (Html5.To_dom.of_p %target17)
+            ignore (mousewheels (Html.To_dom.of_p %target17)
                       (fun (_, (dx, dy)) _ ->
                         ignore (targetresult##appendChild
-                                  ((Html5.To_dom.of_element
-                                      (Html5.F.pcdata
+                                  ((Html.To_dom.of_element
+                                      (Html.F.pcdata
                                       (Printf.sprintf "(%d, %d)" dx dy)) :> Dom.node Js.t)));
                         Lwt.return ()));
-            ignore (Lwt.pick [(keypress (Html5.To_dom.of_textarea %target18) >>=
+            ignore (Lwt.pick [(keypress (Html.To_dom.of_textarea %target18) >>=
                                handler_long);
-                               click (Html5.To_dom.of_p %target19) >>=
+                               click (Html.To_dom.of_p %target19) >>=
                                handler
                              ]);
-            ignore (Lwt.pick [(keypress (Html5.To_dom.of_textarea %target20) >>=
+            ignore (Lwt.pick [(keypress (Html.To_dom.of_textarea %target20) >>=
                                fun _ -> ignore (handler_long ()); Lwt.return () );
-                               click (Html5.To_dom.of_p %target21) >>=
+                               click (Html.To_dom.of_p %target21) >>=
                                handler
                              ]))
 
@@ -1655,16 +1655,16 @@ let tsession_data_example_handler _ _  =
         | Eliom_state.Data name ->
           p [pcdata ("Hello "^name);
              br ();
-             Html5.D.a
+             Html.D.a
                tsession_data_example_close
                [pcdata "close session"] ()]
         | Eliom_state.Data_session_expired
         | Eliom_state.No_data ->
-          Html5.D.Form.post_form
+          Html.D.Form.post_form
             tsession_data_example_with_post_params
             (fun login ->
               [p [pcdata "login: ";
-                  Html5.D.Form.input Html5.D.Form.string
+                  Html.D.Form.input Html.D.Form.string
                     ~input_type:`Text ~name:login]]) ()
     ])
 
@@ -1680,7 +1680,7 @@ let tsession_data_example_with_post_params_handler _ login =
   return
     (make_page [p [pcdata ("Welcome " ^ login ^ ". You are now connected.");
         br ();
-        Html5.D.a tsession_data_example [pcdata "Try again"] ()
+        Html.D.a tsession_data_example [pcdata "Try again"] ()
        ]])
 
 
@@ -1699,7 +1699,7 @@ let tsession_data_example_close_handler () () =
         | Eliom_state.Data_session_expired -> p [pcdata "Your session has expired."]
         | Eliom_state.No_data -> p [pcdata "You were not connected."]
         | Eliom_state.Data _ -> p [pcdata "You have been disconnected."]);
-      p [Html5.D.a tsession_data_example [pcdata "Retry"] () ]])
+      p [Html.D.a tsession_data_example [pcdata "Retry"] () ]])
 
 
 
@@ -1756,7 +1756,7 @@ let tsession_services_example_close =
 
 let tsession_services_example_handler () () =
   let f =
-    Html5.D.Form.post_form
+    Html.D.Form.post_form
       tsession_services_example_with_post_params
       (fun login ->
         [p [pcdata "login: ";
@@ -1870,13 +1870,13 @@ let tcoservices_example_get =
 let _ =
   let c = ref 0 in
   let page () () =
-    let l3 = Html5.D.Form.post_form tcoservices_example_post
-        (fun _ -> [p [Html5.D.Form.input Html5.D.Form.string
+    let l3 = Html.D.Form.post_form tcoservices_example_post
+        (fun _ -> [p [Html.D.Form.input Html.D.Form.string
                         ~input_type:`Submit
                         ~value:"incr i (post)"]]) ()
     in
-    let l4 = Html5.D.Form.get_form tcoservices_example_get
-        (fun _ -> [p [Html5.D.Form.input Html5.D.Form.string
+    let l4 = Html.D.Form.get_form tcoservices_example_get
+        (fun _ -> [p [Html.D.Form.input Html.D.Form.string
                         ~input_type:`Submit
                         ~value:"incr i (get)"]])
     in
@@ -1930,11 +1930,11 @@ let tcalc_i =
 let tcalc_handler () () =
   let create_form intname =
     [p [pcdata "Write a number: ";
-        Html5.D.Form.input Html5.D.Form.int ~input_type:`Text ~name:intname;
+        Html.D.Form.input Html.D.Form.int ~input_type:`Text ~name:intname;
         br ();
-        Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"Send"]]
+        Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"Send"]]
   in
-  let f = Html5.D.Form.get_form tcalc_i create_form in
+  let f = Html.D.Form.get_form tcalc_i create_form in
   return (make_page [f])
 
 
@@ -2016,16 +2016,16 @@ let tdisconnect_action =
 (* login ang logout boxes:                                  *)
 
 let tdisconnect_box s =
-  Html5.D.Form.post_form tdisconnect_action
-    (fun _ -> [p [Html5.D.Form.input Html5.D.Form.string
+  Html.D.Form.post_form tdisconnect_action
+    (fun _ -> [p [Html.D.Form.input Html.D.Form.string
                     ~input_type:`Submit ~value:s]]) ()
 
 let tlogin_box () =
-  Html5.D.Form.post_form tconnect_action
+  Html.D.Form.post_form tconnect_action
     (fun loginname ->
       [p
          (let l = [pcdata "login: ";
-                   Html5.D.Form.input Html5.D.Form.string
+                   Html.D.Form.input Html.D.Form.string
                      ~input_type:`Text ~name:loginname]
          in l)
      ])
@@ -2041,7 +2041,7 @@ let tconnect_example3_handler () () =
     (make_page (match sessdat with
       | Eliom_state.Data name ->
         [p [pcdata ("Hello "^name); br ()];
-         Html5.D.a ~service:tconnect_example3 [pcdata "Try again to check whether you are still connected"] ();
+         Html.D.a ~service:tconnect_example3 [pcdata "Try again to check whether you are still connected"] ();
          tdisconnect_box "Close session"]
       | Eliom_state.Data_session_expired
       | Eliom_state.No_data -> [tlogin_box ()]
@@ -2117,8 +2117,8 @@ let tdisconnect_action =
     (fun () () -> Eliom_state.discard ~scope  ())
 
 let tdisconnect_box s =
-  Html5.D.Form.post_form tdisconnect_action
-    (fun _ -> [p [Html5.D.Form.input Html5.D.Form.string
+  Html.D.Form.post_form tdisconnect_action
+    (fun _ -> [p [Html.D.Form.input Html.D.Form.string
                     ~input_type:`Submit ~value:s]]) ()
 
 
@@ -2131,7 +2131,7 @@ let get_bad_user table =
 (* new login box:                                           *)
 
 let tlogin_box session_expired action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
@@ -2158,7 +2158,7 @@ let tpersist_session_example_handler () () =
         ~fallback:tpersist_session_example ~get_params:unit ~timeout:5. ()
     in
     let _ =
-      Eliom_registration.Html5.register ~service:timeoutcoserv
+      Eliom_registration.Html.register ~service:timeoutcoserv
         ~scope:Eliom_common.default_process_scope
         (fun _ _ ->
           return
@@ -2168,7 +2168,7 @@ let tpersist_session_example_handler () () =
                  [pcdata "I am a coservice with timeout."; br ();
                   pcdata "Try to reload the page!"; br ();
                   pcdata "I will disappear after 5 seconds of inactivity.";
-                  pcdata "Pour l'instant c'est un Eliom_output.Html5 au lieu de My_appl parce qu'il y a un bug à corriger dans ce cas. Remettre My_appl ici et ajouter un test pour ce bug." ];
+                  pcdata "Pour l'instant c'est un Eliom_output.Html au lieu de My_appl parce qu'il y a un bug à corriger dans ce cas. Remettre My_appl ici et ajouter un test pour ce bug." ];
                  ])))
 (*            [p [pcdata "I am a coservice with timeout."; br ();
                 a timeoutcoserv [pcdata "Try again"] (); br ();
@@ -2255,8 +2255,8 @@ let tdisconnect_action =
 
 
 let tdisconnect_box s =
-  Eliom_registration.Html5.post_form tdisconnect_action
-    (fun _ -> [p [Html5.D.Form.input Html5.D.Form.string
+  Eliom_registration.Html.post_form tdisconnect_action
+    (fun _ -> [p [Html.D.Form.input Html.D.Form.string
                     ~input_type:`Submit ~value:s ()]]) ()
 
 
@@ -2271,7 +2271,7 @@ let get_bad_user table =
 (* new login box:                                           *)
 
 let tlogin_box session_expired action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
@@ -2364,8 +2364,8 @@ let tcsrfsafe_example_post =
 
 let _ =
   let page () () =
-    let l3 = Html5.D.Form.post_form tcsrfsafe_example_post
-        (fun _ -> [p [Html5.D.Form.input Html5.D.Form.string
+    let l3 = Html.D.Form.post_form tcsrfsafe_example_post
+        (fun _ -> [p [Html.D.Form.input Html.D.Form.string
                          ~input_type:`Submit
                          ~value:"Click"]]) ()
     in
@@ -2460,7 +2460,7 @@ let _ =
       Lwt_mutex.unlock mutex;
       Lwt.return v
   in
-  Eliom_registration.Html5.register persref
+  Eliom_registration.Html.register persref
     (fun () () ->
       next () >>= fun v ->
       Lwt.return
@@ -2518,7 +2518,7 @@ let _ =
         (fun () () -> Lwt.return [1; 2; 3])
     in
     let serv2 =
-      Eliom_registration.Html5.register_coservice'
+      Eliom_registration.Html.register_coservice'
         ~scope:Eliom_common.default_process_scope
         ~get_params:unit
         (fun () () -> Lwt.return (html
@@ -2545,7 +2545,7 @@ let _ =
           br ();
           pcdata "It works, because we send tab cookies with Eliom_client.call_service or Eliom_client.call_ocaml_service.";
           br ();
-          Html5.D.a ~service:serv2 [pcdata "Here a link to an client process service outside the application."] ();
+          Html.D.a ~service:serv2 [pcdata "Here a link to an client process service outside the application."] ();
           pcdata " For now it does not work, because we do not send tab cookies for non My_appl services ... How to solve this?";
           br ();
           pcdata "Add a test of link to another application."
@@ -2578,8 +2578,8 @@ let disconnect_action789 =
     (fun () () -> Eliom_state.discard ~scope:session ())
 
 let disconnect_box s =
-  Html5.D.Form.post_form disconnect_action789
-    (fun _ -> [p [Html5.D.Form.input Html5.D.Form.string
+  Html.D.Form.post_form disconnect_action789
+    (fun _ -> [p [Html.D.Form.input Html.D.Form.string
                     ~input_type:`Submit ~value:s]]) ()
 
 let bad_user = Eliom_reference.eref ~scope:Eliom_common.request_scope false
@@ -2587,11 +2587,11 @@ let bad_user = Eliom_reference.eref ~scope:Eliom_common.request_scope false
 let user = Eliom_reference.eref ~scope:session None
 
 let login_box session_expired bad_u action =
-  Html5.D.Form.post_form action
+  Html.D.Form.post_form action
     (fun loginname ->
       let l =
         [pcdata "login: ";
-         Html5.D.Form.input Html5.D.Form.string ~input_type:`Text ~name:loginname]
+         Html.D.Form.input Html.D.Form.string ~input_type:`Text ~name:loginname]
       in
       [p (if bad_u
         then (pcdata "Wrong user")::(br ())::l
@@ -2650,12 +2650,12 @@ let isuffixc =
 let create_suffixformc ((suff, endsuff),i) =
     [pcdata "Form to an (internal appl) suffix service.";
      pcdata "Write an int for the suffix:";
-     Html5.D.Form.input Html5.D.Form.int ~input_type:`Text ~name:suff;
+     Html.D.Form.input Html.D.Form.int ~input_type:`Text ~name:suff;
      pcdata "Write a string: ";
-     Html5.D.Form.input Html5.D.Form.string ~input_type:`Text ~name:endsuff;
+     Html.D.Form.input Html.D.Form.string ~input_type:`Text ~name:endsuff;
      pcdata "Write an int: ";
-     Html5.D.Form.input Html5.D.Form.int ~input_type:`Text ~name:i;
-     Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"Click"
+     Html.D.Form.input Html.D.Form.int ~input_type:`Text ~name:i;
+     Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"Click"
     ]
 }}
 
@@ -2686,13 +2686,13 @@ let appl_redir =
           br ();
           a ~service:appl_redir2 [ pcdata "Link to a redirection outside the Eliom application"] ();
          ];
-         Html5.D.Form.get_form ~service:appl_redir1
+         Html.D.Form.get_form ~service:appl_redir1
             (fun () ->
-              [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"Form to a redirection inside the Eliom application"]
+              [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"Form to a redirection inside the Eliom application"]
             );
-         Html5.D.Form.get_form ~service:appl_redir2
+         Html.D.Form.get_form ~service:appl_redir2
             (fun () ->
-              [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"Form to a redirection outside the Eliom application"]
+              [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"Form to a redirection outside the Eliom application"]
             )
         ]))
 
@@ -2717,7 +2717,7 @@ let postformc =
       ~post_params:(Eliom_parameter.string "zzz")
       ()
   in
-  Eliom_registration.Html5.register service
+  Eliom_registration.Html.register service
     (fun () s -> Lwt.return (make_page [p [pcdata "Yo man. ";
                                            pcdata s]]));
   service
@@ -2762,7 +2762,7 @@ let make_page_bis ?(css = []) content =
         div content ] )
 
 {client{
-  module Another_appl = Eliom_registration.Html5
+  module Another_appl = Eliom_registration.Html
 }}
 
 let otherappl =
@@ -2778,19 +2778,19 @@ let _ =
   (fun () () ->
     let rec list i n =
       if i >= n  then
-        [Html5.F.li
-          [Html5.D.a
+        [Html.F.li
+          [Html.D.a
               ~fragment:""
               ~service:long_page [pcdata ("Goto TOP")] ()]]
       else
-        Html5.F.li ~a:[Html5.F.a_id ("id" ^string_of_int i)]
-          [Html5.F.pcdata ("Item #" ^ string_of_int i);
-           Html5.F.pcdata "; ";
-           Html5.D.a
+        Html.F.li ~a:[Html.F.a_id ("id" ^string_of_int i)]
+          [Html.F.pcdata ("Item #" ^ string_of_int i);
+           Html.F.pcdata "; ";
+           Html.D.a
              ~fragment:("id" ^ string_of_int (n-i))
              ~service:long_page [pcdata ("Goto #" ^ string_of_int (n-i))] ();] :: list (i+1) n in
     Lwt.return
-      (make_page [Html5.F.ul (list 1 100)]))
+      (make_page [Html.F.ul (list 1 100)]))
 
 let service_with_get_params =
   Eliom_service.App.service ~path:["intgp"]
@@ -2824,14 +2824,14 @@ let live_description =
        pcdata "Try to navigate between page. Try to leave the application and to get back.";]
 
 let live_links =
-  div [ ul [li [Html5.D.a ~service:live1 [pcdata "Page one"] ()];
-            li [Html5.D.a ~service:live2 [pcdata "Page two"] ()];
-            li [Html5.D.a ~service:live3 [pcdata "Page threee"] ()]]]
+  div [ ul [li [Html.D.a ~service:live1 [pcdata "Page one"] ()];
+            li [Html.D.a ~service:live2 [pcdata "Page two"] ()];
+            li [Html.D.a ~service:live3 [pcdata "Page threee"] ()]]]
 
 let dead_links =
-  div [ ul [li [Html5.D.a ~service:Eliom_testsuite1.coucou
+  div [ ul [li [Html.D.a ~service:Eliom_testsuite1.coucou
                    [pcdata "Link to a service outside the application."] ()];
-            li [Html5.D.a ~service:otherappl
+            li [Html.D.a ~service:otherappl
                    [pcdata "Link to another application."] ()];]]
 
 let () = My_appl.register ~service:live1 (fun () () ->
@@ -2868,7 +2868,7 @@ let () = My_appl.register ~service:live3 (fun () () ->
 
 let formc = My_appl.register_service ["formc"] unit
   (fun () () ->
-    let div = Html5.D.div [h3 [pcdata "Forms and links created on client side:"]] in
+    let div = Html.D.div [h3 [pcdata "Forms and links created on client side:"]] in
     ignore {unit{
       Eliom_client.onload
         (fun _ ->
@@ -2877,52 +2877,52 @@ let formc = My_appl.register_service ["formc"] unit
             [
               h4 [pcdata "to outside the application:"];
 
-              p [Html5.D.a ~service:%Eliom_testsuite1.coucou
+              p [Html.D.a ~service:%Eliom_testsuite1.coucou
                    [pcdata "Link to a service outside the application."]
                    ()];
-              p [Html5.D.a ~service:%Eliom_testsuite1.coucou_params
+              p [Html.D.a ~service:%Eliom_testsuite1.coucou_params
                    [pcdata "Link to a service outside the application, with params (unicode)"]
                    (1, (2, "tutu cccéccc+ccc"))];
 
-             Html5.D.Form.get_form ~service:%Eliom_testsuite1.coucou
+             Html.D.Form.get_form ~service:%Eliom_testsuite1.coucou
                (fun () ->
-                 [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"GET form to a service outside the Eliom application"]
+                 [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"GET form to a service outside the Eliom application"]
                );
 
-             Html5.D.Form.post_form ~service:%Eliom_testsuite1.my_service_with_post_params
+             Html.D.Form.post_form ~service:%Eliom_testsuite1.my_service_with_post_params
                (fun s ->
-                 [Html5.D.Form.input Html5.D.Form.string ~input_type:`Hidden ~name:s ~value:"plop";
-                  Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"POST form to a service outside the Eliom application"]
+                 [Html.D.Form.input Html.D.Form.string ~input_type:`Hidden ~name:s ~value:"plop";
+                  Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"POST form to a service outside the Eliom application"]
                )
                ();
 
-              p [Html5.D.a ~service:%otherappl
+              p [Html.D.a ~service:%otherappl
                     [pcdata "Link to another application."]
                     ();
                 ];
 
-              Html5.D.Form.get_form ~service:%otherappl
+              Html.D.Form.get_form ~service:%otherappl
                 (fun () ->
-                  [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"GET form to another application";];
+                  [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"GET form to another application";];
                 );
 
 
              h4 [pcdata "inside the application — must not stop the process! (same random number in the container)."];
 
-             p [Html5.D.a ~service:%long_page
+             p [Html.D.a ~service:%long_page
                    [pcdata "Link to a service inside the application."]
                    ()];
-             p [Html5.D.a ~service:%long_page
+             p [Html.D.a ~service:%long_page
                   ~fragment:"id40"
                   [pcdata "Link to a service inside the application (fragment)."]
                   ()];
-             p [Html5.D.a ~https:false ~service:%long_page
+             p [Html.D.a ~https:false ~service:%long_page
                    [pcdata "Link to a service inside the application (force http)."]
                    ()];
-             p [Html5.D.a ~https:true ~service:%long_page
+             p [Html.D.a ~https:true ~service:%long_page
                    [pcdata "Link to a service inside the application (force https)."]
                    ()];
-             p [Html5.D.a ~service:%service_with_get_params
+             p [Html.D.a ~service:%service_with_get_params
                    [pcdata "Link to a service inside the application (GET parameters, with spaces and Unicode)."]
                    ("toto aaaéaaa+aaa", "tata oooéooo+ooo")];
              p
@@ -2933,25 +2933,25 @@ let formc = My_appl.register_service ["formc"] unit
                                         ("toto aaaéaaa+aaa", "tata oooéooo+ooo") ())) ]
                [pcdata "Change page to a service inside the application (GET parameters, with spaces and Unicode)."];
 
-             Html5.D.Form.get_form ~service:%eliomclient1
+             Html.D.Form.get_form ~service:%eliomclient1
                (fun () ->
-                 [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"GET form to a service inside the Eliom application"]
+                 [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"GET form to a service inside the Eliom application"]
                );
 
-             Html5.D.Form.post_form ~service:%postformc
+             Html.D.Form.post_form ~service:%postformc
                (fun s ->
-                 [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~name:s ~value:"POST form to a service inside the Eliom application"]
+                 [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~name:s ~value:"POST form to a service inside the Eliom application"]
                )
                ();
 
-             Html5.D.Form.get_form %isuffixc create_suffixformc;
+             Html.D.Form.get_form %isuffixc create_suffixformc;
 
-             Html5.D.Form.post_form ~service:%applvoid_redir
+             Html.D.Form.post_form ~service:%applvoid_redir
                (fun () ->
                  [pcdata "POST form towards action with void service redirection. This must not stop the application (same random number in the container but not in the here: ";
                   pcdata (string_of_int (Random.int 1000));
                   pcdata ") ";
-                  Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"Click to send POST form to myself."]
+                  Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"Click to send POST form to myself."]
                )
                ();
 
@@ -2959,8 +2959,8 @@ let formc = My_appl.register_service ["formc"] unit
           in
           List.iter
             (fun e -> Dom.appendChild
-              (Html5.To_dom.of_div %div)
-              (Html5.To_dom.of_element e)) l)
+              (Html.To_dom.of_div %div)
+              (Html.To_dom.of_element e)) l)
        }};
 
     Lwt.return
@@ -2970,80 +2970,80 @@ let formc = My_appl.register_service ["formc"] unit
 
         h4 [pcdata "to outside the application:"];
 
-        p [Html5.D.a ~service:Eliom_testsuite1.coucou
+        p [Html.D.a ~service:Eliom_testsuite1.coucou
               [pcdata "Link to a service outside the application."]
               ()];
-        p [Html5.D.a ~service:Eliom_testsuite1.coucou_params
+        p [Html.D.a ~service:Eliom_testsuite1.coucou_params
               [pcdata "Link to a service outside the application, with params (unicode)"]
               (1, (2, "tutu cccéccc+ccc"))];
 
-        Html5.D.Form.get_form ~service:Eliom_testsuite1.coucou
+        Html.D.Form.get_form ~service:Eliom_testsuite1.coucou
           (fun () ->
-            [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"GET form to a service outside the Eliom application"]
+            [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"GET form to a service outside the Eliom application"]
           );
 
-        Html5.D.Form.post_form ~service:Eliom_testsuite1.my_service_with_post_params
+        Html.D.Form.post_form ~service:Eliom_testsuite1.my_service_with_post_params
           (fun s ->
-            [Html5.D.Form.input Html5.D.Form.string ~input_type:`Hidden ~name:s ~value:"plop";
-             Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"POST form to a service outside the Eliom application"]
+            [Html.D.Form.input Html.D.Form.string ~input_type:`Hidden ~name:s ~value:"plop";
+             Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"POST form to a service outside the Eliom application"]
           )
           ();
 
-        p [Html5.D.a ~service:otherappl
+        p [Html.D.a ~service:otherappl
               [pcdata "Link to another application."]
               ();
            pcdata " (The other appl won't work as it is not compiled)"];
 
-        Html5.D.Form.get_form ~service:otherappl
+        Html.D.Form.get_form ~service:otherappl
           (fun () ->
-            [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"GET form to another application";]
+            [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"GET form to another application";]
           );
 
 
         h4 [pcdata "inside the application — must not stop the process! (same random number in the container)."];
 
-        p [Html5.D.a ~service:long_page
+        p [Html.D.a ~service:long_page
               [pcdata "Link to a service inside the application."]
               ()];
-        p [Html5.D.a ~service:long_page
+        p [Html.D.a ~service:long_page
              ~fragment:"id40"
               [pcdata "Link to a service inside the application (fragment)."]
               ()];
-        p [Html5.D.a ~https:false ~service:long_page
+        p [Html.D.a ~https:false ~service:long_page
               [pcdata "Link to a service inside the application (force http)."]
               ()];
-        p [Html5.D.a ~https:true ~service:long_page
+        p [Html.D.a ~https:true ~service:long_page
               [pcdata "Link to a service inside the application (force https)."]
               ()];
-        p [Html5.D.a ~service:service_with_get_params
+        p [Html.D.a ~service:service_with_get_params
               [pcdata "Link to a service inside the application (GET parameters, with spaces and Unicode)."]
               ("toto aaaéaaa+aaa", "tata oooéooo+ooo")];
 
-        Html5.D.Form.get_form ~service:eliomclient1
+        Html.D.Form.get_form ~service:eliomclient1
           (fun () ->
-            [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"GET form to a service inside the Eliom application"]
+            [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"GET form to a service inside the Eliom application"]
           );
 
-        Html5.D.Form.post_form ~service:postformc
+        Html.D.Form.post_form ~service:postformc
           (fun s ->
-            [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~name:s ~value:"POST form to a service inside the Eliom application"]
+            [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~name:s ~value:"POST form to a service inside the Eliom application"]
           )
           ();
 
-        Html5.D.Form.get_form isuffixc create_suffixformc;
+        Html.D.Form.get_form isuffixc create_suffixformc;
 
-        Html5.D.Form.post_form ~service:applvoid_redir
+        Html.D.Form.post_form ~service:applvoid_redir
           (fun () ->
             [pcdata "POST form towards action with void service redirection. This must not stop the application (same random number in the container but not in the here: ";
              pcdata (string_of_int (Random.int 1000));
              pcdata ") ";
-             Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:"Click to send POST form to myself."]
+             Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:"Click to send POST form to myself."]
           )
           ();
 
         h4 [pcdata "Changing the URL without doing a request."];
 
-        p [Html5.D.Raw.a
+        p [Html.D.Raw.a
               ~a:[a_onclick {{fun _ ->
                 Eliom_client.change_url ~service:%long_page
                   ~fragment:"id40"
@@ -3076,7 +3076,7 @@ let () =
     let sp = Eliom_common.get_sp () in
     let appl_name = sp.Eliom_common.sp_client_appl_name in
     let links f =
-      span [f "version generated by Eliom_registration.Html5" 0;
+      span [f "version generated by Eliom_registration.Html" 0;
             br ();
             f "version generated by My_appl" 1;
             br ();
@@ -3088,9 +3088,9 @@ let () =
     [p
         [pcdata ("this page was generated by " ^ name);
          br ();
-         links (fun text i -> Html5.D.a ~service:any_service [pcdata text] i);
+         links (fun text i -> Html.D.a ~service:any_service [pcdata text] i);
          br ();
-         pcdata "back button do not work after exiting application (with link to Eliom_registration.Html5) when the last request had post parameters: the post parameters does not appear in the url: it will lead to the fallback";
+         pcdata "back button do not work after exiting application (with link to Eliom_registration.Html) when the last request had post parameters: the post parameters does not appear in the url: it will lead to the fallback";
          br ();
          match appl_name with
            | None -> pcdata "last request was not from an application"
@@ -3101,10 +3101,10 @@ let () =
   let make_any = function
     | 0 ->
       Printf.printf "html5 case\n%!";
-      Eliom_registration.appl_self_redirect Eliom_registration.Html5.send
+      Eliom_registration.appl_self_redirect Eliom_registration.Html.send
         (html
            (head (title (pcdata "html5 content")) [])
-           (body (make_content "Eliom_registration.Html5.send")))
+           (body (make_content "Eliom_registration.Html.send")))
     | 1 ->
       Printf.printf "my appl case\n%!";
       My_appl.send (make_page (make_content "My_appl.send"))
@@ -3138,7 +3138,7 @@ let gracefull_fail_with_file =
     (fun () () ->
       return
         (make_page
-           [Html5.D.a ~service:never_shown_service
+           [Html.D.a ~service:never_shown_service
                [pcdata "link to a service hidden by a file"] ();]))
 
 (*****************************************************************************)
@@ -3169,7 +3169,7 @@ let appl_with_redirect_service =
     (fun () () ->
       return
         (make_page
-           [Html5.D.a ~service:redirected_src_service
+           [Html.D.a ~service:redirected_src_service
                [pcdata "link to a service hidden by a redirection"] ();
             br ();
             pcdata "there should be a line like: <redirect suburl=\"redirect_src\" dest=\"http://localhost:8080/redirect_dst\"/> in the configuration file";
@@ -3196,7 +3196,7 @@ let noreload_appl =
         (html
          (head (title (pcdata "counter")) [])
          (body [p [pcdata (string_of_int (!noreload_ref)); br ();
-                   Html5.D.a ~service:noreload_action
+                   Html.D.a ~service:noreload_action
                      [pcdata "Click to increment the counter."] ();
                    br ();
                    pcdata "You should not see the result if you do not reload the page."
@@ -3274,14 +3274,14 @@ let make_xhr_form ((((((casename,radio),select),multi),text),pass),file) =
 
 let xhr_form_with_file = My_appl.register_service ["xhr_form_with_file"] unit
   (fun () () ->
-    let form = Html5.D.(post_form block_form_result make_xhr_form ()) in
-    let subpage = Html5.D.(div []) in
+    let form = Html.D.(post_form block_form_result make_xhr_form ()) in
+    let subpage = Html.D.(div []) in
     let launch = p ~a:[(*zap* *)a_class ["clickable"];(* *zap*)
       a_onclick {{
         fun _ ->
           let uri = Eliom_uri.make_string_uri ~service:%block_form_result () in
-          ignore (Eliom_request.send_post_form (Html5.To_dom.of_form %form) uri >|=
-              (fun contents -> ( Html5.To_dom.of_div %subpage )##innerHTML <- (Js.string contents)))
+          ignore (Eliom_request.send_post_form (Html.To_dom.of_form %form) uri >|=
+              (fun contents -> ( Html.To_dom.of_div %subpage )##innerHTML <- (Js.string contents)))
       }}]
       [pcdata "send form with an xhr"]
     in
@@ -3294,14 +3294,14 @@ let xhr_form_with_file = My_appl.register_service ["xhr_form_with_file"] unit
 
 
 let global_div =
-  Html5.Id.create_global_elt
+  Html.Id.create_global_elt
     (p ~a:[a_onload {{ fun _ -> Lwt_log.ign_debug "Div1: plop once." }}]
        [pcdata "Div: ";
         span ~a:[a_onload {{ fun _ -> Lwt_log.ign_debug "Span inside Div1: plop once"}}]
           [pcdata "global"]])
 
 let local_div =
-  Html5.D.p ~a:[a_onload {{ fun _ -> Lwt_log.ign_debug "Div2: always plop." }}]
+  Html.D.p ~a:[a_onload {{ fun _ -> Lwt_log.ign_debug "Div2: always plop." }}]
     [pcdata "Div2: ";
      span ~a:[a_onload {{ fun _ -> Lwt_log.ign_debug "Span inside Div2: always plop";}}]
        [pcdata "local"]]
@@ -3334,7 +3334,7 @@ let _ =
                     p [pcdata "This page contains three div with attached onload event.";
                        pcdata "Those events display debug messages in the console. ";
                        pcdata "One div is a global element, the other one is not. ";
-                       Html5.D.a ~service:unique2
+                       Html.D.a ~service:unique2
                          [pcdata "Follow this link"] ();
                        pcdata ", and then press the back button: ";
                        pcdata "only the onload event of the non-global div should be executed.";
@@ -3364,7 +3364,7 @@ let _ =
       ignore {unit{Eliom_client.onload (fun _ -> Lwt_log.ign_debug "Load page 2") }};
       return
         (make_page [h1 [pcdata "Page 2"];
-                    Html5.D.a ~service:unique1 [pcdata "Get back to Page 1."] ();
+                    Html.D.a ~service:unique1 [pcdata "Get back to Page 1."] ();
                     p [pcdata "Try also to reload this page before switching back to Page 1:";
                        pcdata "The onload event of the unique div should be executed ";
                        pcdata "(when it is appears for the first time)"];
@@ -3377,7 +3377,7 @@ let big_service =
     ()
 
 let rec big_page n =
-  let link = Html5.D.a ~service:big_service [pcdata "same page"] () in
+  let link = Html.D.a ~service:big_service [pcdata "same page"] () in
   (*let link = p ~a:[a_class ["toto"]] [span [pcdata "rien"]] in*)
   if n = 0
   then link
@@ -3399,8 +3399,8 @@ let relink_test =
     ~get_params:Eliom_parameter.unit
     ()
 
-let global_list = Html5.Id.create_global_elt (ul [li [pcdata "First element"]])
-let local_list = Html5.D.ul [li [pcdata "First element"]]
+let global_list = Html.Id.create_global_elt (ul [li [pcdata "First element"]])
+let local_list = Html.D.ul [li [pcdata "First element"]]
 
 let relink_page () =
   ignore {unit{
@@ -3414,15 +3414,15 @@ let relink_page () =
     div [pcdata "This div contains a request list sent by reference. There should be only one item in the list.";
          local_list];
     div
-      [Html5.D.a ~service:relink_test
+      [Html.D.a ~service:relink_test
          [pcdata "Same page"] ();
        pcdata " (This should add an item in the global list)";
        br ();
-       Html5.D.a ~service:eliomclient1
+       Html.D.a ~service:eliomclient1
          [pcdata "Another page inside the application"] ();
        pcdata " (If you use the back button to redisplay this page, there should be a new item in the global list)";
        br ();
-       Html5.D.a ~service:Eliom_testsuite_base.main [pcdata "Outside
+       Html.D.a ~service:Eliom_testsuite_base.main [pcdata "Outside
   application"] ();
        pcdata " (If you use the back button to redisplay this page, there should be only only item in the global list)";
        br ();
@@ -3441,13 +3441,13 @@ let _ =
 
   let react_div ?a r =
     let init = React.S.value r in
-    let node = Html5.D.div ?a init in
-    let node_dom = Html5.To_dom.of_element node in
+    let node = Html.D.div ?a init in
+    let node_dom = Html.To_dom.of_element node in
     let s = React.S.map (fun sons ->
       List.iter (fun n -> ignore (node_dom##removeChild((n:> Dom.node Js.t))))
         (Dom.list_of_nodeList (node_dom##childNodes));
       List.iter (fun n ->
-        let n = Html5.To_dom.of_element n in
+        let n = Html.To_dom.of_element n in
         ignore (node_dom##appendChild((n:> Dom.node Js.t))))
         sons) r in
     Lwt_react.S.keep s;
@@ -3459,12 +3459,12 @@ let _ =
 
   let react_node node r =
     let _init = React.S.value r in
-    let node_dom = Html5.To_dom.of_element node in
+    let node_dom = Html.To_dom.of_element node in
     let s = React.S.map (fun sons ->
       List.iter (fun n -> ignore (node_dom##removeChild((n:> Dom.node Js.t))))
         (Dom.list_of_nodeList (node_dom##childNodes));
       List.iter (fun n ->
-        let n = Html5.To_dom.of_element n in
+        let n = Html.To_dom.of_element n in
         ignore (node_dom##appendChild((n:> Dom.node Js.t))))
         sons) r in
     Lwt_react.S.keep s
@@ -3481,7 +3481,7 @@ let () =
   My_appl.register
     react_example
     (fun () () ->
-      let click_div = Html5.D.div ~a:[a_onclick {{ fun _ -> push (incr count; !count) }}] [] in
+      let click_div = Html.D.div ~a:[a_onclick {{ fun _ -> push (incr count; !count) }}] [] in
       ignore {unit{
         Eliom_client.onload
         (fun _ ->
@@ -3497,17 +3497,17 @@ let caml_service_with_onload' =
     ~path:["caml_service_with_onload'"]
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-      let node = Html5.D.div [pcdata "new div"] in
+      let node = Html.D.div [pcdata "new div"] in
       ignore {unit{
         Eliom_client.onload
           (fun _ ->
-             let node = Html5.To_dom.of_div %node in
+             let node = Html.To_dom.of_div %node in
              ignore (Dom_html.addEventListener node Dom_html.Event.click
                        (Dom_html.handler (fun _ -> Dom_html.window##alert(Js.string "clicked!"); Js._true))
                        Js._true);
              ())
       }};
-      Lwt.return (node : Html5_types.div Html5.F.elt))
+      Lwt.return (node : Html_types.div Html.F.elt))
 
 let caml_service_with_onload =
   My_appl.register_service
@@ -3519,7 +3519,7 @@ let caml_service_with_onload =
           fun _ ->
             ignore (
               lwt node = Eliom_client.call_ocaml_service ~service:( %caml_service_with_onload' ) () () in
-              let node = Html5.To_dom.of_div node in
+              let node = Html.To_dom.of_div node in
               ignore (Dom_html.document##body##appendChild( (node:> Dom.node Js.t) ));
               Lwt.return ()
             )
@@ -3537,7 +3537,7 @@ let rec dom_div_tree v width height =
   else
     Array.to_list
       (Array.init width
-         (fun i -> Html5.D.div (dom_div_tree v width (height-1))))
+         (fun i -> Html.D.div (dom_div_tree v width (height-1))))
 let dom_div_tree w h = dom_div_tree (ref 0) w h
 
 let rec div_tree v width height =
@@ -3546,7 +3546,7 @@ let rec div_tree v width height =
   else
     Array.to_list
       (Array.init width
-         (fun i -> Html5.F.div (div_tree v width (height-1))))
+         (fun i -> Html.F.div (div_tree v width (height-1))))
 let div_tree w h = div_tree (ref 0) w h
 
 let domnodes_timings = Eliom_service.App.service
@@ -3578,9 +3578,9 @@ let rec power n m =
 }}
 
 let activate_timings_button =
-  Html5.Id.create_global_elt
-    (Html5.F.Form.input Html5.F.Form.string
-       ~a:[ Html5.F.a_onclick {{
+  Html.Id.create_global_elt
+    (Html.F.Form.input Html.F.Form.string
+       ~a:[ Html.F.a_onclick {{
             fun ev ->
               Eliom_config.debug_timings := not (!Eliom_config.debug_timings);
               change_target_value ev;
@@ -3589,36 +3589,36 @@ let activate_timings_button =
        ~value:"Activate timings")
 
 let update_tree service w h =
-  Html5.F.Form.get_form ~service (fun (wn,hn) ->
-    [ Html5.F.fieldset
-        [ Html5.F.label
-            ~a:[Html5.D.a_for "i_width"]
+  Html.F.Form.get_form ~service (fun (wn,hn) ->
+    [ Html.F.fieldset
+        [ Html.F.label
+            ~a:[Html.D.a_for "i_width"]
             [pcdata "Tree width: "];
-          Html5.F.Form.input Html5.F.Form.int
-            ~a:[Html5.F.a_id "i_width"]
+          Html.F.Form.input Html.F.Form.int
+            ~a:[Html.F.a_id "i_width"]
             ~name:wn ~input_type:`Text ~value:w;
-          Html5.F.label
-            ~a:[Html5.D.a_for "i_height"]
+          Html.F.label
+            ~a:[Html.D.a_for "i_height"]
             [pcdata "and height: "];
-          Html5.F.Form.input Html5.F.Form.int
-            ~a:[Html5.F.a_id "i_height"]
+          Html.F.Form.input Html.F.Form.int
+            ~a:[Html.F.a_id "i_height"]
             ~name:hn ~input_type:`Text ~value:h;
-          Html5.F.Form.input Html5.F.Form.string ~input_type:`Submit ~value:"Update";
+          Html.F.Form.input Html.F.Form.string ~input_type:`Submit ~value:"Update";
         ]
     ])
 
 let _ = My_appl.register
   ~service:domnodes_timings
   (fun (w,h) () ->
-    let div = Html5.F.div ~a:[a_style "display:none;"] (dom_div_tree w h) in
+    let div = Html.F.div ~a:[a_style "display:none;"] (dom_div_tree w h) in
     Lwt.return
       (make_page
-         [Html5.F.h2 [pcdata (Printf.sprintf "Huge tree of dom nodes (%d^%d = %d)"
+         [Html.F.h2 [pcdata (Printf.sprintf "Huge tree of dom nodes (%d^%d = %d)"
                                 w h (power w h))];
-          Html5.F.p [pcdata "This page contains a hidden tree of dom nodes (a.k.a unique nodes of scope request). ";
+          Html.F.p [pcdata "This page contains a hidden tree of dom nodes (a.k.a unique nodes of scope request). ";
                      pcdata "Activate timings and look into the console how the 'relink_request_nodes' value ";
                      pcdata "evolves when the number of unique nodes increase. Then compare timings on the ";
-                     Html5.D.a nodes_timings
+                     Html.D.a nodes_timings
                        [pcdata "same page with non-unique nodes"] (w,h);
                      pcdata "."];
           activate_timings_button;
@@ -3628,12 +3628,12 @@ let _ = My_appl.register
 let _ = My_appl.register
   ~service:nodes_timings
   (fun (w,h) () ->
-    let div = Html5.F.div ~a:[a_style "display:none;"] (div_tree w h) in
+    let div = Html.F.div ~a:[a_style "display:none;"] (div_tree w h) in
     Lwt.return
       (make_page
-         [Html5.F.h2 [pcdata (Printf.sprintf "Huge tree of classical nodes (%d^%d = %d)"
+         [Html.F.h2 [pcdata (Printf.sprintf "Huge tree of classical nodes (%d^%d = %d)"
                                 w h (power w h))];
-          Html5.F.p [Html5.D.a domnodes_timings [pcdata "Back to unique nodes."] (w,h)];
+          Html.F.p [Html.D.a domnodes_timings [pcdata "Back to unique nodes."] (w,h)];
           activate_timings_button;
           update_tree domnodes_timings w h;
           div]))
@@ -3642,28 +3642,28 @@ let shared_dom_nodes = My_appl.register_service
   ~path:["shared_dom_nodes"]
   ~get_params:unit
   (fun () () ->
-    let li = Html5.D.li [pcdata "Shared item"] in
-    let li_appl = Html5.Id.create_global_elt (Html5.F.li [pcdata "Shared item"]) in
+    let li = Html.D.li [pcdata "Shared item"] in
+    let li_appl = Html.Id.create_global_elt (Html.F.li [pcdata "Shared item"]) in
     Lwt.return
       (make_page
-         [Html5.F.h2 [pcdata "Multiple occurences of a unique node"];
-          Html5.F.p [pcdata "The following list contains two occurences of a unique node items (of scope request). ";
+         [Html.F.h2 [pcdata "Multiple occurences of a unique node"];
+          Html.F.p [pcdata "The following list contains two occurences of a unique node items (of scope request). ";
                      pcdata "One between item A and item B ; one between B and C. ";
                      pcdata "Only the second one should be displayed."];
-          Html5.F.ul [ Html5.F.li [pcdata "Non-shared item A"];
+          Html.F.ul [ Html.F.li [pcdata "Non-shared item A"];
                        li;
-                       Html5.F.li [pcdata "Non-shared item B"];
+                       Html.F.li [pcdata "Non-shared item B"];
                        li;
-                       Html5.F.li [pcdata "Non-shared item C"];];
-          Html5.F.p [pcdata "It is possible that for a very short period of time the first one appears. ";
+                       Html.F.li [pcdata "Non-shared item C"];];
+          Html.F.p [pcdata "It is possible that for a very short period of time the first one appears. ";
                      pcdata "However, programmer probably do not want to use multiple occurences of a unique node ";
                      pcdata "and this \"blink\" will be a good reminder of unique node misuse..."];
-          Html5.F.p [pcdata "Same game with scope application."];
-          Html5.F.ul [ Html5.F.li [pcdata "Non-shared item A"];
+          Html.F.p [pcdata "Same game with scope application."];
+          Html.F.ul [ Html.F.li [pcdata "Non-shared item A"];
                        li_appl;
-                       Html5.F.li [pcdata "Non-shared item B"];
+                       Html.F.li [pcdata "Non-shared item B"];
                        li_appl;
-                       Html5.F.li [pcdata "Non-shared item C"];];
+                       Html.F.li [pcdata "Non-shared item C"];];
          ]))
 
 
@@ -3695,25 +3695,25 @@ let tmpl2_page2 = Eliom_service.App.service
   ~get_params:unit
   ()
 
-let tmpl_update (id : Html5_types.flow5 Html5.Id.id) (contents : Html5_types.flow5 Html5.elt list) = {{
+let tmpl_update (id : Html_types.flow5 Html.Id.id) (contents : Html_types.flow5 Html.elt list) = {{
   Eliom_client.onload
     (fun () ->
       Lwt_log.ign_debug "Update";
-      Html5.Manip.Named.replaceChildren %id %contents)
+      Html.Manip.Named.replaceChildren %id %contents)
 }}
 module Tmpl_1 = Eliom_registration.Eliom_tmpl(My_appl)(struct
-  type t = Html5_types.flow5 Html5.elt list
+  type t = Html_types.flow5 Html.elt list
   let name = "template_one"
-  let content_id = Html5.Id.new_elt_id ()
+  let content_id = Html.Id.new_elt_id ()
   let make_page contents =
     Lwt.return
-      Html5.F.(make_page
+      Html.F.(make_page
          [h2 [pcdata "Template #1"];
-          ul [li [Html5.D.a ~service:tmpl1_page1 [pcdata "Page 1"] ()];
-              li [Html5.D.a ~service:tmpl1_page2 [pcdata "Page 2"] ()];
-              li [Html5.D.a ~service:tmpl1_page3 [pcdata "Page 3"] ()];
-              li [Html5.D.a ~service:tmpl2_page1 [pcdata "Page 1 (tmpl2)"] ()];
-              li [Html5.D.a ~service:tmpl2_page2 [pcdata "Page 2 (tmpl2)"] ()];
+          ul [li [Html.D.a ~service:tmpl1_page1 [pcdata "Page 1"] ()];
+              li [Html.D.a ~service:tmpl1_page2 [pcdata "Page 2"] ()];
+              li [Html.D.a ~service:tmpl1_page3 [pcdata "Page 3"] ()];
+              li [Html.D.a ~service:tmpl2_page1 [pcdata "Page 1 (tmpl2)"] ()];
+              li [Html.D.a ~service:tmpl2_page2 [pcdata "Page 2 (tmpl2)"] ()];
               li ~a:[a_onclick {{ fun _ -> Lwt.ignore_result(Eliom_client.change_page ~service:%tmpl1_page1 () ())}}]
                 [pcdata "Click me 1 (change_page)"];
               li ~a:[a_onclick {{ fun _ -> Lwt.ignore_result(Eliom_client.change_page ~service:%tmpl1_page2 () ())}}]
@@ -3725,23 +3725,23 @@ module Tmpl_1 = Eliom_registration.Eliom_tmpl(My_appl)(struct
               li ~a:[a_onclick {{ fun _ -> Lwt.ignore_result(Eliom_client.change_page ~service:%tmpl2_page2 () ())}}]
                  [pcdata "Click me 2 (change_page, tmpl2)"];
              ];
-          Html5.Id.create_named_elt ~id:content_id (div contents)])
+          Html.Id.create_named_elt ~id:content_id (div contents)])
   let update  = tmpl_update content_id
 end)
 
 module Tmpl_2 = Eliom_registration.Eliom_tmpl(My_appl)(struct
-  type t = Html5_types.flow5 Html5.elt list
+  type t = Html_types.flow5 Html.elt list
   let name = "template_two"
-  let content_id = Html5.Id.new_elt_id ()
+  let content_id = Html.Id.new_elt_id ()
   let make_page contents =
     Lwt.return
-      Html5.F.(make_page
+      Html.F.(make_page
          [h2 [pcdata "Template #2"];
-          ul [li [Html5.D.a ~service:tmpl1_page1 [pcdata "Page 1 (tmpl1)"] ()];
-              li [Html5.D.a ~service:tmpl1_page2 [pcdata "Page 2 (tmpl1)"] ()];
-              li [Html5.D.a ~service:tmpl1_page3 [pcdata "Page 3 (tmpl1)"] ()];
-              li [Html5.D.a ~service:tmpl2_page1 [pcdata "Page 1"] ()];
-              li [Html5.D.a ~service:tmpl2_page2 [pcdata "Page 2"] ()];
+          ul [li [Html.D.a ~service:tmpl1_page1 [pcdata "Page 1 (tmpl1)"] ()];
+              li [Html.D.a ~service:tmpl1_page2 [pcdata "Page 2 (tmpl1)"] ()];
+              li [Html.D.a ~service:tmpl1_page3 [pcdata "Page 3 (tmpl1)"] ()];
+              li [Html.D.a ~service:tmpl2_page1 [pcdata "Page 1"] ()];
+              li [Html.D.a ~service:tmpl2_page2 [pcdata "Page 2"] ()];
               li ~a:[a_onclick {{ fun _ -> Lwt.ignore_result(Eliom_client.change_page ~service:%tmpl1_page1 () ())}}]
                 [pcdata "Click me 1 (change_page, tmpl1)"];
               li ~a:[a_onclick {{ fun _ -> Lwt.ignore_result(Eliom_client.change_page ~service:%tmpl1_page2 () ())}}]
@@ -3753,7 +3753,7 @@ module Tmpl_2 = Eliom_registration.Eliom_tmpl(My_appl)(struct
               li ~a:[a_onclick {{ fun _ -> Lwt.ignore_result(Eliom_client.change_page ~service:%tmpl2_page2 () ())}}]
                  [pcdata "Click me 2 (change_page)"];
              ];
-          Html5.Id.create_named_elt ~id:content_id (div contents)])
+          Html.Id.create_named_elt ~id:content_id (div contents)])
   let update  = tmpl_update content_id
 end)
 
@@ -3802,13 +3802,13 @@ let hist_page5 = Eliom_service.App.service
   ()
 
 let make_hist_page contents =
-  Html5.F.(make_page
+  Html.F.(make_page
              [h2 [pcdata "Test History"];
-              ul [li [Html5.D.a ~service:hist_page1 [pcdata "Page 1"] ()];
-                  li [Html5.D.a ~service:hist_page2 [pcdata "Page 2"] ()];
-                  li [Html5.D.a ~service:hist_page3 [pcdata "Page 3"] ()];
-                  li [Html5.D.a ~service:hist_page4 [pcdata "Page 4"] ()];
-                  li [Html5.D.a ~service:hist_page5 [pcdata "Page 5"] ()];
+              ul [li [Html.D.a ~service:hist_page1 [pcdata "Page 1"] ()];
+                  li [Html.D.a ~service:hist_page2 [pcdata "Page 2"] ()];
+                  li [Html.D.a ~service:hist_page3 [pcdata "Page 3"] ()];
+                  li [Html.D.a ~service:hist_page4 [pcdata "Page 4"] ()];
+                  li [Html.D.a ~service:hist_page5 [pcdata "Page 5"] ()];
                  ];
              div contents])
 
@@ -3881,7 +3881,7 @@ let nlpost_with_nlp =
     nl_params nlpost
 
 let create_form_nl s =
-  (fun () -> [Html5.F.p [Html5.D.Form.input Html5.D.Form.string ~input_type:`Submit ~value:s]])
+  (fun () -> [Html.F.p [Html.D.Form.input Html.D.Form.string ~input_type:`Submit ~value:s]])
 
 let () = My_appl.register nlpost
   (fun () () ->
@@ -3890,24 +3890,24 @@ let () = My_appl.register nlpost
         | None -> "no non localised parameter"
         | Some _ -> "some non localised parameter" in
      Lwt.return
-       Html5.F.(html
+       Html.F.(html
           (head (title (pcdata "")) [])
           (body [div [
             pcdata nlp; br();
-            Html5.D.Form.post_form nlpost_with_nlp (create_form_nl "with nl param") ((),(12, "ab"));
+            Html.D.Form.post_form nlpost_with_nlp (create_form_nl "with nl param") ((),(12, "ab"));
             br ();
-            Html5.D.Form.post_form nlpost (create_form_nl "without nl param") ();
+            Html.D.Form.post_form nlpost (create_form_nl "without nl param") ();
           ]])))
 
 let () = My_appl.register nlpost_entry
   (fun () () ->
      Lwt.return
-       Html5.F.(html
+       Html.F.(html
           (head (title (pcdata "")) [])
           (body [div [
-            Html5.D.Form.post_form nlpost_with_nlp (create_form_nl "with nl param") ((),(12, "ab"));
+            Html.D.Form.post_form nlpost_with_nlp (create_form_nl "with nl param") ((),(12, "ab"));
             br ();
-            Html5.D.Form.post_form nlpost (create_form_nl "without nl param") ();
+            Html.D.Form.post_form nlpost (create_form_nl "without nl param") ();
           ]])))
 
 
@@ -4002,10 +4002,10 @@ let () =
 (********************************************************)
 (* Test Eliom_service.static_dir *)
 {shared{
-  let image : _ Html5.elt =
-    Html5.D.(
+  let image : _ Html.elt =
+    Html.D.(
       img ~alt:"some static file"
-        ~src:(Html5.D.make_uri
+        ~src:(Html.D.make_uri
                 ~service:(Eliom_service.static_dir ())
                 ["some static file"])
         ()
@@ -4037,16 +4037,16 @@ let nexti _ = next ()
 let () = My_appl.register states_test
   (fun () () ->
      Lwt.return
-       Html5.F.(
+       Html.F.(
          html
            (head (title (pcdata "States test")) [])
            (body [
              h1 [pcdata "Testing states for different scopes"];
              p [
                pcdata "This test is an extensive test of Eliom references of different scopes, accessed from inside or outside the state itself. To run this test, you need at least two different browsers, one with several tabs on ";
-               Html5.D.a states_test_bis [pcdata "this page"] "A";
+               Html.D.a states_test_bis [pcdata "this page"] "A";
                pcdata " and another with several tabs on ";
-               Html5.D.a states_test_bis [pcdata "this other page"] "B";
+               Html.D.a states_test_bis [pcdata "this other page"] "B";
                pcdata ". All tabs of a same browser must be one the same page, because loading the page sets the session group. Read the instructions on these pages.";
              ]])))
 
@@ -4165,7 +4165,7 @@ let () = My_appl.register states_test_bis
     lwt psr = Eliom_reference.get psr in
     lwt ppr = Eliom_reference.get ppr in
     Lwt.return
-      Html5.F.(
+      Html.F.(
         html
           (head (title (pcdata ("States test — group "^group))) [])
           (body [

--- a/tests/testsuite/eliom_testsuite4.eliom
+++ b/tests/testsuite/eliom_testsuite4.eliom
@@ -37,7 +37,7 @@ let test_client_value_on_caml_service =
   Eliom_testsuite_base.test
     ~title:"Client values in Ocaml-services"
     ~path:["holes"; "caml_service"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       pcdata "On loading: \"From main service\"";
       br ();
       pcdata "On clicking button";
@@ -68,7 +68,7 @@ let test_client_value_on_caml_service =
                 Eliom_testsuite_base.log "Exception on server: %s" msg;
                 Lwt.return ())
        }} in
-       Lwt.return Html5.F.([
+       Lwt.return Html.F.([
          Form.button_no_value ~a:[a_onclick onclick ] ~button_type:`Submit [
            pcdata "Click to get ocaml service";
          ]
@@ -78,13 +78,13 @@ let test_client_value_on_caml_service =
 (*                          Binding of escaped nodes                          *)
 
 let free_global =
-  Html5.(Id.create_global_elt (D.div F.([b [pcdata "Global (free)"]])))
+  Html.(Id.create_global_elt (D.div F.([b [pcdata "Global (free)"]])))
 let bound_global =
-  Html5.(Id.create_global_elt (D.div F.([b [pcdata "Global (bound)"]])))
+  Html.(Id.create_global_elt (D.div F.([b [pcdata "Global (bound)"]])))
 let free_request =
-  Html5.(D.div F.([b [pcdata "Request (free)"]]))
+  Html.(D.div F.([b [pcdata "Request (free)"]]))
 let bound_request =
-  Html5.(D.div F.([b [pcdata "Request (bound)"]]))
+  Html.(D.div F.([b [pcdata "Request (bound)"]]))
 
 let other_service =
   Eliom_registration.Ocaml.register_coservice'
@@ -92,18 +92,18 @@ let other_service =
     (fun () () ->
        ignore {unit{
            Lwt_log.ign_debug "on other service";
-         Html5.Manip.appendChild
+         Html.Manip.appendChild
            %free_request
-           Html5.F.(div [pcdata "from ocaml service"]);
-         Html5.Manip.appendChild
+           Html.F.(div [pcdata "from ocaml service"]);
+         Html.Manip.appendChild
            %free_global
-           Html5.F.(div [pcdata "from ocaml service"]);
-         Html5.Manip.appendChild
+           Html.F.(div [pcdata "from ocaml service"]);
+         Html.Manip.appendChild
            %bound_request
-           Html5.F.(div [pcdata "from ocaml service"]);
-         Html5.Manip.appendChild
+           Html.F.(div [pcdata "from ocaml service"]);
+         Html.Manip.appendChild
            %bound_global
-           Html5.F.(div [pcdata "from ocaml service"]);
+           Html.F.(div [pcdata "from ocaml service"]);
          ()
        }};
        Lwt.return ())
@@ -113,31 +113,31 @@ let other_service =
   Eliom_client.onload
     (fun () ->
        Lwt_log.ign_debug "onload";
-       Html5.Manip.appendChild
+       Html.Manip.appendChild
          %free_request
-         Html5.F.(div [pcdata "from client init"]);
-       Html5.Manip.appendChild
+         Html.F.(div [pcdata "from client init"]);
+       Html.Manip.appendChild
          %free_global
-         Html5.F.(div [pcdata "from client init"]);
-       Html5.Manip.appendChild
+         Html.F.(div [pcdata "from client init"]);
+       Html.Manip.appendChild
          %bound_request
-         Html5.F.(div [pcdata "from client init"]);
-       Html5.Manip.appendChild
+         Html.F.(div [pcdata "from client init"]);
+       Html.Manip.appendChild
          %bound_global
-         Html5.F.(div [pcdata "from client init"]);
+         Html.F.(div [pcdata "from client init"]);
        ())
 }}
 
-let addenda = Html5.D.div []
+let addenda = Html.D.div []
 
-let node_bindings_local_global_id = Html5.Id.new_elt_id ~global:true ()
-let node_bindings_local_request_id = Html5.Id.new_elt_id ~global:false ()
+let node_bindings_local_global_id = Html.Id.new_elt_id ~global:true ()
+let node_bindings_local_request_id = Html.Id.new_elt_id ~global:false ()
 
 let node_bindings =
   Eliom_testsuite_base.test
     ~title:"Binding of nodes"
     ~path:["holes"; "node_binding"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       p [pcdata "Observe when HTML5 elements with DOM semantics are reused."];
       p [pcdata "Bound nodes are sent in the page; free nodes are added by client value side effect after loading the page."];
       ul [
@@ -149,17 +149,17 @@ let node_bindings =
     ])
     (fun () ->
       let local_bound_global =
-        Html5.Id.create_named_elt ~id:node_bindings_local_global_id
-          Html5.(D.div [F.(b [pcdata "Global (bound, local)"])])
+        Html.Id.create_named_elt ~id:node_bindings_local_global_id
+          Html.(D.div [F.(b [pcdata "Global (bound, local)"])])
       in
       let local_bound_request =
-        Html5.Id.create_named_elt ~id:node_bindings_local_request_id
-          Html5.(D.div [F.(b [pcdata "Request (bound, local)"])])
+        Html.Id.create_named_elt ~id:node_bindings_local_request_id
+          Html.(D.div [F.(b [pcdata "Request (bound, local)"])])
       in
       ignore {unit{
           Lwt_log.ign_debug "Adding free";
-         Html5.Manip.appendChild %addenda %free_request;
-         Html5.Manip.appendChild %addenda %free_global;
+         Html.Manip.appendChild %addenda %free_request;
+         Html.Manip.appendChild %addenda %free_global;
          ignore %bound_global;
          ignore %bound_request;
          ignore %local_bound_global;
@@ -171,8 +171,8 @@ let node_bindings =
            Lwt_log.ign_debug "onclick";
            List.iter
              (fun node ->
-               Html5.Manip.appendChild node
-                 Html5.F.(div [pcdata "onclick"]))
+               Html.Manip.appendChild node
+                 Html.F.(div [pcdata "onclick"]))
              [%free_request; %free_global; %bound_request; %bound_global; %local_bound_global; %local_bound_request];
        }} in
        let run_ocaml_service = {{
@@ -181,7 +181,7 @@ let node_bindings =
            Lwt.ignore_result
              (Eliom_client.call_ocaml_service ~service: %other_service () ())
        }} in
-       Lwt.return Html5.F.([
+       Lwt.return Html.F.([
          Eliom_testsuite_base.thebutton ~msg:"Add onclick lines" add_onclick;
          Eliom_testsuite_base.thebutton ~msg:"Run ocaml service" run_ocaml_service;
          local_bound_global;
@@ -194,16 +194,16 @@ let node_bindings =
 (******************************************************************************)
 (*                                Data sharing                                *)
 
-let data_sharing_elt1 = Html5.D.(div ~a:[a_class ["monospace"]] [pcdata "VVVVVVVVVVV"])
-let data_sharing_elt2 = Html5.D.(div ~a:[a_class ["monospace"]] [pcdata "WWWWWWWWWWW"])
-let data_sharing_elt3 = Html5.D.(div ~a:[a_class ["monospace"]] [pcdata "XXXXXXXXXXX"])
-let data_sharing_addenda = Html5.D.div []
+let data_sharing_elt1 = Html.D.(div ~a:[a_class ["monospace"]] [pcdata "VVVVVVVVVVV"])
+let data_sharing_elt2 = Html.D.(div ~a:[a_class ["monospace"]] [pcdata "WWWWWWWWWWW"])
+let data_sharing_elt3 = Html.D.(div ~a:[a_class ["monospace"]] [pcdata "XXXXXXXXXXX"])
+let data_sharing_addenda = Html.D.div []
 
 let data_sharing =
   Eliom_testsuite_base.test
     ~title:"Data sharing"
     ~path:["holes"; "data_sharing"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       p [pcdata "Checks wheather data in the eliom request data is shared"];
       p [pcdata "The string of request data is given below."];
       p [pcdata "There are three elements on the server, which contain the strings
@@ -215,19 +215,19 @@ let data_sharing =
                  exactly once."]
     ])
     (fun () ->
-       let data_sharing_data = Html5.D.div [] in
+       let data_sharing_data = Html.D.div [] in
        ignore {unit{
-         Html5.Manip.appendChild %data_sharing_addenda
+         Html.Manip.appendChild %data_sharing_addenda
            %data_sharing_elt1;
-         Html5.Manip.appendChild %data_sharing_addenda
+         Html.Manip.appendChild %data_sharing_addenda
            %data_sharing_elt2;
        }};
        ignore {unit{
-         Html5.Manip.appendChild %data_sharing_data
-           (Html5.F.pcdata
+         Html.Manip.appendChild %data_sharing_data
+           (Html.F.pcdata
               (Js.to_string (Js.Unsafe.get Js.Unsafe.global (Js.string "__eliom_request_data"))))
        }};
-       Lwt.return Html5.F.([
+       Lwt.return Html.F.([
          data_sharing_elt1;
          section [ h4 [ pcdata "Added from client" ]; data_sharing_addenda ];
          section [ h4 [ pcdata "Request data" ]; data_sharing_data ];
@@ -238,7 +238,7 @@ let data_sharing =
     ignore (%data_sharing_elt1, %data_sharing_elt2);
     Eliom_client.onload
       (fun () ->
-        Html5.Manip.appendChild %data_sharing_addenda
+        Html.Manip.appendChild %data_sharing_addenda
           %data_sharing_elt3)
 }}
 
@@ -250,7 +250,7 @@ let data_sharing =
   type my_data = { x : int; y : int } deriving (Json)
 
   let my_data =
-    Eliom_content.Html5.Custom_data.create_json ~name:"my_int" ~default:{x=0;y=0;} Json.t<my_data>
+    Eliom_content.Html.Custom_data.create_json ~name:"my_int" ~default:{x=0;y=0;} Json.t<my_data>
 
 }}
 
@@ -258,14 +258,14 @@ let data_sharing =
 
   let show_my_data (ev : Dom_html.mouseEvent Js.t) =
     let elt = Js.Opt.get (ev##target) (fun () -> failwith "show_my_data") in
-    let i = Html5.Custom_data.get_dom elt my_data in
+    let i = Html.Custom_data.get_dom elt my_data in
     Dom_html.window##alert (Js.string (Printf.sprintf "custom_data : {x=%d;y=%d}" i.x i.y))
 
   let change_data container =
-    let element = Html5.To_dom.of_element container in
-    let i = Html5.Custom_data.get_dom element my_data in
+    let element = Html.To_dom.of_element container in
+    let i = Html.Custom_data.get_dom element my_data in
     let i' = { x = succ i.x; y = pred i.y } in
-    Html5.Custom_data.set_dom element my_data i'
+    Html.Custom_data.set_dom element my_data i'
 }}
 
 let test_custom_data =
@@ -276,9 +276,9 @@ let test_custom_data =
     ~path
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-       let open Html5.F in
+       let open Html.F in
        let container =
-         Html5.D.div ~a:[Html5.Custom_data.attrib my_data { x = 100; y = 100 }]
+         Html.D.div ~a:[Html.Custom_data.attrib my_data { x = 100; y = 100 }]
            [pcdata "A: click me (my_data is originally {x=100;y=100})"]
        in
        let change_button =
@@ -334,7 +334,7 @@ let client_values_injection =
     ~get_params:Eliom_parameter.unit
     (fun () () ->
        let cstr = {string{ "cstr" }} in
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -385,7 +385,7 @@ let client_values_mutability =
     ~path
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -424,7 +424,7 @@ let client_values_changing_context =
     (fun () () ->
        incr ix;
        debug "ix: %d" !ix;
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -481,7 +481,7 @@ let client_values_initialization =
     (let ix = ref 0 in
      fun () () ->
        incr ix;
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -503,13 +503,13 @@ let client_values_initialization =
 (*                          Client value custom data                          *
 
 {shared{
-  let my_unit_unit = Html5.Custom_data.create_client_value ~name:"my_unit_unit" ()
+  let my_unit_unit = Html.Custom_data.create_client_value ~name:"my_unit_unit" ()
 }}
 
 {client{
 
-  let run_element : _ Eliom_content.Html5.elt -> unit -> unit =
-    let f = Html5.Custom_data.get_dom (To_dom.of_element trg) my_unit_unit in
+  let run_element : _ Eliom_content.Html.elt -> unit -> unit =
+    let f = Html.Custom_data.get_dom (To_dom.of_element trg) my_unit_unit in
     f ()
 
   let f () =
@@ -527,11 +527,11 @@ let client_values_initialization =
   let b = {string->string{ fun x -> "(b" ^ " " ^ %a ^ " " ^ x ^ ")" }}
 
   let my_div label cv =
-    Html5.F.(
+    Html.F.(
       let onclick = {{
         fun ev -> run_element ev##target ()
       }} in
-      div ~a:[a_onclick onclick; Html5.Custom_data.attrib my_unit_unit cv] [
+      div ~a:[a_onclick onclick; Html.Custom_data.attrib my_unit_unit cv] [
         pcdata label
       ]
     )
@@ -543,7 +543,7 @@ let client_values_initialization =
       (fun () () ->
          (* let w = 1 in *)
          Eliom_service.onload' {{ fun () -> debug "hic %s" ( %b "x") }};
-         Lwt.return Html5.F.(
+         Lwt.return Html.F.(
            html
              (Eliom_tools.F.head
                 ~title:"client_values"
@@ -560,7 +560,7 @@ let client_values_initialization =
 
   let elt src =
     ignore {unit{ debug "creating elt from %s" %src }};
-    Html5.F.(div ~a:[a_onclick {{ fun _ -> debug "click!"}}] [pcdata ("click ("^src^")")])
+    Html.F.(div ~a:[a_onclick {{ fun _ -> debug "click!"}}] [pcdata ("click ("^src^")")])
 
 }}
 
@@ -581,9 +581,9 @@ let test_simple =
          fun _ ->
            Dom.appendChild
              (Dom_html.document##body)
-             (Eliom_content.Html5.To_dom.of_div (elt "client"))
+             (Eliom_content.Html.To_dom.of_div (elt "client"))
        }} in
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -645,12 +645,12 @@ let test_simple =
           in
           Dom_html.window##alert(Js.string str)
       }} in
-      Html5.F.(
+      Html.F.(
         li ~a:[a_onclick client_onclick]
           [ pcdata "client_onclick: %shared_value=\"shared_value\" %client_value=\"client_value\""]
       )
     );
-    Html5.F.(
+    Html.F.(
       li ~a:[a_onclick (shared_onclick "client")]
         [pcdata "shared_onclick from client: %shared_onclick=\"shared_value\""]
     );
@@ -682,12 +682,12 @@ let test_simple =
           in
           Dom_html.window##alert(Js.string str)
       }} in
-      Html5.F.(
+      Html.F.(
         li ~a:[a_onclick server_onclick]
           [pcdata "server_onclick: %shared_value=\"shared_value\" %server_value=\"server_value\""]
       )
     );
-    Html5.F.(
+    Html.F.(
       li ~a:[a_onclick (shared_onclick "server")]
         [pcdata "shared_onclick from server: %shared_value=\"shared_value\""]
     );
@@ -701,7 +701,7 @@ let test_simple =
 {shared{
 
   let shared_tests context = [
-    Html5.F.(
+    Html.F.(
       li ~a:[a_onclick (shared_onclick (context^" via shared"))] [
         pcdata
           ("shared_onclick from " ^ context ^ " via shared: " ^ "%shared_value=\"shared_value\"")
@@ -718,15 +718,15 @@ let client_handler_syntax =
     ~path
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-       let open Html5.F in
-       let tests_id = Html5.Id.new_elt_id ~global:false () in
+       let open Html.F in
+       let tests_id = Html.Id.new_elt_id ~global:false () in
        Eliom_service.onload {{
          fun _ ->
-           List.iter (Html5.Manip.Named.appendChild %tests_id) Html5.F.([
+           List.iter (Html.Manip.Named.appendChild %tests_id) Html.F.([
              div [pcdata "Client elements"];
              ul (client_tests);
            ]);
-           List.iter (Html5.Manip.Named.appendChild %tests_id) Html5.F.([
+           List.iter (Html.Manip.Named.appendChild %tests_id) Html.F.([
              div [pcdata "Shared elements used from client"];
              ul (shared_tests "client");
            ])
@@ -736,7 +736,7 @@ let client_handler_syntax =
            (Eliom_tools.F.head ~title:(String.concat "/" path) ())
            (body [
              h1 [pcdata description];
-             Html5.Id.create_named_elt ~id:tests_id
+             Html.Id.create_named_elt ~id:tests_id
                (div [
                  div [pcdata "Server elements"];
                  ul server_tests;
@@ -753,12 +753,12 @@ let client_handler_syntax =
 {shared{
 
   type hidden_widget = {
-    content : Html5_types.div_content Html5.elt list;
-    widget_id : Html5_types.flow5 Html5.Id.id;
-    overlay_id : Html5_types.div Html5.Id.id;
-    container_id : Html5_types.div Html5.Id.id;
+    content : Html_types.div_content Html.elt list;
+    widget_id : Html_types.flow5 Html.Id.id;
+    overlay_id : Html_types.div Html.Id.id;
+    container_id : Html_types.div Html.Id.id;
     mutable show_callback : (unit -> unit) option;
-    mutable content_getter : (unit -> Html5_types.div_content Html5.elt list Lwt.t) option;
+    mutable content_getter : (unit -> Html_types.div_content Html.elt list Lwt.t) option;
     mutable set_content_thread : unit Lwt.t option;
   }
 
@@ -767,25 +767,25 @@ let client_handler_syntax =
 {shared{
 
   let hidden_widget content = {
-    content = (content :> Html5_types.div_content Html5.elt list);
-    widget_id = Html5.Id.new_elt_id ();
-    overlay_id = Html5.Id.new_elt_id ();
-    container_id = Html5.Id.new_elt_id ();
+    content = (content :> Html_types.div_content Html.elt list);
+    widget_id = Html.Id.new_elt_id ();
+    overlay_id = Html.Id.new_elt_id ();
+    container_id = Html.Id.new_elt_id ();
     show_callback = None;
     content_getter = None;
     set_content_thread = None;
   }
 
   let hidden_widget_html w =
-    let open Html5.F in
+    let open Html.F in
     let container =
-      Html5.Id.create_named_elt ~id:w.container_id
+      Html.Id.create_named_elt ~id:w.container_id
         (div ~a:[a_class ["container"]; a_style "display: none"] w.content)
     in
     let onclick_overlay = {{
       fun _ ->
-        Html5.(Manip.SetCss.display (Id.get_element %w.overlay_id) "none");
-        Html5.(Manip.SetCss.display (Id.get_element %w.container_id) "block");
+        Html.(Manip.SetCss.display (Id.get_element %w.overlay_id) "none");
+        Html.(Manip.SetCss.display (Id.get_element %w.container_id) "block");
         Option.iter (fun f -> f ()) %w.show_callback;
         Option.iter
           (fun f ->
@@ -793,7 +793,7 @@ let client_handler_syntax =
              let t =
                lwt () = waiter in
                lwt content = f () in
-               Html5.Manip.Named.replaceAllChild %w.container_id content;
+               Html.Manip.Named.replaceAllChild %w.container_id content;
                Lwt.return ()
              in
              Lwt.wakeup wakener ();
@@ -802,13 +802,13 @@ let client_handler_syntax =
       ()
     }} in
     let overlay =
-      Html5.Id.create_named_elt ~id:w.overlay_id
+      Html.Id.create_named_elt ~id:w.overlay_id
         (div ~a:[
           a_class ["overlay"];
           a_onclick onclick_overlay;
         ] [ pcdata "click to show"; ])
     in
-    Html5.Id.create_named_elt ~id:w.widget_id
+    Html.Id.create_named_elt ~id:w.widget_id
       (div ~a:[a_class ["hidden_widget"]] [ overlay; container; ])
 
 }}
@@ -816,9 +816,9 @@ let client_handler_syntax =
 {client{
 
   let hidden_widget_hide w _ =
-    Html5.Manip.Named.replaceAllChild w.container_id w.content;
-    Html5.(Manip.SetCss.display (Id.get_element w.overlay_id) "block");
-    Html5.(Manip.SetCss.display (Id.get_element w.container_id) "none");
+    Html.Manip.Named.replaceAllChild w.container_id w.content;
+    Html.(Manip.SetCss.display (Id.get_element w.overlay_id) "block");
+    Html.(Manip.SetCss.display (Id.get_element w.container_id) "none");
     Option.iter (fun t -> Lwt.cancel t; w.set_content_thread <- None) w.set_content_thread;
     ()
 
@@ -837,8 +837,8 @@ let get_slow_content =
        let sleep_time = 1.0 +. Random.float 4.0 in
        debug "Sleep %f" sleep_time;
        lwt () = Lwt_unix.sleep sleep_time in
-       Lwt.return Html5.F.([
-         (h2 [pcdata "Slow content"] :> Html5_types.div_content Html5.elt);
+       Lwt.return Html.F.([
+         (h2 [pcdata "Slow content"] :> Html_types.div_content Html.elt);
          p [pcdata (Printf.sprintf "Had to sleep %f seconds for this" sleep_time)];
        ]))
 
@@ -847,9 +847,9 @@ let client_handler_syntax_2 =
     ~path:["client_handler_syntax_2"]
     ~get_params:Eliom_parameter.unit
     (fun () () ->
-       let w = hidden_widget [Html5.F.pcdata "waiting ..."] in
+       let w = hidden_widget [Html.F.pcdata "waiting ..."] in
        let hide_button =
-         Html5.D.(
+         Html.D.(
            button ~a:[a_onclick {{ hidden_widget_hide %w }} ] ~button_type:`Submit [
              pcdata "Hide again";
            ])
@@ -857,11 +857,11 @@ let client_handler_syntax_2 =
        let add_another_waiter_button =
          let onclick = {{
            fun _ ->
-             let w = hidden_widget [Html5.F.pcdata "Incredible content!"] in
+             let w = hidden_widget [Html.F.pcdata "Incredible content!"] in
              ignore (Dom.appendChild (Dom_html.document##body)
-                       (Html5.To_dom.of_element (hidden_widget_html w)))
+                       (Html.To_dom.of_element (hidden_widget_html w)))
          }} in
-         Html5.D.(
+         Html.D.(
            button ~a:[a_onclick onclick ] ~button_type:`Submit [
              pcdata "Add another waiter widget";
            ])
@@ -873,13 +873,13 @@ let client_handler_syntax_2 =
                 ignore
                   (Dom.insertBefore
                      (Dom_html.document##body)
-                     (Html5.To_dom.of_element %hide_button)
+                     (Html.To_dom.of_element %hide_button)
                      Js.null));
            hidden_widget_set_content_getter %w
              (fun () ->
                 Eliom_client.call_caml_service ~service: %get_slow_content () ())
        }};
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:"client_handler_syntax_2"
@@ -911,7 +911,7 @@ let client_values_shared =
   Eliom_testsuite_base.My_appl.register_service
     ~path ~get_params:Eliom_parameter.unit
     (fun () () ->
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -937,7 +937,7 @@ let client_values_shared =
          debug "shared onload from %s" %src;
          Lwt.return ())
     }};
-    Html5.F.(div [pcdata ("shared elt from "^src)])
+    Html.F.(div [pcdata ("shared elt from "^src)])
 }}
 
 {client{
@@ -949,7 +949,7 @@ let client_values_shared =
          debug "client onload";
          Lwt.return ())
     }};
-    Html5.F.(div [pcdata "client elt"])
+    Html.F.(div [pcdata "client elt"])
 }}
 
 {server{
@@ -961,7 +961,7 @@ let client_values_shared =
          debug "server onload";
          Lwt.return ())
     }};
-    Html5.F.(div [pcdata "server elt"])
+    Html.F.(div [pcdata "server elt"])
 }}
 
 
@@ -977,13 +977,13 @@ let client_values_onload =
            (lwt () = Eliom_client.wait_load_end () in
             Dom.appendChild
               (Dom_html.document##body)
-              (Html5.To_dom.of_div (shared_elt "client"));
+              (Html.To_dom.of_div (shared_elt "client"));
             Dom.appendChild
               (Dom_html.document##body)
-              (Html5.To_dom.of_div client_elt);
+              (Html.To_dom.of_div client_elt);
             Lwt.return ())
        }};
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -1044,7 +1044,7 @@ let s = Eliom_registration.Action.register_coservice'
   let () = debug "global_value: %Ld" %global_value
 
   let link () =
-     Html5.F.(div [(*a ~service: %s [pcdata "Action! (on server)"] ()*)])
+     Html.F.(div [(*a ~service: %s [pcdata "Action! (on server)"] ()*)])
 
 }}
 
@@ -1070,10 +1070,10 @@ let escaped_in_client =
             show_server_injections ();
             Dom.appendChild
               (Dom_html.document##body)
-              (Html5.To_dom.of_element (link ()));
+              (Html.To_dom.of_element (link ()));
             Lwt.return ())
        }};
-       Lwt.return Html5.F.(
+       Lwt.return Html.F.(
          html
            (Eliom_tools.F.head
               ~title:(String.concat "/" path)
@@ -1103,7 +1103,7 @@ let request_reference =
 
 let deep_client_value = Some {string{ "client value" }}
 
-let an_elt = Html5.D.div []
+let an_elt = Html.D.div []
 
 {client{
 
@@ -1111,9 +1111,9 @@ let an_elt = Html5.D.div []
     Lwt.ignore_result
       (lwt () = Eliom_client.wait_load_end () in
        debug "---> !!! 2";
-       Html5.Manip.appendChild
+       Html.Manip.appendChild
          %an_elt
-         Html5.F.(pcdata "!!! 2");
+         Html.F.(pcdata "!!! 2");
        Lwt.return ());
     log "client TOP"
 
@@ -1134,7 +1134,7 @@ let deep_client_values =
   Eliom_testsuite_base.test
     ~title:"Client value injections"
     ~path:["client"; "injections"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       pcdata
         ""
     ])
@@ -1157,11 +1157,11 @@ let deep_client_values =
        Eliom_service.onload {{
          fun _ ->
            debug "---> !!! 1";
-           Html5.Manip.appendChild
+           Html.Manip.appendChild
              %an_elt
-             Html5.F.(pcdata "!!! 1")
+             Html.F.(pcdata "!!! 1")
        }};
-       Lwt.return Html5.F.([
+       Lwt.return Html.F.([
          div [a ~service:Eliom_service.reload_action [pcdata "reload in app"] ()];
          div [
            button ~a:[a_onclick onclick ] ~button_type:`Submit [
@@ -1213,7 +1213,7 @@ let test_injection_scoping =
   Eliom_testsuite_base.test
     ~title
     ~path:["holes"; "injection_scoping"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       p [pcdata "Test, which value is referenced by ";
          Eliom_testsuite_base.monospace "v";
          pcdata " and an injection ";
@@ -1238,7 +1238,7 @@ let test_injection_scoping =
          injection_scoping_client ();
          Eliom_testsuite_base.report_flush_assertions %title;
        }};
-       Lwt.return Html5.F.([]))
+       Lwt.return Html.F.([]))
 
 (******************************************************************************)
 
@@ -1296,7 +1296,7 @@ let test_escaping_scoping =
   let title = "Scoping of escaped variables in server/shared-section" in
   Eliom_testsuite_base.test ~title
     ~path:["holes"; "escaping_scoping"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       p [pcdata "Test, which value is referenced by ";
          Eliom_testsuite_base.monospace "v";
          pcdata " and an escaped variable ";
@@ -1324,7 +1324,7 @@ let test_escaping_scoping =
          escaping_scoping_shared ();
          Eliom_testsuite_base.report_flush_assertions %title;
        }};
-       Lwt.return Html5.F.([]))
+       Lwt.return Html.F.([]))
 
 (******************************************************************************)
 
@@ -1341,7 +1341,7 @@ let test_server_function =
   Eliom_testsuite_base.test
     ~title:"RPC / server functions"
     ~path:["mixed"; "server_function"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       pcdata
         "Server functions make functions from the server available on the client.";
       br ();
@@ -1352,10 +1352,10 @@ let test_server_function =
         "If you send the empty string, however, an exception is raised on the server.";
     ])
     (fun () ->
-       let field = Html5.D.input ~a:[Html5.D.a_input_type `Text] () in
+       let field = Html.D.input ~a:[Html.D.a_input_type `Text] () in
        let onclick = {{
          fun _ ->
-           let field_dom = Html5.To_dom.of_input %field in
+           let field_dom = Html.To_dom.of_input %field in
            let str = Js.to_string field_dom##value in
            field_dom##value <- Js.string "";
            Lwt.async
@@ -1368,7 +1368,7 @@ let test_server_function =
                  Eliom_testsuite_base.log "Exception on server: %s" str;
                  Lwt.return ())
        }} in
-       Lwt.return Html5.F.([
+       Lwt.return Html.F.([
          Eliom_testsuite_base.thebutton ~msg:"send" onclick;
          br ();
          field;
@@ -1412,7 +1412,7 @@ let client_value_initialization =
   Eliom_testsuite_base.test
     ~title:"Order of initializations of client values"
     ~path:["holes"; "client_value_initialization"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       p [pcdata "The client logger should show the STEPs 0-6"];
       p [pcdata "The server output should show STEPs 0-1"];
     ])
@@ -1430,10 +1430,10 @@ let wrap_handler =
       (Eliom_tools.wrap_handler
          (fun () -> Eliom_reference.get state)
          (fun () () -> Lwt.return
-           Html5.F.(html (head (title (pcdata "not set")) [])
+           Html.F.(html (head (title (pcdata "not set")) [])
                       (body [pcdata "not set"])))
          (fun value () () -> Lwt.return
-           Html5.F.(html (head (title (pcdata "set")) [])
+           Html.F.(html (head (title (pcdata "set")) [])
                       (body [Printf.ksprintf pcdata "set to %d." value]))))
   in
   let set_state =
@@ -1456,11 +1456,11 @@ let wrap_handler =
   Eliom_testsuite_base.test
     ~title:"Wrap handler"
     ~path:["mixed"; "wrap_handler"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       pcdata "The links 'set state' and 'unset state' allow to modify a state.";
       pcdata "The link 'test state' show whether the state is set or not.";
     ])
-    (fun () -> Lwt.return Html5.F.([
+    (fun () -> Lwt.return Html.F.([
       ul [
         li [a ~service [pcdata "test state"] ()];
         li [a ~service:set_state [pcdata "set state"] ()];
@@ -1474,7 +1474,7 @@ let cross_change_page_client_values =
   Eliom_testsuite_base.test
     ~title:"Cross change page client values"
     ~path:["holes";"cross_change_page"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       ul [
         li [pcdata "The server keeps a global client value with a client reference. \
                     It is logged on each change_page (reload within application). \
@@ -1486,7 +1486,7 @@ let cross_change_page_client_values =
         Eliom_testsuite_base.log "Global client reference is %S" ! %global_client_ref;
         %global_client_ref := ! %global_client_ref ^ "'"
       }};
-      Lwt.return Html5.F.([
+      Lwt.return Html.F.([
       ]))
 
 (******************************************************************************)
@@ -1499,7 +1499,7 @@ let test_ocaml_service_timeout =
   Eliom_testsuite_base.test
     ~title:"Timeout for ocaml services"
     ~path:["timeout_ocaml_service"]
-    ~description:Html5.F.([
+    ~description:Html.F.([
       pcdata "Demo on how to put a timeout on an Ocaml service call.";
     ])
     (fun () ->
@@ -1517,7 +1517,7 @@ let test_ocaml_service_timeout =
              Eliom_testsuite_base.log "Timeout reached";
              Lwt.return ())
        }};
-       Lwt.return Html5.F.([]))
+       Lwt.return Html.F.([]))
 (*****************************************************************************)
 
 let tests = [

--- a/tests/testsuite/eliom_testsuite5.eliom
+++ b/tests/testsuite/eliom_testsuite5.eliom
@@ -8,15 +8,15 @@
 let simple_dom_react = Eliom_testsuite_base.test
     ~title: "Client dom react"
     ~path:["React";"client";"simple"]
-    ~description:Html5.F.([pcdata "a simple example of dom react"])
+    ~description:Html.F.([pcdata "a simple example of dom react"])
     (fun () ->
        let signal = {(string React.S.t * (string -> unit)){
            let s,set =  React.S.create "" in
            s, (fun s -> set s)}} in
        let input =
-         Html5.D.Form.input
-           Html5.D.Form.string
-           ~input_type:`Text ~a:[Html5.D.a_onkeyup {{ fun e ->
+         Html.D.Form.input
+           Html.D.Form.string
+           ~input_type:`Text ~a:[Html.D.a_onkeyup {{ fun e ->
              let i = Dom.eventTarget e in
              let i = Js.Unsafe.coerce i in
              (snd %signal)(Js.to_string (i##value))
@@ -30,15 +30,15 @@ let simple_dom_react = Eliom_testsuite_base.test
          let v_succ = React.S.map succ i in
          let v_double = React.S.map (( * ) 2) i in
          let v_minus = React.S.map (fun x -> - x) i in
-         let r_int s = Html5.R.pcdata (React.S.map string_of_int s) in
+         let r_int s = Html.R.pcdata (React.S.map string_of_int s) in
          let style = React.S.map (fun x -> if x then "color:green;" else "color:red;") valid in
          let rlist, rhandle = ReactiveData.RList.create [0] in
          let _ = React.E.map (fun x ->
              if x > 0
              then ReactiveData.RList.snoc x rhandle
              else ReactiveData.RList.cons x rhandle) (React.S.changes i) in
-         Html5.(F.div ~a:[R.a_style style] [
-             F.div [ F.pcdata "textarea : " ; R.textarea ~a:[F.a_maxlength 10; F.a_readonly `ReadOnly ; F.a_style "vertical-align: top"] (React.S.map F.pcdata s)];
+         Html.(F.div ~a:[R.a_style style] [
+             F.div [ F.pcdata "textarea : " ; R.textarea ~a:[F.a_maxlength 10; F.a_readonly () ; F.a_style "vertical-align: top"] (React.S.map F.pcdata s)];
              F.div [ F.pcdata "original : "; r_int i];
              F.div [ F.pcdata "succ : "; r_int v_succ];
              F.div [ F.pcdata "double : "; r_int v_double];
@@ -57,7 +57,7 @@ let simple_dom_react = Eliom_testsuite_base.test
              R.div (ReactiveData.RList.map (fun i -> F.div [F.pcdata (string_of_int i)]) rlist)
            ])
        }} in
-       Lwt.return [ Html5.F.div [input;Html5.C.node dom] ]
+       Lwt.return [ Html.F.div [input;Html.C.node dom] ]
     )
 
 let tests = [

--- a/tests/testsuite/eliom_testsuite6.eliom
+++ b/tests/testsuite/eliom_testsuite6.eliom
@@ -1,8 +1,8 @@
 (* Copyright Vincent Balat *)
 {shared{
 open Eliom_lib
-open Eliom_content.Html5
-open Eliom_content.Html5.F
+open Eliom_content.Html
+open Eliom_content.Html.F
 }}
 
 

--- a/tests/testsuite/eliom_testsuite7.eliom
+++ b/tests/testsuite/eliom_testsuite7.eliom
@@ -1,8 +1,8 @@
 (* Copyright Vincent Balat *)
 {shared{
 open Eliom_lib
-open Eliom_content.Html5
-open Eliom_content.Html5.F
+open Eliom_content.Html
+open Eliom_content.Html.F
 }}
 
 
@@ -55,7 +55,7 @@ let mainservice = Eliom_testsuite_base.My_appl.register_service
     in f 5
 
 let test, testh = ReactiveData.RList.create
-    ([pcdata "a"; pcdata "b"; ] : Html5_types.div_content_fun elt list)
+    ([pcdata "a"; pcdata "b"; ] : Html_types.div_content_fun elt list)
  }}
 {shared{
   let test0 _ = Lwt.return (D.div [D.h1 [pcdata "ze"]])

--- a/tests/testsuite/eliom_testsuite7_db.eliom
+++ b/tests/testsuite/eliom_testsuite7_db.eliom
@@ -1,8 +1,8 @@
 (* Copyright Vincent Balat *)
 {shared{
 open Eliom_lib
-open Eliom_content.Html5
-open Eliom_content.Html5.F
+open Eliom_content.Html
+open Eliom_content.Html.F
 }}
 
 {client{

--- a/tests/testsuite/eliom_testsuite_base.eliom
+++ b/tests/testsuite/eliom_testsuite_base.eliom
@@ -129,9 +129,9 @@ module Registration = struct
          [ `WithoutSuffix ], unit, unit, 'a) Eliom_service.t ->
       'a redirection
 
-  module Html5 = struct
+  module Html = struct
 
-    include Eliom_registration.Html5
+    include Eliom_registration.Html
 
     let register_service
         ?code ?charset ?headers ?priority ?error_handler ~path
@@ -193,7 +193,7 @@ module Registration = struct
       and get_params = Eliom_service.get_params_type fallback in
       let id = Eliom_service.Path path
       and meth = Eliom_service.Post (get_params, post_params) in
-      Eliom_registration.Html5.create ~id ~meth f
+      Eliom_registration.Html.create ~id ~meth f
 
   end
 
@@ -254,7 +254,7 @@ let main =
 let main_service = main
 
 let tests description services =
-  Html5.F.(
+  Html.F.(
     div [
       h4 [pcdata description];
       ul
@@ -266,15 +266,15 @@ let tests description services =
   )
 
 let testsuite ~name testsuite_tests =
-  Html5.F.(
+  Html.F.(
     div
       (h3 [pcdata name] ::
        List.map (uncurry tests) testsuite_tests)
   )
 
 let test_logger =
-  Html5.Id.create_global_elt
-    (Html5.D.(div ~a:[a_class ["test_logger"]]
+  Html.Id.create_global_elt
+    (Html.D.(div ~a:[a_class ["test_logger"]]
                 [h4 [pcdata "Client logger"]]))
 
 let test ~path ~title:ttl ~description f =
@@ -293,7 +293,7 @@ let test ~path ~title:ttl ~description f =
               }}
               in
               Lwt.return
-                Html5.F.(html
+                Html.F.(html
                            (Eliom_tools.F.head
                               ~title:(String.concat "/" path)
                               ~css:[["style.css"]] ())
@@ -313,8 +313,8 @@ let test ~path ~title:ttl ~description f =
                                content @
                                [ test_logger ]))))
 
-let thebutton ?(msg="THE BUTTON") onclick : [> Html5_types.button ] Html5.elt =
-  Html5.F.(
+let thebutton ?(msg="THE BUTTON") onclick : [> Html_types.button ] Html.elt =
+  Html.F.(
     Form.button_no_value ~button_type:`Submit
       ~a:[a_class ["thebutton"]; a_onclick onclick]
       [ pcdata msg ])
@@ -322,16 +322,16 @@ let thebutton ?(msg="THE BUTTON") onclick : [> Html5_types.button ] Html5.elt =
 let monospace fmt =
   Printf.ksprintf
     (fun str ->
-       Html5.F.(span ~a:[a_class ["monospace"]] [pcdata str]))
+       Html.F.(span ~a:[a_class ["monospace"]] [pcdata str]))
     fmt
 
 {client{
 
   let buffer = ref []
   let append_log_message msg =
-    Html5.Manip.appendChild
+    Html.Manip.appendChild
       %test_logger
-      Html5.D.(div ~a:[a_class ["logging_line"]] [pcdata msg])
+      Html.D.(div ~a:[a_class ["logging_line"]] [pcdata msg])
 
   let () =
     let rec flush () =

--- a/tests/testsuite/eliom_testsuite_site.eliom
+++ b/tests/testsuite/eliom_testsuite_site.eliom
@@ -17,14 +17,14 @@ let reference_scope_site =
          lwt () = Eliom_reference.set Eliom_testsuite_global.eref (Some v) in
          Eliom_reference.set Eliom_testsuite_global.eref' (Some v))
   in
-  Eliom_registration.Html5.create
+  Eliom_registration.Html.create
     ~id:(Eliom_service.Path ["reference_scope_site"])
     ~meth:(Eliom_service.Get Eliom_parameter.unit)
     (fun () () ->
-       let show = function None -> Html5.D.entity "#x2012" | Some str -> Html5.D.pcdata str in
+       let show = function None -> Html.D.entity "#x2012" | Some str -> Html.D.pcdata str in
        lwt v = Lwt.map show (Eliom_reference.get Eliom_testsuite_global.eref) in
        lwt v' = Lwt.map show (Eliom_reference.get Eliom_testsuite_global.eref') in
-       Lwt.return Html5.D.(
+       Lwt.return Html.D.(
          html
            (head (title (pcdata "")) [])
            (body [
@@ -38,11 +38,11 @@ let reference_scope_site =
                pcdata ", persistent "; i [v'];
              ];
              pcdata "Enter a new string for both references";
-             Html5.D.Form.post_form
+             Html.D.Form.post_form
                ~service:action
                (fun name ->
-                  [Html5.D.Form.input ~input_type:`Text ~name
-                     Html5.D.Form.string ])
+                  [Html.D.Form.input ~input_type:`Text ~name
+                     Html.D.Form.string ])
                ()
            ])
        ))


### PR DESCRIPTION
Big but totally boring patch. Needs to be merged at the same time as ocsigen/js_of_ocaml#476 and the Ocsigenserver `tyxml` branch.

@balat @vouillon, you will need to do a mass `Html5 -> Html` replacement and use unit arguments for some attributes (`a_defer`,  etc.).