### PR TITLE
Do not use deprecated Xml_print modules

### DIFF
--- a/src/lib/eliom_content.server.mli
+++ b/src/lib/eliom_content.server.mli
@@ -277,11 +277,11 @@ module Svg : sig
 
   end
 
-  (** SVG printer.
-      See {% <<a_api project="tyxml" | module Xml_sigs.Typed_simple_printer >> %}. *)
-  module Printer : Xml_sigs.Typed_simple_printer with type +'a elt := 'a elt
-                                                  and type doc := F.doc
-
+  (** SVG printer. See
+      {% <<a_api project="tyxml" | module Xml_sigs.Typed_pp >> %}. *)
+  module Printer : Xml_sigs.Typed_pp
+    with type +'a elt := 'a elt
+     and type doc := F.doc
 
 end
 
@@ -474,10 +474,12 @@ module Html : sig
 
   end
 
-  (** {{:http://dev.w3.org/html5/html-xhtml-author-guide/}"Polyglot"} HTML printer.
-     See {% <<a_api project="tyxml" | module Xml_sigs.Typed_simple_printer >> %}. *)
-  module Printer : Xml_sigs.Typed_simple_printer with type +'a elt := 'a elt
-                                                  and type doc := F.doc
+  (** {{:http://dev.w3.org/html5/html-xhtml-author-guide/}"Polyglot"}
+      HTML printer. See
+      {% <<a_api project="tyxml" | module Xml_sigs.Typed_pp >> %}. *)
+  module Printer : Xml_sigs.Typed_pp
+    with type +'a elt := 'a elt
+     and type doc := F.doc
 
 end
 

--- a/src/lib/eliom_content_core.server.ml
+++ b/src/lib/eliom_content_core.server.ml
@@ -312,7 +312,7 @@ module Svg = struct
       D.tot (Xml.make_request_node ?reset (D.toelt elt))
   end
 
-  module Printer = Xml_print.Make_typed_simple(Xml)(F)
+  module Printer = Xml_print.Make_typed_fmt(Xml)(F)
 
 end
 
@@ -421,6 +421,6 @@ module Html = struct
         (custom_data.to_string value)
   end
 
-  module Printer = Xml_print.Make_typed_simple(Xml)(F)
+  module Printer = Xml_print.Make_typed_fmt(Xml)(F)
 
 end

--- a/src/lib/eliom_content_core.server.mli
+++ b/src/lib/eliom_content_core.server.mli
@@ -136,8 +136,9 @@ module Svg : sig
 
   end
 
-  module Printer : Xml_sigs.Typed_simple_printer with type +'a elt := 'a F.elt
-                                          and type doc := F.doc
+  module Printer : Xml_sigs.Typed_pp
+    with type +'a elt := 'a F.elt
+     and type doc := F.doc
 
 end
 
@@ -227,7 +228,8 @@ module Html : sig
 
   end
 
-  module Printer : Xml_sigs.Typed_simple_printer with type +'a elt := 'a F.elt
-                                          and type doc := F.doc
+  module Printer : Xml_sigs.Typed_pp
+    with type +'a elt := 'a F.elt
+     and type doc := F.doc
 
 end

--- a/src/lib/eliom_registration.server.ml
+++ b/src/lib/eliom_registration.server.ml
@@ -111,11 +111,12 @@ module Make_typed_xml_registration
 
     let out =
       let encode x = fst (Xml_print.Utf8.normalize_html x) in
-      Format.asprintf "%a" (Fmt.pp_elt ~encode ())
+      Fmt.pp_elt ~encode ()
 
     let out_list l =
-      List.map out l
-      |> String.concat ""
+      Format.asprintf "%a"
+        (Format.pp_print_list ~pp_sep:(fun _ () -> ()) out)
+        l
       |> Ocsigen_stream.StringStream.put
       |> Ocsigen_stream.StringStream.make
 


### PR DESCRIPTION
This PR eliminates use of the `Xml_print` modules that are deprecated (as of TyXML 4.0).

This has an impact on the printers that we export, so it is a breaking change.

@Drup, this is well within your jurisdiction, and I am not very proficient in `Format`, so please take a look :).
