### PR TITLE
Make Eliom_parameter user types injectable

### DIFF
--- a/src/lib/eliom_common.client.ml
+++ b/src/lib/eliom_common.client.ml
@@ -49,3 +49,15 @@ let get_site_dir sitedata = sitedata.Eliom_types.site_dir
 let get_site_dir_string sitedata = sitedata.Eliom_types.site_dir_string
 
 let add_unregistered _ _ = ()
+
+module To_and_of_shared = struct
+
+  type 'a t = 'a to_and_of
+
+  let of_string {of_string} = of_string
+
+  let to_string {to_string} = to_string
+
+  let to_and_of tao = tao
+
+end

--- a/src/lib/eliom_common.server.ml
+++ b/src/lib/eliom_common.server.ml
@@ -1365,3 +1365,38 @@ let get_secure secure sitedata =
   match secure with
   | None -> sitedata.secure_cookies
   | Some s -> s
+
+module To_and_of_shared = struct
+
+  (* FIXME : work-around for weak polymorphism in create :( *)
+  type wrapper
+
+  type 'a t = {
+    server  : 'a to_and_of ;
+    client  : 'a to_and_of Eliom_client_value.t option;
+    wrapper : wrapper
+  }
+
+  let wrapper : wrapper = Obj.magic @@
+    Eliom_wrap.create_wrapper @@ function
+    | {client = Some tao} ->
+      tao
+    | {client = None} ->
+      failwith
+        "Cannot wrap user type parameter.\n\
+         Use the ?client_to_and_of parameter of Eliom_parameter.user_type\n\
+         or (Eliom_parameter.all_suffix_user)"
+
+  let to_string {server = {to_string}} = to_string
+
+  let of_string {server = {of_string}} = of_string
+
+  let to_and_of {server} = server
+
+  let create ?client_to_and_of server = {
+    server ;
+    client = client_to_and_of ;
+    wrapper
+  }
+
+end

--- a/src/lib/eliom_common.server.mli
+++ b/src/lib/eliom_common.server.mli
@@ -716,3 +716,25 @@ val get_secure : bool option -> sitedata -> bool
 val is_client_app : bool ref
 
 val make_actual_path : string list -> string list
+
+type 'a to_and_of = {
+  of_string : string -> 'a;
+  to_string : 'a -> string
+}
+
+module To_and_of_shared : sig
+
+  type 'a t
+
+  val create :
+    ?client_to_and_of : 'a to_and_of Eliom_client_value.t ->
+    'a to_and_of ->
+    'a t
+
+  val to_string : 'a t -> 'a -> string
+
+  val of_string : 'a t -> string -> 'a
+
+  val to_and_of : 'a t -> 'a to_and_of
+
+end

--- a/src/lib/eliom_common_base.shared.ml
+++ b/src/lib/eliom_common_base.shared.ml
@@ -413,3 +413,8 @@ type ('params, 'result) service = {
   s_expire          : (float * float ref) option;
   s_f               : bool -> 'params -> 'result Lwt.t
 }
+
+type 'a to_and_of = {
+  of_string : string -> 'a;
+  to_string : 'a -> string
+}

--- a/src/lib/eliom_parameter.client.ml
+++ b/src/lib/eliom_parameter.client.ml
@@ -144,6 +144,12 @@ and reconstruct_params_form :
     | _ ->
       None
 
+let user_type ~of_string ~to_string n =
+  TUserType (n, {of_string ; to_string})
+
+let all_suffix_user ~of_string ~to_string n =
+  TESuffixu (n, {of_string ; to_string})
+
 let reconstruct_params_form l y =
   reconstruct_params_form (M.of_assoc_list l) y >>= fun (v, _) ->
   Some v

