### PR TITLE
The handler for beforeunload events should return undefined rather than null

### DIFF
--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -1297,9 +1297,9 @@ let add_string_event_listener o e f capt : unit =
     | Some s ->
       let s = Js.string s in
       (Js.Unsafe.coerce e)##returnValue <- s;
-      Js.some s
+      Js.def s
     | None ->
-      Js.null
+      Js.undefined
   in
   let f = Js.Unsafe.callback f in
   ignore @@


### PR DESCRIPTION
This is what is expected by internet explorer.