### PR TITLE
Add some comments in Makefile.options to avoid an error with ocsipersist

### DIFF
--- a/pkg/distillery/basic.camlp4/Makefile.options
+++ b/pkg/distillery/basic.camlp4/Makefile.options
@@ -28,6 +28,9 @@ CLIENT_PACKAGES :=
 LOCAL_STATIC = static
 
 # The backend for persistent data. Can be dbm or sqlite.
+# Be sure you installed the following OPAM packages:
+# - *dbm* if you use dbm --> opam install dbm.
+# - *sqlite3* if you use sqlite --> opam install sqlite3.
 PERSISTENT_DATA_BACKEND = %%%PROJECT_DB%%%
 
 # Debug application (yes/no): Debugging info in compilation,

--- a/pkg/distillery/basic.camlp4/Makefile.options
+++ b/pkg/distillery/basic.camlp4/Makefile.options
@@ -28,7 +28,7 @@ CLIENT_PACKAGES :=
 LOCAL_STATIC = static
 
 # The backend for persistent data. Can be dbm or sqlite.
-# Be sure you installed the following OPAM packages:
+# Make sure you have the following packages installed:
 # - *dbm* if you use dbm --> opam install dbm.
 # - *sqlite3* if you use sqlite --> opam install sqlite3.
 PERSISTENT_DATA_BACKEND = %%%PROJECT_DB%%%

--- a/pkg/distillery/basic.ppx/Makefile.options
+++ b/pkg/distillery/basic.ppx/Makefile.options
@@ -28,6 +28,9 @@ CLIENT_PACKAGES := lwt.ppx js_of_ocaml.ppx js_of_ocaml.deriving.ppx
 LOCAL_STATIC = static
 
 # The backend for persistent data. Can be dbm or sqlite.
+# Be sure you installed the following OPAM packages:
+# - *dbm* if you use dbm --> opam install dbm.
+# - *sqlite3* if you use sqlite --> opam install sqlite3.
 PERSISTENT_DATA_BACKEND = %%%PROJECT_DB%%%
 
 # Debug application (yes/no): Debugging info in compilation,

--- a/pkg/distillery/basic.ppx/Makefile.options
+++ b/pkg/distillery/basic.ppx/Makefile.options
@@ -28,7 +28,7 @@ CLIENT_PACKAGES := lwt.ppx js_of_ocaml.ppx js_of_ocaml.deriving.ppx
 LOCAL_STATIC = static
 
 # The backend for persistent data. Can be dbm or sqlite.
-# Be sure you installed the following OPAM packages:
+# Make sure you have the following packages installed
 # - *dbm* if you use dbm --> opam install dbm.
 # - *sqlite3* if you use sqlite --> opam install sqlite3.
 PERSISTENT_DATA_BACKEND = %%%PROJECT_DB%%%


### PR DESCRIPTION
If `sqlite3` (or `dbm`) is not installed, we have the error:
```
ocsigenserver: ocsigen:main: Fatal - Findlib package ocsigenserver.ext.ocsipersist-sqlite not found: maybe you forgot <findlib path="..."/>?
Makefile:58: recipe for target 'test.byte' failed
```

I put it in comments and not as OPAM dependencies to avoid to have too many OPAM dependencies and maybe the dev will always use `dbm` and not `sqlite`.