### PR TITLE
Call exit_to if we don't have a client service

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -884,6 +884,11 @@ let change_page (type m)
            let%lwt () = f get_params post_params in
            commit_target ~nested:false ();
            Lwt.return ()
+         | None when is_client_app () ->
+           Lwt.return @@ exit_to
+             ?absolute ?absolute_path ?https ~service ?hostname ?port
+             ?fragment ?keep_nl_params ~nl_params ?keep_get_na_params
+             get_params post_params
          | None ->
            (* No client-side implementation *)
            reload_function := None;


### PR DESCRIPTION
Previously, when we were inside a mobile app, calling an action that is registered only on the server would cause trouble. In particular, we would end up doing `Eliom_client.set_content`, which is not meant for mobile apps.

I think this fixes #326.