### PR TITLE
Fix recent client value issues with the ppx

### DIFF
--- a/src/ppx/ppx_eliom_server.ml
+++ b/src/ppx/ppx_eliom_server.ml
@@ -102,10 +102,10 @@ module Pass = struct
           [%e eid @@ id_file_hash loc]
     ] [@metaloc loc]
 
-  let may_close_server_section item =
-    if Cannot_have_fragment.structure_item item
+  let may_close_server_section ~no_fragment loc =
+    if no_fragment
     then []
-    else [close_server_section item.pstr_loc]
+    else [close_server_section loc]
 
 
   let close_client_section loc injections =
@@ -147,16 +147,17 @@ module Pass = struct
       bind_injected_idents l ::
       [ close_client_section loc all_injections ]
 
-  let server_str item =
+  let server_str no_fragment item =
+    let loc = item.pstr_loc in
     item ::
-    may_close_server_section item
+    may_close_server_section ~no_fragment loc
 
-  let shared_str item =
+  let shared_str no_fragment item =
     let all_injections = flush_injections () in
     let loc = item.pstr_loc in
     let cl =
       item ::
-      may_close_server_section item
+      may_close_server_section ~no_fragment loc
     in
     match all_injections with
     | [] -> cl

--- a/src/ppx/ppx_eliom_type.ml
+++ b/src/ppx/ppx_eliom_type.ml
@@ -94,11 +94,11 @@ module Pass = struct
     flush_typing_str_item () @
     [%str let () = [%e flush_typing_expr () ] ] [@metaloc loc]
 
-  let server_str item =
+  let server_str _ item =
     flush_typing_str_item () @
     [ item ]
 
-  let shared_str item =
+  let shared_str _ item =
     let loc = item.pstr_loc in
     flush_typing_str_item () @
     [%str let () = [%e flush_typing_expr () ] ] [@metaloc loc] @

--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -299,8 +299,8 @@ module type Pass = sig
 
   (** How to handle "client", "shared" and "server" sections for top level structure items. *)
 
-  val shared_str: structure_item -> structure_item list
-  val server_str: structure_item -> structure_item list
+  val shared_str: bool -> structure_item -> structure_item list
+  val server_str: bool -> structure_item -> structure_item list
   val client_str: structure_item -> structure_item list
 
   (** How to handle "client", "shared" and "server" sections for top level signature items. *)
@@ -588,20 +588,25 @@ module Make (Pass : Pass) = struct
       structure item.
   *)
 
-  let dispatch (server, shared, client) field context str =
+  let dispatch_str context _mapper stri =
+    (* We must do this before any transformation on the structure. *)
+    let no_fragment = Cannot_have_fragment.structure_item stri in
     let f = match context with
-      | `Server -> server | `Shared -> shared | `Client -> client
+      | `Server -> Pass.server_str no_fragment
+      | `Shared -> Pass.shared_str no_fragment
+      | `Client -> Pass.client_str
     in
     let m = eliom_mapper context in
-    f @@ (field m) m str
+    f @@ m.AM.structure_item m stri
 
-  let dispatch_str c _mapper =
-    dispatch Pass.(server_str, shared_str, client_str)
-      (fun x -> x.AM.structure_item) c
-
-  let dispatch_sig c _mapper =
-    dispatch Pass.(server_sig, shared_sig, client_sig)
-      (fun x -> x.AM.signature_item) c
+  let dispatch_sig context _mapper sigi =
+    let f = match context with
+      | `Server -> Pass.server_sig
+      | `Shared -> Pass.shared_sig
+      | `Client -> Pass.client_sig
+    in
+    let m = eliom_mapper context in
+    f @@ m.AM.signature_item m sigi
 
   let toplevel_structure context mapper structs =
     let f pstr =

--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -326,6 +326,12 @@ module type Pass = sig
 
 end
 
+(** These functions try to guess if a given expression will lead to a fragment evaluation
+    This is not possible in general, this criteria is only syntactic
+
+    If the expression cannot have fragments, we don't need to use sections.
+    Consequently, this function should *never* return false positive.
+*)
 module Cannot_have_fragment = struct
 
   let opt_forall p = function

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -13,20 +13,6 @@ val format_args : expression list -> expression
 
 val pat_args : pattern list -> pattern
 
-(** These functions try to guess if a given expression will lead to a fragment evaluation
-    This is not possible in general, this criteria is only syntactic
-
-    If the expression cannot have fragments, we don't need to use sections.
-    Consequently, this function should *never* return false positive.
-*)
-module Cannot_have_fragment : sig
-
-  val expression : expression -> bool
-  val structure_item : structure_item -> bool
-
-end
-
-
 (** Context convenience module. *)
 module Context : sig
 

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -65,10 +65,14 @@ end
 (** Signature of specific code of a preprocessor. *)
 module type Pass = sig
 
-  (** How to handle "client", "shared" and "server" sections for top level structure items. *)
+  (** How to handle "client", "shared" and "server" sections for top level structure items.
 
-  val shared_str: structure_item -> structure_item list
-  val server_str: structure_item -> structure_item list
+      For shared and server, the boolean argument indicate if this
+      declaration can lead to evaluation of a fragment.
+  *)
+
+  val shared_str: bool -> structure_item -> structure_item list
+  val server_str: bool -> structure_item -> structure_item list
   val client_str: structure_item -> structure_item list
 
   (** How to handle "client", "shared" and "server" sections for top level signature items. *)


### PR DESCRIPTION
In particular, fix https://github.com/ocsigen/ocsigen-start/issues/202
Thanks @vasilisp for noticing.

Wow, that was quite hard to debug. o_°

The predicate to remove `close_client_section` was inconsistent between client and server code generation on [this specific code pattern](https://github.com/ocsigen/ocsigen-start/blob/d60b89105786608f101fdf4d64cce28c7dce98e9/template.distillery/PROJECT_NAME_otdemo.eliom#L40-L74), due to the order of AST transformation.

We now compute the predicate before any further transformation of the AST, which should prevent similar issues. The predicate for client section should hopefully not suffer similar issues (since it's computed by the traversal itself, on the fly).