### PR TITLE
Fix client values in Eliom_service

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -436,6 +436,9 @@ let current_pseudo_fragment = ref ""
 let url_fragment_prefix = "!"
 let url_fragment_prefix_with_sharp = "#!"
 
+let default_reload_function () () =
+  Dom_html.window##location##reload()
+
 let reload_function = ref None
 let reload_functions = ref []
 

--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -508,9 +508,9 @@ let change_url
      | Some (Some _ as t) when t = Eliom_request_info.get_request_template () ->
          None
      | _ ->
-         match Eliom_service.get_reload_fun service with
-         | Some rf -> Some (fun () () -> rf params ())
-         | None    -> None);
+       match Eliom_service.reload_fun service with
+       | Some rf -> Some (fun () () -> rf params ())
+       | None    -> None);
   change_url_string ?replace
     (Eliom_uri.make_string_uri
        ?absolute
@@ -751,7 +751,7 @@ let change_page (type m)
              get_params post_params in
          set_template_content ?replace ~uri ?fragment (Some content)
        | _ ->
-         match Eliom_service.client_fun service () with
+         match Eliom_service.client_fun service with
          | Some f ->
            (* The service has a client side implementation.
               We do not make the request *)
@@ -759,7 +759,7 @@ let change_page (type m)
            Eliom_lib.Option.iter
              (fun rf ->
                 reload_function := Some (fun () () -> rf get_params ()))
-             (Eliom_service.get_reload_fun service);
+             (Eliom_service.reload_fun service);
            lwt () = f get_params post_params in
            let uri =
              match

--- a/src/lib/eliom_client_main.eliom
+++ b/src/lib/eliom_client_main.eliom
@@ -32,6 +32,17 @@ let _force_link =
 
 {client{
 
+let default_reload () =
+  Dom_html.window##location##reload();
+  Lwt.return ()
+
+let reload () =
+  match !Eliom_client.reload_function with
+  | Some f ->
+    f () ()
+  | None ->
+    default_reload ()
+
 let reload_with_warning () () =
   let f = !Eliom_client.reload_function in
   (*VVV When calling server side (non hidden) void coservice, GET
@@ -47,7 +58,7 @@ let reload_with_warning () () =
        not remone GET non-attached parameters (FIX in Eliom)";
     f () ()
   | None ->
-    Lwt.return ()
+    default_reload ()
 
 let switch_to_https () =
   let info = Eliom_process.get_info () in
@@ -67,19 +78,8 @@ let _ =
     {{ fun () () -> switch_to_https (); reload_with_warning () () }};
   Eliom_service.internal_set_client_fun
     ~service:Eliom_service.reload_action_hidden
-    {{ fun () () ->
-       match !Eliom_client.reload_function with
-       | Some f ->
-         f () ()
-       | None ->
-         Lwt.return () }};
+    {{ fun () () -> reload () }};
   Eliom_service.internal_set_client_fun
     ~service:Eliom_service.reload_action_https_hidden
-    {{ fun () () ->
-       switch_to_https ();
-       match !Eliom_client.reload_function with
-       | Some f ->
-         f () ()
-       | None ->
-         Lwt.return () }}
+    {{ fun () () -> switch_to_https (); reload () }}
 }}

--- a/src/lib/eliom_form.eliom
+++ b/src/lib/eliom_form.eliom
@@ -257,7 +257,7 @@ module Make (Html : Html) = struct
     let elt = Js.Unsafe.coerce elt in
     Lwt_js_events.async @@ fun () ->
     Lwt_js_events.submits elt @@ fun ev _ ->
-    match Eliom_service.client_fun service () with
+    match Eliom_service.client_fun service with
     | Some f ->
       (match read_params elt y with
        | Some v ->
@@ -276,7 +276,7 @@ module Make (Html : Html) = struct
     let elt = Js.Unsafe.coerce elt in
     Lwt_js_events.async @@ fun () ->
     Lwt_js_events.submits elt @@ fun ev _ ->
-    match Eliom_service.client_fun service () with
+    match Eliom_service.client_fun service with
     | Some f ->
       (match read_params elt y with
        | Some v ->

--- a/src/lib/eliom_parameter_base.shared.ml
+++ b/src/lib/eliom_parameter_base.shared.ml
@@ -553,3 +553,12 @@ let rec wrap_param_type : type a c. (a,'b,c) params_type -> (a,'b,c) params_type
   (* the filter is only on server side (at least for now) *)
   | TTypeFilter (t, _) -> TTypeFilter (t, None)
   | t -> t
+
+type _ is_unit =
+  | U_not : _    is_unit
+  | U_yes : unit is_unit
+
+let is_unit : type a c . (a, _, c) params_type -> a is_unit =
+  function
+  | TUnit -> U_yes
+  | _     -> U_not

--- a/src/lib/eliom_parameter_sigs.shared.mli
+++ b/src/lib/eliom_parameter_sigs.shared.mli
@@ -428,4 +428,10 @@ module type S = sig
   val wrap_param_type :
     ('a, 'b, 'c) params_type -> ('a, 'b, 'c) params_type
 
+  type _ is_unit =
+    | U_not : _    is_unit
+    | U_yes : unit is_unit
+
+  val is_unit : ('a, _, _) params_type -> 'a is_unit
+
 end

--- a/src/lib/eliom_service.client.ml
+++ b/src/lib/eliom_service.client.ml
@@ -30,12 +30,22 @@ let xhr_with_cookies s =
       None
     | XSame_appl (_, tmpl) -> Some tmpl
 
-let has_client_fun service = client_fun service () <> None
+let has_client_fun service = client_fun service <> None
 
-let get_reload_fun s =
-  match s.reload_fun with
-  | Rf_keep -> None
-  | Rf_some f -> !f ()
+let reload_fun :
+  type gp pp .
+  (gp, pp, _, _, _, _, _, _, _, _, _) t ->
+  (gp -> unit -> unit Lwt.t) option =
+  fun service ->
+    match Eliom_parameter.is_unit (post_params_type service) with
+    | Eliom_parameter.U_yes ->
+      (match service with
+       | { client_fun = Some f ; reload_fun = Rf_client_fun } ->
+         Some f
+       | _ ->
+         None)
+    | _ ->
+      None
 
 let register_delayed_get_or_na_coservice ~sp s =
   failwith "CSRF coservice not implemented client side for now"

--- a/src/lib/eliom_service.client.mli
+++ b/src/lib/eliom_service.client.mli
@@ -26,11 +26,6 @@ val pre_applied_parameters :
   (string * Eliommod_parameters.param) list Eliom_lib.String.Table.t *
     (string * Eliommod_parameters.param) list
 
-val get_reload_fun :
+val reload_fun :
   ('a, _, _, _, _, _, _, _, _, _, _) t ->
-  ('a -> unit -> unit Lwt.t) option
-
-val internal_set_client_fun :
-  service : ('a, 'b, _, _, _, _, _, _, _, _, _) t ->
-  (unit -> ('a -> 'b -> unit Lwt.t) option) ->
-  unit
+  ('a -> unit -> unit Lwt.t) Eliom_client_value.t option

--- a/src/lib/eliom_service_sigs.shared.mli
+++ b/src/lib/eliom_service_sigs.shared.mli
@@ -381,7 +381,7 @@ module type S = sig
 
   val client_fun :
     ('a, 'b, _, _, _, _, _, _, _, _, _) t ->
-    (unit -> ('a -> 'b -> unit Lwt.t) option) Eliom_client_value.t
+    ('a -> 'b -> unit Lwt.t) Eliom_client_value.t option
 
   val has_client_fun :
     (_, _, _, _, _, _, _, _, _, _, _) t -> bool
@@ -442,9 +442,10 @@ module type S = sig
     service:('a, 'b, _, _, _, _, _, _, _, _, _) t ->
     ('a -> 'b -> unit Lwt.t) Eliom_client_value.t ->
     unit
+
   val internal_set_client_fun :
-    service :('a, 'b, _, _, _, _, _, _, _, _, _) t ->
-    (unit -> ('a -> 'b -> unit Lwt.t) option) Eliom_client_value.t ->
+    service : ('a, 'b, _, _, _, _, _, _, _, _, _) t ->
+    ('a -> 'b -> unit Lwt.t) Eliom_client_value.t ->
     unit
 
 end


### PR DESCRIPTION
Producing client values at the time `Eliom_service` is initialized is problematic; see discussion in 1f0afdfd0144201e71698c35a9c47fd22c10b446. This patch deals with the issue by using a mutable option for the `client_fun` field. The `set_client_fun` function can be used to initialize the `client_fun` later (e.g., by `Eliom_registration`).

The reload function is now represented as `Rf_keep | Rf_client_fun`; the `Rf_client_fun` means that we need to use the `client_fun` for reload. Only services with no POST parameters can have a reload function. `Obj.magic` is no longer needed. (I suspect it was previously hiding problems...)

This is a prefix of the `client-registration` branch implementing client-side `Eliom_registration`, but it is a subtle issue, so I prefer it receives adequate attention in its own.

@balat @vouillon can you take a look?