### PR TITLE
Merge form handlers

### DIFF
--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -346,3 +346,6 @@ val set_content_local :
 val do_not_set_uri : bool ref
 
 val change_page_after_action : unit -> unit Lwt.t
+
+type client_form_handler =
+  Eliom_content_core.Xml.biggest_event Js.t -> bool Lwt.t

--- a/src/lib/eliom_content.client.mli
+++ b/src/lib/eliom_content.client.mli
@@ -881,5 +881,12 @@ val wrap_client_fun :
 
 (** With [set_form_error_handler f], [f] becomes the action to be
     called when we are unable to call a client-side service due to
-    invalid form data. *)
-val set_form_error_handler : (unit -> unit Lwt.t) -> unit
+    invalid form data.
+
+    If the handler returns [true], nothing happens.
+
+    If the handler returns [false], we proceed to call the server-side
+    service.
+
+    The default handler throws an exception (via [Lwt.fail_with]). *)
+val set_form_error_handler : (unit -> bool Lwt.t) -> unit

--- a/src/lib/eliom_form.eliom
+++ b/src/lib/eliom_form.eliom
@@ -39,7 +39,7 @@ let iter_contents y ev f =
   | Some v ->
     lwt () = f v in Lwt.return true
   | None ->
-    Lwt.return false
+    !error_handler ()
 
 type client_form_handler = Eliom_client.client_form_handler
 

--- a/src/lib/eliom_form.eliomi
+++ b/src/lib/eliom_form.eliomi
@@ -19,7 +19,7 @@
 *)
 
 {client{
-val set_error_handler : (unit -> unit Lwt.t) -> unit
+val set_error_handler : (unit -> bool Lwt.t) -> unit
 }}
 
 {shared{

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -173,15 +173,6 @@ let client_fun {client_fun} = client_fun
 }}
 
 {shared{
-let has_client_fun_lazy s =
-  {unit -> bool{
-     fun () ->
-       match %s.client_fun with
-       | Some s ->
-         true
-       | _ ->
-         false
-   }}
 
 let internal_set_client_fun ~service f = service.client_fun <- Some f
 

--- a/src/lib/eliom_service_sigs.shared.mli
+++ b/src/lib/eliom_service_sigs.shared.mli
@@ -389,10 +389,6 @@ module type S = sig
   val has_client_fun :
     (_, _, _, _, _, _, _, _, _, _, _) t -> bool
 
-  val has_client_fun_lazy :
-    (_, _, _, _, _, _, _, _, _, _, _) t ->
-    (unit -> bool) Eliom_client_value.t
-
   val keep_nl_params :
     (_, _, _, _, _, _, _, _, _, _, _) t -> [ `All | `Persistent | `None ]
 


### PR DESCRIPTION
Previously, there were two different handlers for form input:

- #287 introduced a handler in `Eliom_form`. This was used to call client-side services, if possible.
- A handler in `Eliom_client_core` for all other cases.

The separation was due to the fact that `Eliom_client_core` is low-level. The notion of a service is undefined there.

The handler in `Eliom_client_core` was trying to detect the existence of a client-side service implementation, in which case it would do nothing, expecting `Eliom_form` to do the work. This scheme was error-prone, and we needed an extra `onsubmit` handler.

`Eliom_form` now knows how to pass a function for use by the client in `Eliom_client_core`, rather than introducing a separate handler.

CC @canonici (we have discussed the underlying issue)