### PR TITLE
Add cookie substitutes for iOS WkWebView apps

### DIFF
--- a/src/lib/client/eliommod_cookies.ml
+++ b/src/lib/client/eliommod_cookies.ml
@@ -30,28 +30,29 @@ let cookie_tables = Jstable.create ()
 let get_table ?(in_local_storage=false) = function
   | None -> Cookies.empty
   | Some host ->
-    let host = Js.string host in
     if in_local_storage then
+      let host = Js.string (host ^ "/substitutes") in
       Js.Optdef.case (Dom_html.window##localStorage) (fun () -> Cookies.empty)
         (fun st ->
            Js.Opt.case (st##getItem(host))
              (fun () -> Cookies.empty)
              (fun v -> Json.unsafe_input v))
     else
-      Js.Optdef.get (Jstable.find cookie_tables host) (fun () -> Cookies.empty)
+      Js.Optdef.get (Jstable.find cookie_tables (Js.string host))
+        (fun () -> Cookies.empty)
 
 (** [in_local_storage] implements cookie substitutes for iOS WKWebView *)
 let set_table ?(in_local_storage=false) host t =
   match host with
     | None -> ()
     | Some host ->
-      let host = Js.string host in
       if in_local_storage then
+        let host = Js.string (host ^ "/substitutes") in
         Js.Optdef.case (Dom_html.window##localStorage)
           (fun () -> ())
           (fun st -> st##setItem(host, (Json.output t)))
       else
-        Jstable.add cookie_tables host t
+        Jstable.add cookie_tables (Js.string host) t
 
 let now () =
   let date = jsnew Js.date_now () in

--- a/src/lib/eliom_common_base.shared.ml
+++ b/src/lib/eliom_common_base.shared.ml
@@ -192,6 +192,11 @@ let internal_form_full_name =
 
 let set_tab_cookies_header_name = "X-Eliom-Set-Process-Cookies"
 let tab_cookies_header_name = "X-Eliom-Process-Cookies"
+
+(* Cookie substitutes for iOS WKWebView *)
+let cookie_substitutes_header_name = "X-Eliom-Cookie-Substitutes"
+let set_cookie_substitutes_header_name = "X-Eliom-Set-Cookie-Substitutes"
+
 let tab_cpi_header_name = "X-Eliom-Process-Info"
 let expecting_process_page_name = "X-Eliom-Expecting-Process-Page"
 

--- a/src/lib/eliom_request.client.ml
+++ b/src/lib/eliom_request.client.ml
@@ -115,6 +115,17 @@ let nl_template =
 (* Warning: it must correspond to [nl_template]. *)
 let nl_template_string = "__nl_n_eliom-template.name"
 
+
+
+(** Same as XmlHttpRequest.perform_raw_url, but:
+    - sends tab cookies in an HTTP header
+    - does half and full XHR redirections according to headers
+
+    The optional parameter [~cookies_info] is a pair
+    containing the information (secure, path)
+    that is taken into account for finding tab cookies to send.
+    If not present, the path and protocol are taken from the URL.
+*)
 let send
     ?with_credentials
     ?(expecting_process_page = false) ?cookies_info
@@ -140,6 +151,20 @@ let send
       | [] -> []
       | _ -> [ Eliom_common.tab_cookies_header_name,
                encode_header_value cookies ] in
+    let headers =
+      if Js.Unsafe.global##___eliom_use_cookie_substitutes_ <> Js.undefined then
+        (* Cookie substitutes are for iOS WKWebView *)
+        let host = match host with
+          | None -> "/substitutes" | Some h -> (h  ^ "/substitutes") in
+        let cookies =
+          Eliommod_cookies.get_cookies_to_send
+            ~in_local_storage:true (Some host) https path in
+        ( Eliom_common.cookie_substitutes_header_name,
+          encode_header_value cookies )
+        :: headers
+      else
+        headers
+    in
     (* CCC *
        For now we assume that an eliom application is not distributed
        among different server with different hostnames:
@@ -207,6 +232,20 @@ let send
           ?post_args ~get_args ?form_arg:form_contents ~check_headers
           ?progress ?upload_progress ?override_mime_type url
       in
+      (if Js.Unsafe.global##___eliom_use_cookie_substitutes_ <> Js.undefined
+       then
+         match (* Cookie substitutes are for iOS WKWebView *)
+           r.XmlHttpRequest.headers
+             Eliom_common.set_cookie_substitutes_header_name
+         with
+         | None | Some "" -> ()
+         | Some cookie_substitutes ->
+           let host = match host with
+             | None ->    "/substitutes"
+             | Some h ->  h ^ "/substitutes" in
+           Eliommod_cookies.update_cookie_table ~in_local_storage:true
+             (Some host)
+             (Eliommod_cookies.cookieset_of_json cookie_substitutes));
       (match r.XmlHttpRequest.headers Eliom_common.set_tab_cookies_header_name
        with
          | None | Some "" -> () (* Empty tab_cookies for IE compat *)
@@ -284,17 +323,6 @@ let send
       | _ -> url),
     content)
 
-
-
-(** Same as XmlHttpRequest.perform_raw_url, but:
-    - sends tab cookies in an HTTP header
-    - does half and full XHR redirections according to headers
-
-    The optional parameter [~cookies_info] is a pair
-    containing the information (secure, path)
-    that is taken into account for finding tab cookies to send.
-    If not present, the path and protocol and taken from the URL.
-*)
 
 (* BEGIN FORMDATA HACK *)
 let add_button_arg inj args form =

--- a/src/lib/eliom_request.client.ml
+++ b/src/lib/eliom_request.client.ml
@@ -154,11 +154,9 @@ let send
     let headers =
       if Js.Unsafe.global##___eliom_use_cookie_substitutes_ <> Js.undefined then
         (* Cookie substitutes are for iOS WKWebView *)
-        let host = match host with
-          | None -> "/substitutes" | Some h -> (h  ^ "/substitutes") in
         let cookies =
           Eliommod_cookies.get_cookies_to_send
-            ~in_local_storage:true (Some host) https path in
+            ~in_local_storage:true host https path in
         ( Eliom_common.cookie_substitutes_header_name,
           encode_header_value cookies )
         :: headers
@@ -240,11 +238,8 @@ let send
          with
          | None | Some "" -> ()
          | Some cookie_substitutes ->
-           let host = match host with
-             | None ->    "/substitutes"
-             | Some h ->  h ^ "/substitutes" in
            Eliommod_cookies.update_cookie_table ~in_local_storage:true
-             (Some host)
+             host
              (Eliommod_cookies.cookieset_of_json cookie_substitutes));
       (match r.XmlHttpRequest.headers Eliom_common.set_tab_cookies_header_name
        with


### PR DESCRIPTION
Context: on iOS WkWebView apps, on the first launch of the app,
cookies don't work at all. After a pause or an exit, they seem to
work at least "OK". But it's not acceptable for an app to be that
broken on the first launch. So, this patch implements a work-around
consisting in using (client) local storage to replace the cookies.
The "cookie substitutes" transit via HTTP headers.

(Implemented with help and advice from Vincent Balat and Jérôme Vouillon.)

modified:   src/lib/client/eliommod_cookies.ml
modified:   src/lib/eliom_common.server.ml
modified:   src/lib/eliom_common_base.shared.ml
modified:   src/lib/eliom_request.client.ml
modified:   src/lib/server/eliommod_pagegen.ml