### PR TITLE
No nested `change_page` calls for client services

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -755,17 +755,12 @@ let target, set_target, reset_target =
   (fun path params -> r := Some (path, params)),
   (fun () -> r := None)
 
-(* Some services do not need to set the URL (e.g.,
-   Eliom_registration.Unit).  The subsequent change_page will set the
-   URI. *)
-let do_not_set_uri = ref false
-
 let commit_target ~replace ~nested () =
-  match nested, target (), !do_not_set_uri with
-  | false, Some (path, params), false ->
+  match nested, target () with
+  | false, Some (path, params) ->
     change_url_string ~replace (make_uri path params)
-  | _, _, _ ->
-    do_not_set_uri := false
+  | _, _ ->
+    ()
 
 let route
     ~replace

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -346,8 +346,6 @@ val set_content_local :
   ?offset:Eliommod_dom.position ->
   ?fragment:string -> Dom_html.element Js.t -> unit Lwt.t
 
-val change_page_after_action : unit -> unit Lwt.t
-
 type client_form_handler = Dom_html.event Js.t -> bool Lwt.t
 
 val current_uri : string ref

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -353,3 +353,13 @@ val change_page_after_action : unit -> unit Lwt.t
 type client_form_handler = Dom_html.event Js.t -> bool Lwt.t
 
 val current_uri : string ref
+
+type _ redirection =
+    Redirection :
+      (unit, unit, Eliom_service.get , _, _, _, _,
+       [ `WithoutSuffix ], unit, unit, 'a) Eliom_service.t ->
+    'a redirection
+
+val register_redirect : Eliom_service.non_ocaml redirection -> unit
+
+val register_reload : unit -> unit

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -346,8 +346,6 @@ val set_content_local :
   ?offset:Eliommod_dom.position ->
   ?fragment:string -> Dom_html.element Js.t -> unit Lwt.t
 
-val do_not_set_uri : bool ref
-
 val change_page_after_action : unit -> unit Lwt.t
 
 type client_form_handler = Dom_html.event Js.t -> bool Lwt.t

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -268,7 +268,7 @@ module Action = Make (struct
     | Some `Reload | None ->
       Eliom_client.register_reload ()
     | _ ->
-      Eliom_client.do_not_set_uri := true
+      ()
 
 end)
 
@@ -282,7 +282,6 @@ module Unit = Make (struct
     let reset_reload_fun = true
 
     let send ?options:_ page =
-      Eliom_client.do_not_set_uri := true;
       Lwt.return ()
 
   end)

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -263,13 +263,12 @@ module Action = Make (struct
 
   let reset_reload_fun = true
 
-  let send ?options page =
+  let send ?options page = Lwt.return @@
     match options with
     | Some `Reload | None ->
-      Eliom_client.change_page_after_action ()
+      Eliom_client.register_reload ()
     | _ ->
-      Eliom_client.do_not_set_uri := true;
-      Lwt.return ()
+      Eliom_client.do_not_set_uri := true
 
 end)
 
@@ -313,7 +312,7 @@ module App (P : Eliom_registration_sigs.APP_PARAM) = struct
 
 end
 
-type _ redirection =
+type 'a redirection = 'a Eliom_client.redirection =
     Redirection :
       (unit, unit, Eliom_service.get , _, _, _, _,
        [ `WithoutSuffix ], unit, unit, 'a) Eliom_service.t ->
@@ -341,9 +340,8 @@ module Redirection = struct
 
   let send
       ?options:_ ?charset:_ ?code:_ ?content_type:_ ?headers:_
-      (Redirection service) =
-    let%lwt () = Eliom_client.change_page service () () in
-    Eliom_client.do_not_set_uri := true;
+      rdr =
+    Eliom_client.register_redirect rdr;
     Lwt.return ()
 
   let register


### PR DESCRIPTION
This PR simplifies the client service logic a bit.

Previously, to implement actions and redirections, we used to perform "nested" calls to `Eliom_client.change_page` and friends. This led to execution paths that were hard to get right. We now register the follow-up page change for later.

Fixes (I hope) #390 , among other issues.