### PR TITLE
Fix forms on client apps

### DIFF
--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -409,8 +409,9 @@ let raw_a_handler node cookies_info tmpl ev =
   let https = Url.get_ssl (Js.to_string href) in
   (* Returns true when the default link behaviour is to be kept: *)
   (middleClick ev)
-  || (https = Some true && not Eliom_request_info.ssl_)
-  || (https = Some false && Eliom_request_info.ssl_)
+  || (not !Eliom_common.is_client_app
+      && (  (https = Some true && not Eliom_request_info.ssl_)
+         || (https = Some false && Eliom_request_info.ssl_)))
   || (
     (* If a link is clicked, we do not want to continue propagation
        (for example if the link is in a wider clickable area)  *)
@@ -430,8 +431,9 @@ let raw_form_handler form kind cookies_info tmpl ev client_form_handler =
     if not b then change_page_form ?cookies_info ?tmpl form action;
     Lwt.return ()
   in
-  (   https = Some true  && not Eliom_request_info.ssl_)
-  || (https = Some false &&     Eliom_request_info.ssl_)
+  (not !Eliom_common.is_client_app
+   && (  (https = Some true && not Eliom_request_info.ssl_)
+      || (https = Some false && Eliom_request_info.ssl_)))
   || (f (); false)
 
 let raw_event_handler value =


### PR DESCRIPTION
We are serving from a local file. So, if the form target were over
https, we were not performing the local action but performing a post
request, which does not make sense with client apps.