### PR TITLE
Implement client-side Eliom_registration.Unit

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -751,12 +751,17 @@ let target_url, set_target_url, reset_target_url =
   (fun uri -> r := Some uri),
   (fun () -> r := None)
 
+(* Some services do not need to set the URL (e.g.,
+   Eliom_registration.Unit).  The subsequent change_page will set the
+   URI. *)
+let do_not_set_uri = ref false
+
 let commit_target_url ~nested () =
-  match nested, target_url () with
-  | false, Some url ->
-    change_url_string url
-  | _, _ ->
-    ()
+  match nested, target_url (), !do_not_set_uri with
+   | false, Some url, false ->
+     change_url_string url
+   | _, _, _ ->
+     do_not_set_uri := false
 
 let route
     ?(nested = false)
@@ -772,10 +777,6 @@ let route
   with e ->
     Eliom_request_info.get_sess_info := r;
     Lwt.fail e
-
-(* do_not_set_uri is set in Eliom_registration.Redirection .  The
-   subsequent change_page will set the URI. *)
-let do_not_set_uri = ref false
 
 (* == Main (exported) function: change the content of the page without
    leaving the javascript application. See [change_page_uri] for the

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -32,8 +32,6 @@ module Html_text = Base
 module CssText = Base
 module Text = Base
 
-module Unit = Base
-
 module String_redirection = Base
 
 module Streamlist = Base
@@ -237,6 +235,19 @@ module Action = Make (struct
       Lwt.return ()
 
 end)
+
+module Unit = Make (struct
+
+    type page = unit
+    type options = unit
+    type return = Eliom_service.non_ocaml
+    type result = browser_content kind
+
+    let send ?options:_ page =
+      Eliom_client.do_not_set_uri := true;
+      Lwt.return ()
+
+  end)
 
 module App (P : Eliom_registration_sigs.APP_PARAM) = struct
   let application_name = P.application_name

--- a/src/lib/eliom_registration.client.mli
+++ b/src/lib/eliom_registration.client.mli
@@ -33,6 +33,12 @@ module Action : Eliom_registration_sigs.S
    and type return = Eliom_service.non_ocaml
    and type result = browser_content kind
 
+module Unit : Eliom_registration_sigs.S
+  with type page = unit
+   and type options = unit
+   and type return = Eliom_service.non_ocaml
+   and type result = browser_content kind
+
 module App (P : Eliom_registration_sigs.APP_PARAM) : sig
   val application_name : string
   include module type of Html
@@ -75,7 +81,6 @@ module Html_text : Base
 module CssText : Base
 module Text : Base
 module String : Base
-module Unit : Base
 module String_redirection : Base
 module Streamlist : Base
 

--- a/src/lib/eliom_registration.server.ml
+++ b/src/lib/eliom_registration.server.ml
@@ -517,7 +517,7 @@ module Unit_reg_base = struct
 
   let result_of_http_result = Result_types.cast_result
 
-  let send_appl_content = Eliom_service.XNever
+  let send_appl_content = Eliom_service.XAlways
 
   let send ?options ?charset ?(code = 204)
       ?content_type ?headers content =

--- a/src/lib/eliom_service.client.ml
+++ b/src/lib/eliom_service.client.ml
@@ -47,6 +47,8 @@ let reload_fun :
     | _ ->
       None
 
+let reset_reload_fun service = service.reload_fun <- Rf_keep
+
 let register_delayed_get_or_na_coservice ~sp s =
   failwith "CSRF coservice not implemented client side for now"
 

--- a/src/lib/eliom_service.client.mli
+++ b/src/lib/eliom_service.client.mli
@@ -21,6 +21,8 @@ include Eliom_service_sigs.S
 
 (**/**)
 
+val reset_reload_fun : (_, _, _, _, _, _, _, _, _, _, _) t -> unit
+
 val pre_applied_parameters :
   (_, _, _, _, _, _, _, _, _, _, _) t ->
   (string * Eliommod_parameters.param) list Eliom_lib.String.Table.t *


### PR DESCRIPTION
`Eliom_registration.Unit` is similar to `Action`, but without the subsequent reload. CC @balat . See ocsigen/eliom-base-app#86 .