### PR TITLE
Make the PPX emit less sections

### DIFF
--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -128,26 +128,34 @@ module Pass = struct
   (** Syntax extension *)
 
   let client_str item =
-    let loc = item.pstr_loc in
-    [ open_client_section loc ;
-      item ;
-    ]
+    if not @@ must_have_section item then [item]
+    else begin
+      let loc = item.pstr_loc in
+      [ open_client_section loc ;
+        item ;
+      ]
+    end
 
   let server_str item =
-    let loc = item.pstr_loc in
-    register_client_closures (flush_client_value_datas ()) @
-    [ close_server_section loc ]
+    if not @@ must_have_section item then []
+    else begin
+      let loc = item.pstr_loc in
+      register_client_closures (flush_client_value_datas ()) @
+      [ close_server_section loc ]
+    end
 
   let shared_str item =
-    let loc = item.pstr_loc in
-    let client_expr_data = flush_client_value_datas () in
-    open_client_section loc ::
-    register_client_closures client_expr_data @
-    define_client_functions loc client_expr_data @
-    [ item ;
-      close_server_section loc ;
-    ]
-
+    if not @@ must_have_section item then [item]
+    else begin
+      let loc = item.pstr_loc in
+      let client_expr_data = flush_client_value_datas () in
+      open_client_section loc ::
+      register_client_closures client_expr_data @
+      define_client_functions loc client_expr_data @
+      [ item ;
+        close_server_section loc ;
+      ]
+    end
 
 
   let fragment ?typ:_ ~context ~num ~id expr =

--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -123,7 +123,7 @@ module Pass = struct
     [%stri
       let () =
         Eliom_client_core.Syntax_helpers.close_server_section
-          [%e AC.str @@ file_hash loc]
+          [%e eid @@ id_file_hash loc]
     ][@metaloc loc]
 
   let may_close_server_section item =
@@ -136,7 +136,7 @@ module Pass = struct
     [%stri
       let () =
         Eliom_client_core.Syntax_helpers.open_client_section
-          [%e AC.str @@ file_hash loc]
+          [%e eid @@ id_file_hash loc]
     ][@metaloc loc]
 
   let may_open_client_section loc =

--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -92,11 +92,9 @@ module Pass = struct
         )
         client_value_datas
     in
-    [%str
-      let () =
-        [%e AC.sequence registrations] ;
-        ()
-    ]
+    match registrations with
+    | [] -> []
+    | _ -> [Str.eval (AC.sequence registrations)]
 
   let define_client_functions ~loc client_value_datas =
     match client_value_datas with

--- a/src/ppx/ppx_eliom_server.ml
+++ b/src/ppx/ppx_eliom_server.ml
@@ -143,7 +143,7 @@ module Pass = struct
       in
       match all_injections with
       | [] ->
-        [ ccs ]
+        [ ]
       | l ->
         [ bind_injected_idents l ; ccs ]
     end
@@ -159,19 +159,18 @@ module Pass = struct
     if not @@ must_have_section item then [item]
     else begin
       let all_injections = flush_injections () in
-      let cl =
-        let loc = item.pstr_loc in
-        [
-          item;
-          close_server_section loc ;
-          close_client_section loc all_injections ;
-        ]
+      let loc = item.pstr_loc in
+      let cl = [
+        item;
+        close_server_section loc ;
+      ]
       in
       match all_injections with
       | [] ->
         cl
       | l ->
-        bind_injected_idents l :: cl
+        bind_injected_idents l :: cl @
+        [ close_client_section loc all_injections ]
     end
 
   let fragment ?typ ~context:_ ~num ~id expr =

--- a/src/ppx/ppx_eliom_server.ml
+++ b/src/ppx/ppx_eliom_server.ml
@@ -96,11 +96,10 @@ module Pass = struct
     Str.value Nonrecursive bindings
 
   let close_server_section loc =
-    let s = file_hash loc in
     [%stri
       let () =
         Eliom_syntax.close_server_section
-          [%e AC.str s]
+          [%e eid @@ id_file_hash loc]
     ] [@metaloc loc]
 
   let may_close_server_section item =
@@ -129,11 +128,10 @@ module Pass = struct
         injections
         [%expr []]
     in
-    let s = file_hash loc in
     [%stri
       let () =
         Eliom_syntax.close_client_section
-          [%e AC.str s ]
+          [%e eid @@ id_file_hash loc ]
           [%e injection_list ]
     ][@metaloc loc]
 

--- a/src/ppx/ppx_eliom_server.ml
+++ b/src/ppx/ppx_eliom_server.ml
@@ -134,37 +134,45 @@ module Pass = struct
   (** Syntax extension *)
 
   let client_str item =
