### PR TITLE
Add .eliomignore support to not copy some files from a template.

### DIFF
--- a/src/tools/distillery.ml
+++ b/src/tools/distillery.ml
@@ -1,12 +1,12 @@
 open Printf
 
 (* File containing the reserve project names for templates *)
-let reserve_project_name_filename = ".reserve"
+let reserve_project_name_filename = ".eliomreserve"
 
 (* File containing files which must be ignored while copying a template. *)
 let eliomignore_filename          = ".eliomignore"
 
-let distillery_basic = "basic.ppx"
+let distillery_basic              = "basic.ppx"
 
 (* Returns all lines of [file] as a string list. Returns an empty list if [file]
  * doesn't exist.

--- a/src/tools/distillery.ml
+++ b/src/tools/distillery.ml
@@ -1,11 +1,27 @@
 open Printf
 
-(* Constant use for the filename containing the reserve project name for
- * templates
- *)
+(* File containing the reserve project names for templates *)
 let reserve_project_name_filename = ".reserve"
 
+(* File containing files which must be ignored while copying a template. *)
+let eliomignore_filename          = ".eliomignore"
+
 let distillery_basic = "basic.ppx"
+
+(* Returns all lines of [file] as a string list. Returns an empty list if [file]
+ * doesn't exist.
+ *)
+let lines_of_file file =
+  if not (Sys.file_exists file) then []
+  else
+  (
+    let lines       = ref [] in
+    let in_file     = open_in file in
+    let rec aux ()  =
+      try lines := (input_line in_file) :: !lines; aux ()
+      with End_of_file -> close_in in_file
+    in aux (); !lines
+  )
 
 let pp_list () l =
   let f s =
@@ -144,6 +160,9 @@ let copy_file ?(env=[]) ?(preds=[]) src_name dst_name =
       eprintf "%s.\n%!" msg
 
 let create_project ~name ~env ~preds ~source_dir ~destination_dir =
+  let eliom_ignore_files =
+    lines_of_file (Filename.concat source_dir eliomignore_filename)
+  in
   if not (Sys.file_exists destination_dir) then
     ( if ksprintf (yes_no ~default:true) "Destination directory %S doesn't exist. Create it?" destination_dir then
         mkdir_p destination_dir
@@ -154,7 +173,8 @@ let create_project ~name ~env ~preds ~source_dir ~destination_dir =
       exit 1 );
   Array.iter
     (fun src_file ->
-      if src_file = reserve_project_name_filename then ()
+      (* First, we check if the file is in .eliomignore *)
+      if List.exists (fun x -> x = src_file) eliom_ignore_files then ()
       else
         let src_path = Filename.concat source_dir src_file in
         let dst_path =
@@ -215,20 +235,7 @@ let check_reserve_project_name project_name template_name =
     (Filename.concat (get_templatedir ()) template_name)
     reserve_project_name_filename
   in
-  if Sys.file_exists file
-  then
-  (
-    let in_file = open_in file in
-    try
-      let rec aux () =
-        if project_name = (input_line in_file) then true else aux ()
-      in
-      aux ()
-    with
-    | End_of_file -> close_in in_file; false
-  )
-  else
-    false
+  List.exists (fun x -> x = project_name) (lines_of_file file)
 
 (* ---------- Reserve project name ---------- *)
 (* ------------------------------------------ *)
@@ -292,7 +299,7 @@ let main () =
         template
     else
       let env, preds, source_dir = init_project template name in
-      create_project ~name ~env ~preds ~source_dir ~destination_dir:destination_dir
+      create_project ~name ~env ~preds ~source_dir ~destination_dir
   end
 
 let () = main ()


### PR DESCRIPTION
Due to [this PR on Ocsigen-start](https://github.com/ocsigen/ocsigen-start/pull/138) about an update script from an older version to a newer, we need to have a way to ignore some files while copying. (It doesn't make sense to copy the ~~`update.sql`~~ `upgrade.sql` file in the template).

This PR allows to add a `.eliomignore` file in templates to avoid to copy some file (like `.gitignore`).
It will be more interesting when we will add a feature like #368 (I'm on it, but I don't like the way I implemented it, I need to improve it).

It implements a function `lines_of_files` returning all lines in a file as a string list to be able to check if a filename is in the `.eliomignore` file without doing multiple I/O operations on `.eliomignore`.

I also changed the implementation for `.reserve` by using `lines_of_files` because it did too much I/O operations.