--- a/src/lib/eliom_parameter.client.mli
+++ b/src/lib/eliom_parameter.client.mli
@@ -1,4 +1,42 @@
+(* Ocsigen
+ * http://www.ocsigen.org
+ * Copyright (C) 2007-2016 Vincent Balat
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
 include Eliom_parameter_sigs.S with type raw_post_data = unit
+
+(** Specifying parameter as [user_type ~of_string ~to_string s] tells
+    that the service take a parameter, labeled [s], and that the
+    server will have to use [of_string] and [to_string] to make the
+    conversion between the OCaml representation of the parameter and
+    it's external representation as a string. It allows one to use
+    whatever type you want for a parameter of the service.  *)
+val user_type :
+  of_string:(string -> 'a) ->
+  to_string:('a -> string) ->
+  string ->
+  ('a, [ `WithoutSuffix ], [ `One of 'a ] param_name) params_type
+
+(** Takes the whole suffix, as long as possible, with a type specified
+    by the user. *)
+val all_suffix_user :
+  of_string:(string -> 'a) ->
+  to_string:('a -> string) -> string ->
+  ('a, [ `Endsuffix ], [` One of 'a ] param_name) params_type
 
 val reconstruct_params_form :
   (string * Form.form_elt) list -> ('a, _, _) params_type -> 'a option

--- a/src/lib/eliom_parameter.server.ml
+++ b/src/lib/eliom_parameter.server.ml
@@ -29,7 +29,32 @@ open Ocsigen_extensions
 
 let section = Lwt_log.Section.make "eliom:parameter"
 
-(*****************************************************************************)
+(* server-specific constructors *)
+
+let user_type
+    ?client_to_and_of
+    ~(of_string : string -> 'a)
+    ~(to_string : 'a -> string)
+    (n : string) =
+  TUserType (
+    n,
+    Eliom_common.To_and_of_shared.create
+      ?client_to_and_of
+      {of_string ; to_string}
+  )
+
+let all_suffix_user
+    ?client_to_and_of
+    ~(of_string : string -> 'a)
+    ~(to_string : 'a -> string)
+    (n : string) =
+  TESuffixu (
+    n,
+    Eliom_common.To_and_of_shared.create
+      ?client_to_and_of
+      {of_string ; to_string}
+  )
+
 (* types available only on server side (no pcre on browser) *)
 
 let regexp reg dest ~to_string n =

--- a/src/lib/eliom_parameter.server.mli
+++ b/src/lib/eliom_parameter.server.mli
@@ -1,6 +1,6 @@
 (* Ocsigen
  * http://www.ocsigen.org
- * Copyright (C) 2007 Vincent Balat
+ * Copyright (C) 2007-2016 Vincent Balat
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,6 +21,31 @@ include Eliom_parameter_sigs.S
   with type raw_post_data =
     ((string * string) * (string * string) list) option *
     string Ocsigen_stream.t option
+
+(** [user_type ~of_string ~to_string s] construct a parameter, labeled
+    [s], such that the server will have to use [of_string] and
+    [to_string] to make the conversion between the OCaml
+    representation of the parameter and it's representation as a
+    string. It allows one to use any type for a parameter. Providing
+    converters via the optional [?client_to_and_from] parameter allows
+    injecting the parameter (or a service that uses it) for use in
+    client code. *)
+val user_type :
+  ?client_to_and_of : 'a to_and_of Eliom_client_value.t ->
+  of_string : (string -> 'a) ->
+  to_string : ('a -> string) ->
+  string ->
+  ('a, [ `WithoutSuffix ], [ `One of 'a ] param_name) params_type
+
+(** Takes the whole suffix, as long as possible, with a type specified
+    by the user. See [user_type] for the description of the
+    arguments. *)
+val all_suffix_user :
+  ?client_to_and_of : 'a to_and_of Eliom_client_value.t ->
+  of_string : (string -> 'a) ->
+  to_string : ('a -> string) ->
+  string ->
+  ('a, [ `Endsuffix ], [` One of 'a ] param_name) params_type
 
 (** Specifying parameter as [type_checker check t] is equivalent as
     [t] but the check function is called after decoding the

--- a/src/lib/eliom_parameter_sigs.shared.mli
+++ b/src/lib/eliom_parameter_sigs.shared.mli
@@ -85,7 +85,7 @@ module type S = sig
     it :'el 'a. ('an -> 'el -> 'a -> 'a) -> 'el list -> 'a -> 'a
   }
 
-  type 'a to_and_from = {
+  type 'a to_and_of = {
     of_string : string -> 'a;
     to_string : 'a -> string
   }
@@ -136,18 +136,6 @@ module type S = sig
   (** Specifying parameter as [unit] is used for services that don't
       have any parameters *)
   val unit : (unit, [ `WithoutSuffix ], unit) params_type
-
-  (** Specifying parameter as [user_type ~of_string ~to_string s]
-      tells that the service take a parameter, labeled [s], and that the
-      server will have to use [of_string] and [to_string] to make the
-      conversion between the OCaml representation of the parameter and
-      it's external representation as a string. It allows one to use
-      whatever type you want for a parameter of the service.  *)
-  val user_type :
-    of_string:(string -> 'a) ->
-    to_string:('a -> string) ->
-    string ->
-    ('a, [ `WithoutSuffix ], [ `One of 'a ] param_name) params_type
 
   (** The type [coordinates] represents the data sent by an [<input
       type="image" ...>]. *)
@@ -267,13 +255,6 @@ module type S = sig
     string ->
     (string, [`Endsuffix], [` One of string ] param_name) params_type
 
-  (** Takes the whole suffix, as long as possible, with a type
-      specified by the user. *)
-  val all_suffix_user :
-    of_string:(string -> 'a) ->
-    to_string:('a -> string) -> string ->
-    ('a, [ `Endsuffix ], [` One of 'a ] param_name) params_type
-
   (** Tells that the function that will generate the service takes a
       pair whose first element is the suffix of the URL of the current
       service, and the second element corresponds to other (regular)
@@ -362,14 +343,14 @@ module type S = sig
       - unit
       - string
       - bool *)
-  val get_to_and_from : ('a, 'b, 'c) params_type -> 'a to_and_from
+  val get_to_and_of : ('a, 'b, 'c) params_type -> 'a to_and_of
 
   (**/**)
 
   val walk_parameter_tree :
     [`One of string] param_name ->
     ('a, 'b, 'c) params_type ->
-    'a to_and_from option
+    'a to_and_of option
 
   (* None = no suffix. The bool means : redirect_if_not_suffix *)
   val contains_suffix : ('a, 'b, 'c) params_type -> bool option


### PR DESCRIPTION
This patch allows us to inject user parameters, and by extension services that use them.

A prerequisite for removing client-side service creation (for which the patch is ready).

A bit hackish in places.