-    let all_injections = flush_injections () in
-    let ccs =
-      let loc = item.pstr_loc in
-      close_client_section loc all_injections
-    in
-    match all_injections with
-    | [] ->
-      [ ccs ]
-    | l ->
-      [ bind_injected_idents l ; ccs ]
+    if not @@ must_have_section item then []
+    else begin
+      let all_injections = flush_injections () in
+      let ccs =
+        let loc = item.pstr_loc in
+        close_client_section loc all_injections
+      in
+      match all_injections with
+      | [] ->
+        [ ccs ]
+      | l ->
+        [ bind_injected_idents l ; ccs ]
+    end
 
-  let server_str item = [
-    item ;
-    close_server_section item.pstr_loc
-  ]
+  let server_str item =
+    if not @@ must_have_section item then [item]
+    else [
+      item ;
+      close_server_section item.pstr_loc
+    ]
 
   let shared_str item =
-    let all_injections = flush_injections () in
-    let cl =
-      let loc = item.pstr_loc in
-      [
-        item;
-        close_server_section loc ;
-        close_client_section loc all_injections ;
-      ]
-    in
-    match all_injections with
-    | [] ->
-      cl
-    | l ->
-      bind_injected_idents l :: cl
+    if not @@ must_have_section item then [item]
+    else begin
+      let all_injections = flush_injections () in
+      let cl =
+        let loc = item.pstr_loc in
+        [
+          item;
+          close_server_section loc ;
+          close_client_section loc all_injections ;
+        ]
+      in
+      match all_injections with
+      | [] ->
+        cl
+      | l ->
+        bind_injected_idents l :: cl
+    end
 
   let fragment ?typ ~context:_ ~num ~id expr =
     let typ =

--- a/src/ppx/ppx_eliom_type.ml
+++ b/src/ppx/ppx_eliom_type.ml
@@ -130,12 +130,7 @@ module Pass = struct
     | `Injection `Shared -> expr
     | `Injection `Client -> [%expr assert false]
 
-  let prelude loc =
-    let txt =
-      Printf.sprintf "__eliom__compilation_unit_id__%s" (file_hash loc) in
-    let id = Pat.var ~loc { loc ; txt } in
-    [%str let [%p id] = () ]
-
+  let prelude _ = []
   let postlude _ = []
 
   let shared_sig _ = []

--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -307,6 +307,33 @@ module type Pass = sig
 
 end
 
+(** Determine if a structure item must be wrapped into client/server sections.
+
+    This is the case if some evaluation is possible, which would lead to
+    client fragment and/or injections evaluation.
+*)
+let must_have_section x = match x.pstr_desc with
+  (* This is very conservative and could be revisited. *)
+  | Pstr_open _
+  | Pstr_class _
+  | Pstr_class_type _
+  | Pstr_include _ -> true
+
+  (* Inner declarations can be eventful *)
+  | Pstr_module _
+  | Pstr_recmodule _ -> true
+
+  | Pstr_eval _
+  | Pstr_value _
+  | Pstr_primitive _ -> true
+  | Pstr_type _
+  | Pstr_typext _
+  | Pstr_exception _
+  | Pstr_modtype _ -> false
+  | Pstr_attribute _ -> false
+  (* Just in case. *)
+  | Pstr_extension _ -> true
+
 (**
    Replace shared expression by the equivalent pair.
 

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -12,7 +12,19 @@ val format_args : expression list -> expression
 
 val pat_args : pattern list -> pattern
 
-val must_have_section : structure_item -> bool
+(** These functions try to guess if a given expression will lead to a fragment evaluation
+    This is not possible in general, this criteria is only syntactic
+
+    If the expression cannot have fragments, we don't need to use sections.
+    Consequently, this function should *never* return false positive.
+*)
+module Cannot_have_fragment : sig
+
+  val expression : expression -> bool
+  val structure_item : structure_item -> bool
+
+end
+
 
 (** Context convenience module. *)
 module Context : sig

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -2,7 +2,8 @@ open Parsetree
 
 (** {2 Various helping functions} *)
 
-val file_hash : Location.t -> string
+(** Name of the variable which holds the hash of the file. *)
+val id_file_hash : Location.t -> string Location.loc
 
 val eid : string Location.loc -> expression
 

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -12,6 +12,8 @@ val format_args : expression list -> expression
 
 val pat_args : pattern list -> pattern
 
+val must_have_section : structure_item -> bool
+
 (** Context convenience module. *)
 module Context : sig
 


### PR DESCRIPTION
Apparently, the eliom ppx is a bit too eager to put sections everywhere.
Those two small optimisations are backported from the eliom compiler. This is basically untested.

@vouillon, can you take a look?