### PR TITLE
Add cookie substitutes for iOS WkWebView apps

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -161,6 +161,13 @@ let init () =
     (Some (Eliom_process.get_info ()).cpi_hostname)
     (Eliom_request_info.get_request_cookies ());
 
+  let use_substitutes = (* for iOS WKWebView, on which cookies are broken *)
+    Js.Unsafe.global##___eliom_use_cookie_substitutes_ <> Js.undefined in
+  if use_substitutes then
+    Eliommod_cookies.update_cookie_table ~in_local_storage:true
+      (Some (Eliom_process.get_info ()).cpi_hostname)
+      (Eliom_process.get_cookie_substitutes ());
+
   let onload_handler = ref None in
 
   let onload ev =

--- a/src/lib/eliom_common_base.shared.ml
+++ b/src/lib/eliom_common_base.shared.ml
@@ -192,6 +192,11 @@ let internal_form_full_name =
 
 let set_tab_cookies_header_name = "X-Eliom-Set-Process-Cookies"
 let tab_cookies_header_name = "X-Eliom-Process-Cookies"
+
+(* Cookie substitutes for iOS WKWebView *)
+let cookie_substitutes_header_name = "X-Eliom-Cookie-Substitutes"
+let set_cookie_substitutes_header_name = "X-Eliom-Set-Cookie-Substitutes"
+
 let tab_cpi_header_name = "X-Eliom-Process-Info"
 let expecting_process_page_name = "X-Eliom-Expecting-Process-Page"
 

--- a/src/lib/eliom_process.client.ml
+++ b/src/lib/eliom_process.client.ml
@@ -56,11 +56,24 @@ let set_info, is_set_info,
   =
   get_set_js_serverside_value (ref None) "__eliom_appl_process_info"
 
-let set_request_cookies, is_set_request_cookies,
+let (set_request_cookies :
+       Eliommod_cookies.cookie Ocsigen_cookies.CookiesTable.t
+         Ocsigen_cookies.Cookies.t -> unit),
+    is_set_request_cookies,
     (get_request_cookies : unit -> Eliommod_cookies.cookie
        Ocsigen_cookies.CookiesTable.t Ocsigen_cookies.Cookies.t),
   reset_request_cookies =
   get_set_js_serverside_value (ref None) "__eliom_request_cookies"
+
+(* Cookie substitutes for iOS WKWebView *)
+let (set_cookie_substitutes :
+       Eliommod_cookies.cookie Ocsigen_cookies.CookiesTable.t
+         Ocsigen_cookies.Cookies.t -> unit),
+    is_set_cookie_substitutes,
+    (get_cookie_substitutes : unit -> Eliommod_cookies.cookie
+       Ocsigen_cookies.CookiesTable.t Ocsigen_cookies.Cookies.t),
+  reset_cookie_substitutes =
+  get_set_js_serverside_value (ref None) "__eliom_use_cookie_substitutes"
 
 let set_request_template, is_set_request_template,
     (get_request_template : unit -> string option),

--- a/src/lib/server/eliommod_pagegen.ml
+++ b/src/lib/server/eliommod_pagegen.ml
@@ -299,6 +299,13 @@ let gen is_eliom_extension sitedata = function
                >>= fun all_new_cookies ->
                let res =
                  Ocsigen_http_frame.Result.update res
+                   ~headers:(
+                     Http_headers.add
+                       (Http_headers.name
+                          Eliom_common_base.set_cookie_substitutes_header_name)
+                       (Eliommod_cookies.cookieset_to_json all_new_cookies)
+                       (Ocsigen_http_frame.Result.headers res)
+                   )
                    ~cookies:all_new_cookies ()
                in
 


### PR DESCRIPTION
Context: on iOS WkWebView apps, on the first launch of the app,
cookies don't work at all. After a pause or an exit, they seem to
work at least "OK". But it's not acceptable for an app to be that
broken on the first launch. So, this patch implements a work-around
consisting in using (client) local storage to replace the cookies.
The "cookie substitutes" transit via HTTP headers.

(Implemented with help and advice from Vincent Balat and Jérôme Vouillon.)

modified:   src/lib/client/eliommod_cookies.ml
modified:   src/lib/eliom_client.client.ml
modified:   src/lib/eliom_common.server.ml
modified:   src/lib/eliom_common_base.shared.ml
modified:   src/lib/eliom_process.client.ml
modified:   src/lib/eliom_request.client.ml
modified:   src/lib/server/eliommod_pagegen.ml