### PR TITLE
Implement client-side Eliom_registration.appl_self_redirect

### DIFF
--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -42,6 +42,7 @@ end
 
 type 'a kind = unit
 type browser_content = [`Browser]
+type 'a application_content = [`Appl of 'a]
 
 module type PARAM = sig
 
@@ -287,9 +288,29 @@ module Unit = Make (struct
 
   end)
 
+type appl_service_options = { do_not_launch : bool }
+
 module App (P : Eliom_registration_sigs.APP_PARAM) = struct
+
+  type app_id
+
   let application_name = P.application_name
-  include Html
+
+  include Make (struct
+
+      type page = Html_types.html Eliom_content.Html.elt
+      type options = appl_service_options
+      type return = Eliom_service.non_ocaml
+      type result = browser_content kind
+
+      let reset_reload_fun = false
+
+      let send ?options:_ page =
+        Eliom_client.set_content_local
+          (Eliom_content.Html.To_dom.of_element page)
+
+    end)
+
 end
 
 type _ redirection =

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -442,4 +442,6 @@ module Any = struct
 
 end
 
+let appl_self_redirect f x = f x
+
 module String = Base

--- a/src/lib/eliom_registration.client.mli
+++ b/src/lib/eliom_registration.client.mli
@@ -71,6 +71,12 @@ module Any : Eliom_registration_sigs.S_poly
    and type 'a return = Eliom_service.non_ocaml
    and type 'a result = 'a kind
 
+(** For compatibility with server-side [appl_self_redirect] *)
+val appl_self_redirect :
+  ('page -> browser_content kind Lwt.t) ->
+  'page ->
+  browser_content kind Lwt.t
+
 (**/**)
 
 module type Base = sig

--- a/src/lib/eliom_registration.client.mli
+++ b/src/lib/eliom_registration.client.mli
@@ -20,6 +20,7 @@
 type 'a kind
 
 type browser_content
+type _ application_content
 
 module Html : Eliom_registration_sigs.S
   with type page = Html_types.html Eliom_content.Html.elt
@@ -39,9 +40,24 @@ module Unit : Eliom_registration_sigs.S
    and type return = Eliom_service.non_ocaml
    and type result = browser_content kind
 
+(** Has no effect on client ; for compatibility with server *)
+type appl_service_options = { do_not_launch : bool }
+
 module App (P : Eliom_registration_sigs.APP_PARAM) : sig
+
   val application_name : string
-  include module type of Html
+
+  (** The type [appl] is an abstract type for identifying an
+      application. It usually used a phantom parameter for
+      {!application_content}. *)
+  type app_id
+
+  include Eliom_registration_sigs.S
+    with type page = Html_types.html Eliom_content.Html.elt
+     and type options = appl_service_options
+     and type return = Eliom_service.non_ocaml
+     and type result = app_id application_content kind
+
 end
 
 type _ redirection =


### PR DESCRIPTION
It doesn't do much on the client, but we need it for compatibility with the server.

We also change the client-side signature of `Eliom_registration.App`, also for compatibility.

This is a temporary solution. We will revisit the `Eliom_registration.X.result` types soon.