### PR TITLE
Typo in Eliom_client_main (missing space)

### DIFF
--- a/src/lib/eliom_client_main.eliom
+++ b/src/lib/eliom_client_main.eliom
@@ -51,7 +51,7 @@ let reload_with_warning () () =
   match f with
   | Some f ->
     print_endline
-      "Warning: (non hidden) calling void coservice' on client side does\
+      "Warning: (non hidden) calling void coservice' on client side does \
        not remone GET non-attached parameters (FIX in Eliom)";
     f () ()
   | None ->


### PR DESCRIPTION
Missing space