### PR TITLE
Separate onunload and onbeforeunload callbacks

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -103,16 +103,10 @@ let _ =
 
 let onunload_fun _ =
   update_state ();
-  (* running remaining callbacks, if onbeforeunload left some *)
-  let _ = run_onunload ~final:true () in
+  run_callbacks (flush_onunload ());
   Js._true
 
-and onbeforeunload_fun e =
-  match run_onunload ~final:false () with
-  | None ->
-    update_state (); None
-  | r ->
-    r
+let onbeforeunload_fun _ = run_onbeforeunload ()
 
 (* Function called (in Eliom_client_main), once when starting the app.
    Either when sent by a server or initiated on client side. *)

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -237,7 +237,7 @@ val onbeforeunload : (unit -> string option) -> unit
     change. The callback [f] is sometimes trigerred by internal
     service calls, and sometimes by the browser [onunload] event.
     [onunload] can be used to register multiple callbacks. *)
-val onunload : (unit -> _) -> unit
+val onunload : (unit -> unit) -> unit
 
 (** Wait for the initialization phase to terminate *)
 val wait_load_end : unit -> unit Lwt.t

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -219,7 +219,7 @@ val onload : (unit -> unit) -> unit
 (** Returns a Lwt thread that waits until the next page is loaded. *)
 val lwt_onload : unit -> unit Lwt.t
 
-(** [onunload f] registers [f] as a handler to be called before
+(** [onbeforeunload f] registers [f] as a handler to be called before
     changing the page the next time. If [f] returns [Some s], then we
     ask the user to confirm quitting. We try to use [s] in the
     confirmation pop-up. [None] means no confirmation needed.
@@ -230,10 +230,14 @@ val lwt_onload : unit -> unit Lwt.t
     browser. For Firefox, the string [s] returned by [f] is ignored:
     https://bugzilla.mozilla.org/show_bug.cgi?id=641509
 
-    [onunload] can be used to register multiple callbacks. If the user
-    decides to stay, we call any remaining callbacks, but these cannot
-    ask for further confirmation. *)
-val onunload : (unit -> string option) -> unit
+    [onbeforeunload] can be used to register multiple callbacks. *)
+val onbeforeunload : (unit -> string option) -> unit
+
+(** [onunload f] registers [f] as a handler to be called before page
+    change. The callback [f] is sometimes trigerred by internal
+    service calls, and sometimes by the browser [onunload] event.
+    [onunload] can be used to register multiple callbacks. *)
+val onunload : (unit -> _) -> unit
 
 (** Wait for the initialization phase to terminate *)
 val wait_load_end : unit -> unit Lwt.t

--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -59,8 +59,6 @@ let onload, _, flush_onload, push_onload :
 
 let onunload, _, flush_onunload, _ = create_buffer ()
 
-let onunload f = onunload (fun () -> ignore (f()))
-
 let onbeforeunload, run_onbeforeunload, flush_onbeforeunload =
   let add, get, flush, _ = create_buffer () in
   let rec run lst =


### PR DESCRIPTION
We want to have `onbeforeunload` callbacks that are able to cancel page changes, and `onunload` callbacks that are invoked when we are sure that the page is going to change (and may have destructive effects).

This changes the type of `onunload` callbacks from `unit -> string option` to `unit -> _` to avoid breaking existing code. Eventually, type `unit -> unit` would be better.