### PR TITLE
Add _opam in gitignore for OPAM 2.0 local switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ local/var/www/distillery-*
 tests/distillery/distillery-*
 
 ocsigen.org-data
+
+_opam


### PR DESCRIPTION
OPAM 2.0 allows to have a local configuration and compiler (see https://opam.ocaml.org/blog/opam-2-0-preview/). This configuration is put in `_opam` directory.
Useful for people who wants to contribute to `eliom` without having to install all dependencies in another switch.