### PR TITLE
Replaces tabs with spaces and remove some empty lines

### DIFF
--- a/src/lib/client/eliom_client.js
+++ b/src/lib/client/eliom_client.js
@@ -72,7 +72,7 @@ var caml_unwrap_value_from_string = function (){
           var size = (code >> 4) & 0x7;
           var v = [tag];
           if (size == 0) return v;
-	  intern_obj_table[obj_counter] = v;
+          intern_obj_table[obj_counter] = v;
           stack.push(obj_counter++, size);
           return v;
         } else
@@ -109,7 +109,7 @@ var caml_unwrap_value_from_string = function (){
             var size = header >> 10;
             var v = [tag];
             if (size == 0) return v;
-	    intern_obj_table[obj_counter] = v;
+            intern_obj_table[obj_counter] = v;
             stack.push(obj_counter++, size);
             return v;
           case cst.CODE_BLOCK64:
@@ -230,7 +230,7 @@ var caml_unwrap_value_from_string = function (){
             v = unwrapped_v[1];
           }
           intern_obj_table[ofs] = v;
-	  ancestor[ancestor.length-1] = v;
+          ancestor[ancestor.length-1] = v;
         }
       } else {
         stack.push(ofs, size);

--- a/src/lib/eliom_bus.client.ml
+++ b/src/lib/eliom_bus.client.ml
@@ -80,10 +80,13 @@ let create service channel waiter =
     let t,u = Lwt.wait () in
     (try%lwt let%lwt _ = t in assert false with e -> [%lwt raise ( e)]), u in
   let stream =
-    lazy (let stream = Eliom_comet.register channel in
-	  (* iterate on the stream to consume messages: avoid memory leak *)
-	  let _ = consume error_h stream in
-	  stream) in
+    lazy (
+      let stream = Eliom_comet.register channel in
+      (* iterate on the stream to consume messages: avoid memory leak *)
+      let _ = consume error_h stream in
+      stream
+    )
+  in
   let t = {
     channel;
     stream;

--- a/src/lib/eliom_common.server.ml
+++ b/src/lib/eliom_common.server.ml
@@ -463,7 +463,7 @@ and sitedata =
      ((full_state_name * (float option * bool)) list);
 
    site_value_table : Polytables.t; (* table containing evaluated
-				       lazy site values *)
+                                       lazy site values *)
 
    mutable registered_scope_hierarchies: Hier_set.t;
 
@@ -624,7 +624,7 @@ let register_scope_hierarchy (name:string) =
         Hier_set.add name !registered_scope_hierarchies
     | Some sp ->
       if Hier_set.mem name !registered_scope_hierarchies ||
-	Hier_set.mem name sp.sp_sitedata.registered_scope_hierarchies
+         Hier_set.mem name sp.sp_sitedata.registered_scope_hierarchies
       then failwith (Printf.sprintf "the scope hierarchy %s has already been registered" name)
       else sp.sp_sitedata.registered_scope_hierarchies <-
         Hier_set.add name sp.sp_sitedata.registered_scope_hierarchies
@@ -732,15 +732,15 @@ let force_lazy_site_value v =
                          "force_lazy_site_value")
   in
   try Polytables.get
-	~table:sitedata.site_value_table
-	~key:v.lazy_sv_key
+    ~table:sitedata.site_value_table
+    ~key:v.lazy_sv_key
   with
     | Not_found ->
       let value = v.lazy_sv_fun () in
       Polytables.set
-	~table:sitedata.site_value_table
-	~key:v.lazy_sv_key
-	~value;
+        ~table:sitedata.site_value_table
+        ~key:v.lazy_sv_key
+        ~value;
       value
 
 let lazy_site_value_from_fun f =
@@ -955,7 +955,7 @@ let get_session_info req previous_extension_err =
           let (tc, pp) =
             List.assoc_remove tab_cookies_param_name post_params
           in
-	  let tc = [%derive.of_json: (string * string) list] tc in
+          let tc = [%derive.of_json: (string * string) list] tc in
           (List.fold_left (fun t (k,v) -> CookiesTable.add k v t) CookiesTable.empty tc, pp)
           (*Marshal.from_string (Ocsigen_lib.decode tc) 0, pp*)
         with Not_found ->
@@ -963,7 +963,7 @@ let get_session_info req previous_extension_err =
             let tc = Ocsigen_headers.find tab_cookies_header_name
               (Ocsigen_extensions.Ocsigen_request_info.http_frame ri)
             in
-	    let tc = [%derive.of_json: (string * string) list] tc in
+            let tc = [%derive.of_json: (string * string) list] tc in
             (List.fold_left (fun t (k,v) -> CookiesTable.add k v t) CookiesTable.empty tc,
              post_params)
           with Not_found -> CookiesTable.empty, post_params
@@ -975,9 +975,9 @@ let get_session_info req previous_extension_err =
   let cpi =
     try (* looking for client process info in headers *)
       let cpi =
-	Ocsigen_headers.find
-	  tab_cpi_header_name
-	  (Ocsigen_extensions.Ocsigen_request_info.http_frame ri) in
+        Ocsigen_headers.find
+          tab_cpi_header_name
+          (Ocsigen_extensions.Ocsigen_request_info.http_frame ri) in
       Some ([%derive.of_json: cpi] cpi)
     with Not_found -> None
   in
@@ -985,8 +985,8 @@ let get_session_info req previous_extension_err =
   let epd =
     lazy (try (* looking in headers *)
             let epd = Ocsigen_headers.find
-	      expecting_process_page_name
-	      (Ocsigen_extensions.Ocsigen_request_info.http_frame ri)
+              expecting_process_page_name
+              (Ocsigen_extensions.Ocsigen_request_info.http_frame ri)
             in
             [%derive.of_json: bool] epd
       with Not_found -> false)

--- a/src/lib/eliom_common.server.mli
+++ b/src/lib/eliom_common.server.mli
@@ -31,17 +31,17 @@ open Eliom_lib
 type scope_hierarchy = Eliom_common_base.scope_hierarchy
 
 type cookie_scope = [ `Session of scope_hierarchy
-		    | `Client_process of scope_hierarchy ]
+                    | `Client_process of scope_hierarchy ]
 
 type user_scope = [ `Session_group of scope_hierarchy
                   | cookie_scope ]
 
 type scope = [ `Site
-	     | user_scope ]
+             | user_scope ]
 
 type all_scope = [ scope
                  | `Global
-		 | `Request ]
+                 | `Request ]
 
 type cookie_level = [ `Session | `Client_process ]
 
@@ -528,7 +528,7 @@ and sitedata = {
      ((full_state_name * (float option * bool)) list);
 
   site_value_table : Polytables.t; (* table containing evaluated
-					   lazy site values *)
+                                      lazy site values *)
 
   mutable registered_scope_hierarchies: Hier_set.t;
 
@@ -559,9 +559,9 @@ and sitedata = {
 }
 
 type 'a lazy_site_value (** lazy site values, are lazy values with
-			   content available only in the context of a
-			   site: the closure one time for each site (
-			   requesting it ) *)
+                            content available only in the context of a
+                            site: the closure one time for each site (
+                            requesting it ) *)
 
 val force_lazy_site_value : 'a lazy_site_value -> 'a
 val lazy_site_value_from_fun : ( unit -> 'a ) -> 'a lazy_site_value

--- a/src/lib/eliom_common_base.shared.ml
+++ b/src/lib/eliom_common_base.shared.ml
@@ -31,15 +31,15 @@ type scope_hierarchy =
   | Default_comet_hier
 
 type user_scope = [ `Session_group of scope_hierarchy
-		  | `Session of scope_hierarchy
-		  | `Client_process of scope_hierarchy ]
+                  | `Session of scope_hierarchy
+                  | `Client_process of scope_hierarchy ]
 
 type scope = [ `Site
-	     | user_scope ]
+             | user_scope ]
 
 type all_scope = [ scope
                  | `Global
-		 | `Request ]
+                 | `Request ]
 
 type global_scope = [`Global]
 type site_scope = [`Site]

--- a/src/lib/eliom_content_.client.ml
+++ b/src/lib/eliom_content_.client.ml
@@ -302,13 +302,13 @@ module MakeManip
       done
 
       let toggle elt cl1 =
-	if contain elt cl1
-	then remove elt cl1
-	else add elt cl1
+        if contain elt cl1
+        then remove elt cl1
+        else add elt cl1
       let toggle2 elt cl1 cl2 =
-	  if contain elt cl1
-	  then replace elt cl1 cl2
-	  else replace elt cl2 cl1
+          if contain elt cl1
+          then replace elt cl1 cl2
+          else replace elt cl2 cl1
 
     end
 
@@ -524,44 +524,44 @@ module Html = struct
       type ('a,'b) ev_unit = 'a elt -> ('b Js.t -> unit) -> unit
       let bool_cb f = Dom_html.handler (fun e -> Js.bool (f e))
       let onkeyup elt f =
-	let elt = get_unique_elt "Ev.onkeyup" elt in
-	elt##.onkeyup := (bool_cb f)
+        let elt = get_unique_elt "Ev.onkeyup" elt in
+        elt##.onkeyup := (bool_cb f)
       let onkeydown elt f =
-	let elt = get_unique_elt "Ev.onkeydown" elt in
-	elt##.onkeydown := (bool_cb f)
+        let elt = get_unique_elt "Ev.onkeydown" elt in
+        elt##.onkeydown := (bool_cb f)
       let onmouseup elt f =
-	let elt = get_unique_elt "Ev.onmouseup" elt in
-	elt##.onmouseup := (bool_cb f)
+        let elt = get_unique_elt "Ev.onmouseup" elt in
+        elt##.onmouseup := (bool_cb f)
       let onmousedown elt f =
-	let elt = get_unique_elt "Ev.onmousedown" elt in
-	elt##.onmousedown := (bool_cb f)
+        let elt = get_unique_elt "Ev.onmousedown" elt in
+        elt##.onmousedown := (bool_cb f)
       let onmouseout elt f =
-	let elt = get_unique_elt "Ev.onmouseout" elt in
-	elt##.onmouseout := (bool_cb f)
+        let elt = get_unique_elt "Ev.onmouseout" elt in
+        elt##.onmouseout := (bool_cb f)
       let onmouseover elt f =
-	let elt = get_unique_elt "Ev.onmouseover" elt in
-	elt##.onmouseover := (bool_cb f)
+        let elt = get_unique_elt "Ev.onmouseover" elt in
+        elt##.onmouseover := (bool_cb f)
       let onclick elt f =
-	let elt = get_unique_elt "Ev.onclick" elt in
-	elt##.onclick := (bool_cb f)
+        let elt = get_unique_elt "Ev.onclick" elt in
+        elt##.onclick := (bool_cb f)
       let ondblclick elt f =
-	let elt = get_unique_elt "Ev.ondblclick" elt in
-	elt##.ondblclick := (bool_cb f)
+        let elt = get_unique_elt "Ev.ondblclick" elt in
+        elt##.ondblclick := (bool_cb f)
       let onload elt f =
-	let elt = get_unique_elt_img "Ev.onload" elt in
-	elt##.onload := (bool_cb f)
+        let elt = get_unique_elt_img "Ev.onload" elt in
+        elt##.onload := (bool_cb f)
       let onerror elt f =
-	let elt = get_unique_elt_img "Ev.onerror" elt in
-	elt##.onerror := (bool_cb f)
+        let elt = get_unique_elt_img "Ev.onerror" elt in
+        elt##.onerror := (bool_cb f)
       let onabort elt f =
-	let elt = get_unique_elt_img "Ev.onabort" elt in
-	elt##.onabort := (bool_cb f)
+        let elt = get_unique_elt_img "Ev.onabort" elt in
+        elt##.onabort := (bool_cb f)
       let onfocus elt f =
-	let elt = get_unique_elt_input "Ev.onfocus" elt in
-	elt##.onfocus := (bool_cb f)
+        let elt = get_unique_elt_input "Ev.onfocus" elt in
+        elt##.onfocus := (bool_cb f)
       let onblur elt f =
-	let elt = get_unique_elt_input "Ev.onblur" elt in
-	elt##.onblur := (bool_cb f)
+        let elt = get_unique_elt_input "Ev.onblur" elt in
+        elt##.onblur := (bool_cb f)
       let onfocus_textarea elt f =
         let elt = get_unique_elt_textarea "Ev.onfocus" elt in
         elt##.onfocus := (bool_cb f)
@@ -569,17 +569,17 @@ module Html = struct
         let elt = get_unique_elt_textarea "Ev.onblur" elt in
         elt##.onblur := (bool_cb f)
       let onscroll elt f =
-	let elt = get_unique_elt "Ev.onscroll" elt in
-	elt##.onscroll := (bool_cb f)
+        let elt = get_unique_elt "Ev.onscroll" elt in
+        elt##.onscroll := (bool_cb f)
       let onreturn elt f =
-	let f ev =
-	  let key = ev##.keyCode in
-	  if key = Keycode.return then f ev;
-	  true in
-	onkeydown elt f
+        let f ev =
+          let key = ev##.keyCode in
+          if key = Keycode.return then f ev;
+          true in
+        onkeydown elt f
       let onchange elt f =
-	let elt = get_unique_elt_input "Ev.onchange" elt in
-	elt##.onchange := (bool_cb f)
+        let elt = get_unique_elt_input "Ev.onchange" elt in
+        elt##.onchange := (bool_cb f)
       let onchange_select elt f =
         let elt = get_unique_elt_select "Ev.onchange_select" elt in
         elt##.onchange := (bool_cb f)
@@ -587,23 +587,23 @@ module Html = struct
 
     module Attr = struct
       let clientWidth elt =
-	let elt = get_unique_elt "Attr.clientWidth" elt in
-	elt##.clientWidth
+        let elt = get_unique_elt "Attr.clientWidth" elt in
+        elt##.clientWidth
       let clientHeight elt =
-	let elt = get_unique_elt "Attr.clientHeight" elt in
-	elt##.clientHeight
+        let elt = get_unique_elt "Attr.clientHeight" elt in
+        elt##.clientHeight
       let offsetWidth elt =
-	let elt = get_unique_elt "Attr.offsetWidth" elt in
-	elt##.offsetWidth
+        let elt = get_unique_elt "Attr.offsetWidth" elt in
+        elt##.offsetWidth
       let offsetHeight elt =
-	let elt = get_unique_elt "Attr.offsetHeight" elt in
-	elt##.offsetHeight
+        let elt = get_unique_elt "Attr.offsetHeight" elt in
+        elt##.offsetHeight
       let clientLeft elt =
-	let elt = get_unique_elt "Attr.clientLeft" elt in
-	elt##.clientLeft
+        let elt = get_unique_elt "Attr.clientLeft" elt in
+        elt##.clientLeft
       let clientTop elt =
-	let elt = get_unique_elt "Attr.clientTop" elt in
-	elt##.clientTop
+        let elt = get_unique_elt "Attr.clientTop" elt in
+        elt##.clientTop
     end
 
     module Css = struct
@@ -641,8 +641,8 @@ module Html = struct
         let elt = get_unique_elt "Css.borderBottomWidth" elt in
         Js.to_bytestring (elt##.style##.borderBottomWidth)
       let borderBottomWidthPx elt =
-	let elt = get_unique_elt "Css.borderBottomWidthPx" elt in
-	Js.parseInt (elt##.style##.borderBottomWidth)
+        let elt = get_unique_elt "Css.borderBottomWidthPx" elt in
+        Js.parseInt (elt##.style##.borderBottomWidth)
       let borderCollapse elt =
         let elt = get_unique_elt "Css.borderCollapse" elt in
         Js.to_bytestring (elt##.style##.borderCollapse)
@@ -662,8 +662,8 @@ module Html = struct
         let elt = get_unique_elt "Css.borderLeftWidth" elt in
         Js.to_bytestring (elt##.style##.borderLeftWidth)
       let borderLeftWidthPx elt =
-	let elt = get_unique_elt "Css.borderLeftWidthPx" elt in
-	Js.parseInt (elt##.style##.borderLeftWidth)
+        let elt = get_unique_elt "Css.borderLeftWidthPx" elt in
+        Js.parseInt (elt##.style##.borderLeftWidth)
       let borderRight elt =
         let elt = get_unique_elt "Css.borderRight" elt in
         Js.to_bytestring (elt##.style##.borderRight)
@@ -677,8 +677,8 @@ module Html = struct
         let elt = get_unique_elt "Css.borderRightWidth" elt in
         Js.to_bytestring (elt##.style##.borderRightWidth)
       let borderRightWidthPx elt =
-	let elt = get_unique_elt "Css.borderRightWidthPx" elt in
-	Js.parseInt (elt##.style##.borderRightWidth)
+        let elt = get_unique_elt "Css.borderRightWidthPx" elt in
+        Js.parseInt (elt##.style##.borderRightWidth)
       let borderSpacing elt =
         let elt = get_unique_elt "Css.borderSpacing" elt in
         Js.to_bytestring (elt##.style##.borderSpacing)
@@ -698,14 +698,14 @@ module Html = struct
         let elt = get_unique_elt "Css.borderTopWidth" elt in
         Js.to_bytestring (elt##.style##.borderTopWidth)
       let borderTopWidthPx elt =
-	let elt = get_unique_elt "Css.borderTopWidthPx" elt in
-	Js.parseInt (elt##.style##.borderTopWidth)
+        let elt = get_unique_elt "Css.borderTopWidthPx" elt in
+        Js.parseInt (elt##.style##.borderTopWidth)
       let borderWidth elt =
         let elt = get_unique_elt "Css.borderWidth" elt in
         Js.to_bytestring (elt##.style##.borderWidth)
       let borderWidthPx elt =
-	let elt = get_unique_elt "Css.borderWidthPx" elt in
-	Js.parseInt (elt##.style##.borderWidth)
+        let elt = get_unique_elt "Css.borderWidthPx" elt in
+        Js.parseInt (elt##.style##.borderWidth)
       let bottom elt =
         let elt = get_unique_elt "Css.bottom" elt in
         Js.to_bytestring (elt##.style##.bottom)
@@ -770,14 +770,14 @@ module Html = struct
         let elt = get_unique_elt "Css.height" elt in
         Js.to_bytestring (elt##.style##.height)
       let heightPx elt =
-	let elt = get_unique_elt "Css.heightPx" elt in
-	Js.parseInt (elt##.style##.height)
+        let elt = get_unique_elt "Css.heightPx" elt in
+        Js.parseInt (elt##.style##.height)
       let left elt =
         let elt = get_unique_elt "Css.left" elt in
         Js.to_bytestring (elt##.style##.left)
       let leftPx elt =
-	let elt = get_unique_elt "Css.leftPx" elt in
-	Js.parseInt (elt##.style##.left)
+        let elt = get_unique_elt "Css.leftPx" elt in
+        Js.parseInt (elt##.style##.left)
       let letterSpacing elt =
         let elt = get_unique_elt "Css.letterSpacing" elt in
         Js.to_bytestring (elt##.style##.letterSpacing)
@@ -803,50 +803,50 @@ module Html = struct
         let elt = get_unique_elt "Css.marginBottom" elt in
         Js.to_bytestring (elt##.style##.marginBottom)
       let marginBottomPx elt =
-	let elt = get_unique_elt "Css.marginBottomPx" elt in
-	Js.parseInt (elt##.style##.marginBottom)
+        let elt = get_unique_elt "Css.marginBottomPx" elt in
+        Js.parseInt (elt##.style##.marginBottom)
       let marginLeft elt =
         let elt = get_unique_elt "Css.marginLeft" elt in
         Js.to_bytestring (elt##.style##.marginLeft)
       let marginLeftPx elt =
-	let elt = get_unique_elt "Css.marginLeftPx" elt in
-	Js.parseInt (elt##.style##.marginLeft)
+        let elt = get_unique_elt "Css.marginLeftPx" elt in
+        Js.parseInt (elt##.style##.marginLeft)
       let marginRight elt =
         let elt = get_unique_elt "Css.marginRight" elt in
         Js.to_bytestring (elt##.style##.marginRight)
       let marginRightPx elt =
-	let elt = get_unique_elt "Css.marginRightPx" elt in
-	Js.parseInt (elt##.style##.marginRight)
+        let elt = get_unique_elt "Css.marginRightPx" elt in
+        Js.parseInt (elt##.style##.marginRight)
       let marginTop elt =
         let elt = get_unique_elt "Css.marginTop" elt in
         Js.to_bytestring (elt##.style##.marginTop)
       let marginTopPx elt =
-	let elt = get_unique_elt "Css.marginTopPx" elt in
-	Js.parseInt (elt##.style##.marginTop)
+        let elt = get_unique_elt "Css.marginTopPx" elt in
+        Js.parseInt (elt##.style##.marginTop)
       let maxHeight elt =
         let elt = get_unique_elt "Css.maxHeight" elt in
         Js.to_bytestring (elt##.style##.maxHeight)
       let maxHeightPx elt =
-	let elt = get_unique_elt "Css.maxHeightPx" elt in
-	Js.parseInt (elt##.style##.maxHeight)
+        let elt = get_unique_elt "Css.maxHeightPx" elt in
+        Js.parseInt (elt##.style##.maxHeight)
       let maxWidth elt =
         let elt = get_unique_elt "Css.maxWidth" elt in
         Js.to_bytestring (elt##.style##.maxWidth)
       let maxWidthPx elt =
-	let elt = get_unique_elt "Css.maxWidthPx" elt in
-	Js.parseInt (elt##.style##.maxWidth)
+        let elt = get_unique_elt "Css.maxWidthPx" elt in
+        Js.parseInt (elt##.style##.maxWidth)
       let minHeight elt =
         let elt = get_unique_elt "Css.minHeight" elt in
         Js.to_bytestring (elt##.style##.minHeight)
       let minHeightPx elt =
-	let elt = get_unique_elt "Css.minHeightPx" elt in
-	Js.parseInt (elt##.style##.minHeight)
+        let elt = get_unique_elt "Css.minHeightPx" elt in
+        Js.parseInt (elt##.style##.minHeight)
       let minWidth elt =
         let elt = get_unique_elt "Css.minWidth" elt in
         Js.to_bytestring (elt##.style##.minWidth)
       let minWidthPx elt =
-	let elt = get_unique_elt "Css.minWidthPx" elt in
-	Js.parseInt (elt##.style##.minWidth)
+        let elt = get_unique_elt "Css.minWidthPx" elt in
+        Js.parseInt (elt##.style##.minWidth)
       let opacity elt =
         let elt = get_unique_elt "Css.opacity" elt in
         Option.map Js.to_bytestring (Js.Optdef.to_option (elt##.style##.opacity))
@@ -881,26 +881,26 @@ module Html = struct
         let elt = get_unique_elt "Css.paddingBottom" elt in
         Js.to_bytestring (elt##.style##.paddingBottom)
       let paddingBottomPx elt =
-	let elt = get_unique_elt "Css.paddingBottomPx" elt in
-	Js.parseInt (elt##.style##.paddingBottom)
+        let elt = get_unique_elt "Css.paddingBottomPx" elt in
+        Js.parseInt (elt##.style##.paddingBottom)
       let paddingLeft elt =
         let elt = get_unique_elt "Css.paddingLeft" elt in
         Js.to_bytestring (elt##.style##.paddingLeft)
       let paddingLeftPx elt =
-	let elt = get_unique_elt "Css.paddingLeftPx" elt in
-	Js.parseInt (elt##.style##.paddingLeft)
+        let elt = get_unique_elt "Css.paddingLeftPx" elt in
+        Js.parseInt (elt##.style##.paddingLeft)
       let paddingRight elt =
         let elt = get_unique_elt "Css.paddingRight" elt in
         Js.to_bytestring (elt##.style##.paddingRight)
       let paddingRightPx elt =
-	let elt = get_unique_elt "Css.paddingRightPx" elt in
-	Js.parseInt (elt##.style##.paddingRight)
+        let elt = get_unique_elt "Css.paddingRightPx" elt in
+        Js.parseInt (elt##.style##.paddingRight)
       let paddingTop elt =
         let elt = get_unique_elt "Css.paddingTop" elt in
         Js.to_bytestring (elt##.style##.paddingTop)
       let paddingTopPx elt =
-	let elt = get_unique_elt "Css.paddingTopPx" elt in
-	Js.parseInt (elt##.style##.paddingTop)
+        let elt = get_unique_elt "Css.paddingTopPx" elt in
+        Js.parseInt (elt##.style##.paddingTop)
       let pageBreakAfter elt =
         let elt = get_unique_elt "Css.pageBreakAfter" elt in
         Js.to_bytestring (elt##.style##.pageBreakAfter)
@@ -914,8 +914,8 @@ module Html = struct
         let elt = get_unique_elt "Css.right" elt in
         Js.to_bytestring (elt##.style##.right)
       let rightPx elt =
-	let elt = get_unique_elt "Css.rightPx" elt in
-	Js.parseInt (elt##.style##.right)
+        let elt = get_unique_elt "Css.rightPx" elt in
+        Js.parseInt (elt##.style##.right)
       let tableLayout elt =
         let elt = get_unique_elt "Css.tableLayout" elt in
         Js.to_bytestring (elt##.style##.tableLayout)
@@ -935,8 +935,8 @@ module Html = struct
         let elt = get_unique_elt "Css.top" elt in
         Js.to_bytestring (elt##.style##.top)
       let topPx elt =
-	let elt = get_unique_elt "Css.topPx" elt in
-	Js.parseInt (elt##.style##.top)
+        let elt = get_unique_elt "Css.topPx" elt in
+        Js.parseInt (elt##.style##.top)
       let verticalAlign elt =
         let elt = get_unique_elt "Css.verticalAlign" elt in
         Js.to_bytestring (elt##.style##.verticalAlign)
@@ -950,8 +950,8 @@ module Html = struct
         let elt = get_unique_elt "Css.width" elt in
         Js.to_bytestring (elt##.style##.width)
       let widthPx elt =
-	let elt = get_unique_elt "Css.widthPx" elt in
-	Js.parseInt (elt##.style##.width)
+        let elt = get_unique_elt "Css.widthPx" elt in
+        Js.parseInt (elt##.style##.width)
       let wordSpacing elt =
         let elt = get_unique_elt "Css.wordSpacing" elt in
         Js.to_bytestring (elt##.style##.wordSpacing)

--- a/src/lib/eliom_content_core.client.ml
+++ b/src/lib/eliom_content_core.client.ml
@@ -327,8 +327,8 @@ module Html = struct
 
     let lazy_form ?(a = []) elts =
       tot (Xml'.lazy_node ~a:(to_xmlattribs a) "form"
-	     (Eliom_lazy.from_fun
-	        (fun () -> toeltl (Eliom_lazy.force elts))))
+             (Eliom_lazy.from_fun
+                (fun () -> toeltl (Eliom_lazy.force elts))))
 
   end
 
@@ -371,8 +371,8 @@ module Html = struct
 
     let lazy_form ?(a = []) elts =
       tot (Xml'.lazy_node ~a:(to_xmlattribs a) "form"
-	     (Eliom_lazy.from_fun
-	        (fun () -> toeltl (Eliom_lazy.force elts))))
+             (Eliom_lazy.from_fun
+                (fun () -> toeltl (Eliom_lazy.force elts))))
 
   end
 

--- a/src/lib/eliom_mkreg.server.ml
+++ b/src/lib/eliom_mkreg.server.ml
@@ -25,19 +25,19 @@ let suffix_redir_uri_key = Polytables.make_key ()
 
 type ('options,'page,'result) param =
     { send :
-	?options:'options ->
-	?charset:string ->
-	?code: int ->
-	?content_type:string ->
-	?headers: Http_headers.t ->
-	'page ->
-	Ocsigen_http_frame.result Lwt.t;
+        ?options:'options ->
+        ?charset:string ->
+        ?code: int ->
+        ?content_type:string ->
+        ?headers: Http_headers.t ->
+        'page ->
+        Ocsigen_http_frame.result Lwt.t;
 
       send_appl_content : S.send_appl_content;
       (** Whether the service is capable to send application content when
-	  required. This field is usually [Eliom_service.XNever]. This
-	  value is recorded inside each service just after
-	  registration.  *)
+          required. This field is usually [Eliom_service.XNever]. This
+          value is recorded inside each service just after
+          registration.  *)
 
       result_of_http_result : Ocsigen_http_frame.result -> 'result; }
 
@@ -73,8 +73,8 @@ let check_before name service =
   (* the appl name of the service *)
   with
     | S.XSame_appl (an, _)
-	when (an = name)
-	  -> (* Same appl, it is ok *) false
+        when (an = name)
+          -> (* Same appl, it is ok *) false
     | S.XAlways -> (* It is an action *) false
     | _ -> true
 
@@ -98,11 +98,11 @@ let check_process_redir sp f param =
     if Eliom_request_info.expecting_process_page ()
     then
       match sp.Eliom_common.sp_client_appl_name with
-	(* the appl name as sent by browser *)
-	| None -> false (* should not happen *)
-	| Some anr -> f anr param
-	  (* the browser asked application eliom data
-	     (content only) for application anr *)
+        (* the appl name as sent by browser *)
+        | None -> false (* should not happen *)
+        | Some anr -> f anr param
+          (* the browser asked application eliom data
+             (content only) for application anr *)
     else false
   in
   if redir
@@ -110,9 +110,9 @@ let check_process_redir sp f param =
     let ri = Eliom_request_info.get_ri_sp sp in
     [%lwt raise (
       (* we answer to the xhr
-	 by asking an HTTP redirection *)
+         by asking an HTTP redirection *)
       (Eliom_common.Eliom_do_half_xhr_redirection
-	 ("/"^
+         ("/"^
              Eliom_lib.String.may_concat
                   (Ocsigen_extensions.Ocsigen_request_info.original_full_path_string ri)
                   ~sep:"?"
@@ -180,7 +180,7 @@ let register_aux pages
     S.set_send_appl_content service (pages.send_appl_content);
     begin
       match S.info service with
-	| S.Attached attser ->
+        | S.Attached attser ->
           let key_meth = S.which_meth_untyped service in
           let attserget = S.get_name attser in
           let attserpost = S.post_name attser in
@@ -219,71 +219,71 @@ let register_aux pages
                       let ri = Eliom_request_info.get_ri_sp sp
                       and suff = Eliom_request_info.get_suffix_sp sp in
                       (Lwt.catch (fun () ->
-			 Eliom_parameter.reconstruct_params
-			  ~sp
-			  sgpt
-			  (Some (Lwt.return (Lazy.force (Ocsigen_extensions.Ocsigen_request_info.get_params ri))))
-			  (Some (Lwt.return []))
-			  nosuffixversion
-			  suff
-			>>= fun g ->
-			let post_params =
-			  Eliom_request_info.get_post_params_sp sp
-			in
-			let files =
-			  Eliom_request_info.get_files_sp sp
-			in
-			Eliom_parameter.reconstruct_params
-			  ~sp
-			  sppt
-			  post_params
-			  files
-			  false
-			  None
-			>>= fun p ->
-			(* GRGR TODO: avoid
-			   Eliom_uri.make_string_uri_. But we need to
-			   "downcast" the type of service to the
-			   correct "get service". *)
-			(if Eliom_request_info.get_http_method () =
+                         Eliom_parameter.reconstruct_params
+                          ~sp
+                          sgpt
+                          (Some (Lwt.return (Lazy.force (Ocsigen_extensions.Ocsigen_request_info.get_params ri))))
+                          (Some (Lwt.return []))
+                          nosuffixversion
+                          suff
+                        >>= fun g ->
+                        let post_params =
+                          Eliom_request_info.get_post_params_sp sp
+                        in
+                        let files =
+                          Eliom_request_info.get_files_sp sp
+                        in
+                        Eliom_parameter.reconstruct_params
+                          ~sp
+                          sppt
+                          post_params
+                          files
+                          false
+                          None
+                        >>= fun p ->
+                        (* GRGR TODO: avoid
+                           Eliom_uri.make_string_uri_. But we need to
+                           "downcast" the type of service to the
+                           correct "get service". *)
+                        (if Eliom_request_info.get_http_method () =
                            Ocsigen_http_frame.Http_header.GET
                          && nosuffixversion && suffix_with_redirect
-			 then
-			    (* it is a suffix service in version
-			       without suffix. We redirect. *)
-			    if not (Eliom_request_info.expecting_process_page ())
-			    then
-			      let redir_uri =
-			        Eliom_uri.make_string_uri_
-				  ~absolute:true
-				  ~service:
-				  (service :
-				     ('a, 'b, _, _, _,
+                         then
+                            (* it is a suffix service in version
+                               without suffix. We redirect. *)
+                            if not (Eliom_request_info.expecting_process_page ())
+                            then
+                              let redir_uri =
+                                Eliom_uri.make_string_uri_
+                                  ~absolute:true
+                                  ~service:
+                                  (service :
+                                     ('a, 'b, _, _, _,
                                       S.non_ext, S.reg, _,
                                       'c, 'd, 'return)
                                        S.t :>
-				     ('a, 'b, _, _, _, _, _, _,
-				      'c, 'd, 'return)
-				     S.t)
-				  g
-			      in
-			      Lwt.fail
+                                     ('a, 'b, _, _, _, _, _, _,
+                                      'c, 'd, 'return)
+                                     S.t)
+                                  g
+                              in
+                              Lwt.fail
                                 (Eliom_common.Eliom_do_redirection redir_uri)
-			    else begin
-			    (* It is an internal application form.
-			       We don't redirect but we set this
-			       special information for url to be displayed
-			       by the browser
-			       (see Eliom_request_info.rebuild_uri_without_iternal_form_info_)
-			    *)
-			      let redir_uri =
-			        Eliom_uri.make_string_uri_ ~service g in
-			      let rc = Eliom_request_info.get_request_cache_sp sp in
-			      Polytables.set ~table:rc ~key:suffix_redir_uri_key ~value:redir_uri;
-			      Lwt.return ()
-			    end
-			 else Lwt.return ())
-			>>= fun () ->
+                            else begin
+                            (* It is an internal application form.
+                               We don't redirect but we set this
+                               special information for url to be displayed
+                               by the browser
+                               (see Eliom_request_info.rebuild_uri_without_iternal_form_info_)
+                            *)
+                              let redir_uri =
+                                Eliom_uri.make_string_uri_ ~service g in
+                              let rc = Eliom_request_info.get_request_cache_sp sp in
+                              Polytables.set ~table:rc ~key:suffix_redir_uri_key ~value:redir_uri;
+                              Lwt.return ()
+                            end
+                         else Lwt.return ())
+                        >>= fun () ->
                         check_process_redir sp check_before service >>= fun () ->
                         page_generator g p)
                          (function
@@ -291,7 +291,7 @@ let register_aux pages
                              error_handler l
                            | e -> Lwt.fail e)
                        >>= fun content ->
-		       send_with_cookies sp pages
+                       send_with_cookies sp pages
                          ?options
                          ?charset
                          ?code
@@ -372,7 +372,7 @@ let register_aux pages
                         ?secure:secure_session ~scope ~sp ())
               in
               f tablereg (attserget, attserpost))
-	| S.Nonattached naser ->
+        | S.Nonattached naser ->
           let na_name = S.na_name naser in
           let f table na_name =
             Eliom_route.add_naservice
@@ -401,24 +401,24 @@ let register_aux pages
                            None
                          >>= fun g ->
                          let post_params =
-			   Eliom_request_info.get_post_params_sp sp
+                           Eliom_request_info.get_post_params_sp sp
                          in
                          let files = Eliom_request_info.get_files_sp sp in
                          Eliom_parameter.reconstruct_params
-			   ~sp
-			   (S.post_params_type service)
-			   post_params
-			   files
-			   false
-			   None
+                           ~sp
+                           (S.post_params_type service)
+                           post_params
+                           files
+                           false
+                           None
                          >>= fun p ->
                          check_process_redir sp check_before service >>= fun () ->
-			 page_generator g p)
+                         page_generator g p)
                        (function
                          | Eliom_common.Eliom_Typing_Error l ->
                            error_handler l
                          | e -> Lwt.fail e) >>= fun content ->
-		     send_with_cookies sp pages
+                     send_with_cookies sp pages
                        ?options
                        ?charset
                        ?code

--- a/src/lib/eliom_notif.server.ml
+++ b/src/lib/eliom_notif.server.ml
@@ -29,9 +29,9 @@ module Make (A : S) = struct
     type t = (A.identity * notification_react) option
     let equal a b = match a, b with
       | None, None ->
-	true
+        true
       | Some (a, b), Some (c, d) ->
-	A.equal_identity a c && b == d
+        A.equal_identity a c && b == d
       | _ -> false
     let hash = Hashtbl.hash
   end)
@@ -39,7 +39,7 @@ module Make (A : S) = struct
   module I = struct
 
     let tbl = Notif_hashtbl.create A.max_resource
-      
+
     let lock = Lwt_mutex.create ()
 
     let async_locked f = Lwt.async (fun () ->
@@ -55,21 +55,21 @@ module Make (A : S) = struct
 
     let remove v key = async_locked (fun () ->
       let () =
-	try
-	  let wt = Notif_hashtbl.find tbl key in
+        try
+          let wt = Notif_hashtbl.find tbl key in
           Weak_tbl.remove wt v;
-	  remove_if_empty wt key
-	with Not_found -> ()
+          remove_if_empty wt key
+        with Not_found -> ()
       in
       Lwt.return ()
     )
 
     let add v key = async_locked (fun () ->
       let wt =
-	try
-	  Notif_hashtbl.find tbl key
+        try
+          Notif_hashtbl.find tbl key
         with Not_found ->
-	  let wt = Weak_tbl.create A.max_identity_per_resource in
+          let wt = Weak_tbl.create A.max_identity_per_resource in
           Notif_hashtbl.add tbl key wt;
           wt
       in
@@ -80,27 +80,27 @@ module Make (A : S) = struct
 
     let iter =
       let iter (f : Weak_tbl.data -> unit Lwt.t) wt : unit =
-	Weak_tbl.iter
-	  (fun data -> Lwt.async (fun () -> f data))
-	  wt
+        Weak_tbl.iter
+          (fun data -> Lwt.async (fun () -> f data))
+          wt
       in
       fun f key -> async_locked (fun () ->
-	let () =
-	  try
-	    let wt = Notif_hashtbl.find tbl key in
-	    let g data = match data with
+        let () =
+          try
+            let wt = Notif_hashtbl.find tbl key in
+            let g data = match data with
               | None ->
-		Weak_tbl.remove wt data;
-		remove_if_empty wt key;
-		Lwt.return ()
+                Weak_tbl.remove wt data;
+                remove_if_empty wt key;
+                Lwt.return ()
               | Some v ->
-		f v;
-		Lwt.return ()
-	    in
+                f v;
+                Lwt.return ()
+            in
             iter g wt;
-	  with Not_found -> ()
-	in
-	Lwt.return ()
+          with Not_found -> ()
+        in
+        Lwt.return ()
       )
   end
 
@@ -136,9 +136,9 @@ module Make (A : S) = struct
       let client_ev = Eliom_react.Down.of_react
       (*VVV If we add throttling, some events may be lost
             even if buffer size is not 1 :O *)
-	~size: 100 (*VVV ? *)
-	~scope:Eliom_common.default_process_scope
-	e
+        ~size: 100 (*VVV ? *)
+        ~scope:Eliom_common.default_process_scope
+        e
       in
       (client_ev, send_e)
     in
@@ -166,7 +166,7 @@ module Make (A : S) = struct
     let f = fun (identity, ((_, send_e) as notif)) ->
       Eliom_reference.get notif_e >>= fun notif_o ->
       if notforme && notif == (of_option notif_o) then
-	Lwt.return ()
+        Lwt.return ()
       else
         content_gen identity >>= fun content -> match content with
         | Some content -> send_e (key, content); Lwt.return ()
@@ -181,7 +181,7 @@ module Make (A : S) = struct
     Lwt.return ev
 
   let clean () =
-    let f key weak_tbl = I.async_locked (fun () -> 
+    let f key weak_tbl = I.async_locked (fun () ->
       if Weak_tbl.count weak_tbl = 0
       then Notif_hashtbl.remove I.tbl key
     ) in

--- a/src/lib/eliom_notif.server.mli
+++ b/src/lib/eliom_notif.server.mli
@@ -75,11 +75,11 @@ sig
          ignore
            [%client
               (ignore (React.E.map
-		        (handle_notification ~%some_stuff)
-		        ~%(Notif_module.client_ev ())
-	      ) : unit)
+                (handle_notification ~%some_stuff)
+                ~%(Notif_module.client_ev ())
+              ) : unit)
            ]
-  
+
   *)
   val client_ev : unit -> (A.key * A.notification) Eliom_react.Down.t Lwt.t
 

--- a/src/lib/eliom_react.server.ml
+++ b/src/lib/eliom_react.server.ml
@@ -83,10 +83,10 @@ struct
   let of_react ?scope ?throttling ?name ?size (e : 'a E.t) =
     let t =
       match scope with
-	| Some `Site -> stateless ?throttling ?name ?size e
-	| None -> stateful ?throttling ?name ?size e
-	| Some ((`Client_process n) as scope) ->
-	  stateful ~scope ?throttling ?name ?size e
+        | Some `Site -> stateless ?throttling ?name ?size e
+        | None -> stateful ?throttling ?name ?size e
+        | Some ((`Client_process n) as scope) ->
+          stateful ~scope ?throttling ?name ?size e
     in
     { t; react_down_mark=react_down_mark () }
 
@@ -152,22 +152,22 @@ struct
 
     type 'a stateful =
         {throttling: float option;
-	 scope: Eliom_common.client_process_scope option;
+         scope: Eliom_common.client_process_scope option;
          signal: 'a S.t;
          name: string option;}
 
     type 'a stateless =
-	{channel: 'a Eliom_comet.Channel.t;
-	 stream: 'a Lwt_stream.t; (* avoid garbage collection *)
-	 sl_signal: 'a S.t}
+        {channel: 'a Eliom_comet.Channel.t;
+         stream: 'a Lwt_stream.t; (* avoid garbage collection *)
+         sl_signal: 'a S.t}
 
     type 'a t' =
       | Stateful of 'a stateful
       | Stateless of 'a stateless
 
     type 'a t =
-	{ t : 'a t';
-	  signal_down_mark: 'a t Eliom_common.wrapper; }
+        { t : 'a t';
+          signal_down_mark: 'a t Eliom_common.wrapper; }
 
     type 'a store =
         { s : unit S.t Lazy.t; (* to avoid signal GC *)
@@ -209,7 +209,7 @@ struct
 
     let wrap_stateful
         {throttling=t;
-	 scope;
+         scope;
          signal=s;
          name=name} =
       let s : 'a S.t =
@@ -253,33 +253,33 @@ struct
     let stateful ?scope
         ?throttling ?name (s : 'a S.t) =
       Stateful
-	{throttling=throttling;
-	 scope;
-	 signal=s;
-	 name=name;}
+        {throttling=throttling;
+         scope;
+         signal=s;
+         name=name;}
 
     let stateless ?throttling ?name (s : 'a S.t) =
       let s =
-	match throttling with
+        match throttling with
           | None -> s
           | Some t -> S.limit (fun () -> Lwt_unix.sleep t) s
       in
       let e = S.changes s in
       let stream = E.to_stream e in
       Stateless
-	{channel = Eliom_comet.Channel.create_newest ?name stream;
-	 stream;
-	 sl_signal = s}
+        {channel = Eliom_comet.Channel.create_newest ?name stream;
+         stream;
+         sl_signal = s}
 
     let of_react
-	?scope
+        ?scope
         ?throttling ?name (s : 'a S.t) =
       let t =
-	match scope with
-	  | Some `Site -> stateless ?throttling ?name s
-	  | None -> stateful ?throttling ?name s
-	  | Some ((`Client_process n) as scope) ->
-	    stateful ~scope ?throttling ?name s
+        match scope with
+          | Some `Site -> stateless ?throttling ?name s
+          | None -> stateful ?throttling ?name s
+          | Some ((`Client_process n) as scope) ->
+            stateful ~scope ?throttling ?name s
       in
       { t; signal_down_mark=signal_down_mark () }
   end

--- a/src/lib/eliom_state.server.ml
+++ b/src/lib/eliom_state.server.ml
@@ -462,7 +462,7 @@ let get_service_session_group
   try
     let c =
       Eliommod_sersess.find_service_cookie_only
-	~cookie_scope:(scope:>Eliom_common.cookie_scope) ~secure ()
+        ~cookie_scope:(scope:>Eliom_common.cookie_scope) ~secure ()
     in
     match !(c.Eliom_common.sc_session_group) with
       | _, _, Right _ -> None
@@ -476,12 +476,12 @@ let get_service_session_group_size
   try
     let c =
       Eliommod_sersess.find_service_cookie_only
-	~cookie_scope:(scope:>Eliom_common.cookie_scope) ~secure ()
+        ~cookie_scope:(scope:>Eliom_common.cookie_scope) ~secure ()
     in
     match !(c.Eliom_common.sc_session_group) with
       | _, _, Right _ -> None
       | _, _, Left v ->
-	Some (Eliommod_sessiongroups.Serv.group_size !(c.Eliom_common.sc_session_group))
+        Some (Eliommod_sessiongroups.Serv.group_size !(c.Eliom_common.sc_session_group))
   with
     | Not_found
     | Eliom_common.Eliom_Session_expired -> None
@@ -510,7 +510,7 @@ let unset_volatile_data_session_group ?set_max
     let c =
       Eliommod_datasess.find_data_cookie_only
         ~cookie_scope:(scope:>Eliom_common.cookie_scope)
-	~secure ~sp ()
+        ~secure ~sp ()
     in
     let n =
       Eliommod_sessiongroups.make_full_group_name
@@ -557,12 +557,12 @@ let get_volatile_data_session_group_size
   try
     let c =
       Eliommod_datasess.find_data_cookie_only
-	~cookie_scope:(scope:>Eliom_common.cookie_scope) ~secure ()
+        ~cookie_scope:(scope:>Eliom_common.cookie_scope) ~secure ()
     in
     match !(c.Eliom_common.dc_session_group) with
       | _, _, Right _ -> None
       | _, _, Left v ->
-	Some (Eliommod_sessiongroups.Data.group_size !(c.Eliom_common.dc_session_group))
+        Some (Eliommod_sessiongroups.Data.group_size !(c.Eliom_common.dc_session_group))
   with
     | Not_found
     | Eliom_common.Eliom_Session_expired -> None
@@ -878,11 +878,11 @@ let get_session_service_table ~sp ~scope ?secure () =
   match scope with
     | `Session_group _ ->
       begin
-	match
-	  Eliommod_sessiongroups.Serv.find_node_in_group_of_groups
+        match
+          Eliommod_sessiongroups.Serv.find_node_in_group_of_groups
             !(c.Eliom_common.sc_session_group)
-	with None -> raise Not_found
-	  | Some (t, _) -> t
+        with None -> raise Not_found
+          | Some (t, _) -> t
       end
     | _ -> c.Eliom_common.sc_table
 
@@ -896,13 +896,13 @@ let get_session_service_table_if_exists ~sp
     in
     match scope with
       | `Session_group _ ->
-	begin
-	  match
+        begin
+          match
             Eliommod_sessiongroups.Serv.find_node_in_group_of_groups
               !(c.Eliom_common.sc_session_group)
-	  with None -> raise Not_found
+          with None -> raise Not_found
             | Some (t, _) -> t
-	end
+        end
       | _ -> c.Eliom_common.sc_table
   with Eliom_common.Eliom_Session_expired -> raise Not_found
 

--- a/src/lib/eliom_tools.eliom
+++ b/src/lib/eliom_tools.eliom
@@ -245,22 +245,22 @@ module Make(DorF : module type of Eliom_content.Html.F) : HTML5_TOOLS = struct
         ((* MAYBE : use get_original_full_path_string? *)
           ("/" ^ Eliom_request_info.get_original_full_path_string ()))
       | Some s' ->
-	let node_url = make_string_uri ~absolute_path:true ~service:s' () in
-	string_prefix service_url node_url
+        let node_url = make_string_uri ~absolute_path:true ~service:s' () in
+        string_prefix service_url node_url
 
   let find_longest_prefix_in_hierarchy service (main, pages) =
     let rec aux prefix (max_len, _ as max) i = function
       | [] -> max
       | (_, Site_tree (Main_page (Srv s), hsl)) :: pages when service_prefix s service ->
-	let len =
-	  String.length (make_string_uri ~absolute_path:true ~service:s ()) in
-	let max = if len >= max_len then (len, List.rev (i::prefix)) else max in
+        let len =
+          String.length (make_string_uri ~absolute_path:true ~service:s ()) in
+        let max = if len >= max_len then (len, List.rev (i::prefix)) else max in
         let max = aux (i::prefix) max 0 hsl in
-	aux prefix max (i+1) pages
+        aux prefix max (i+1) pages
       | (_, Disabled)::pages -> aux prefix max (i+1) pages
       | (_, Site_tree (_, hsl))::pages ->
         let max = aux (i::prefix) max 0 hsl in
-	aux prefix max (i+1) pages
+        aux prefix max (i+1) pages
     in
     let length, path = aux [] (0,[]) 0 pages in
     path

--- a/src/lib/eliom_wrap.server.ml
+++ b/src/lib/eliom_wrap.server.ml
@@ -79,10 +79,10 @@ let is_marked (mark:Mark.t) o =
   let is_mark o =
     if (Obj.tag o = 0 && Obj.size o = 2 && Obj.field o 0 == (Obj.repr mark))
     then (let f = (Obj.field o 1) in
-	  assert (Obj.tag f = 0); (* The case None should not happen here *)
-	  assert (Obj.size f = 1);
-	  assert (let tag = Obj.tag (Obj.field f 0) in tag = Obj.infix_tag || tag = Obj.closure_tag);
-	  true)
+          assert (Obj.tag f = 0); (* The case None should not happen here *)
+          assert (Obj.size f = 1);
+          assert (let tag = Obj.tag (Obj.field f 0) in tag = Obj.infix_tag || tag = Obj.closure_tag);
+          true)
     else false
   in
 
@@ -130,46 +130,46 @@ let search_and_replace v =
     | (Wrap (f,v))::q ->
       let new_v = f v in
       (* f v is not guaranted to be in the major head: we need to move
-	 it before adding to the table *)
+         it before adding to the table *)
       Gc.minor ();
       loop ((Do (new_v,Replace v))::q)
     | (Do (v,action))::q as s ->
       match find t v with
-	| Some r ->
-	  (match action with
-	    | Set_field (o,i) ->
-	      Obj.set_field o i r;
-	      loop q
-	    | Replace o -> T.replace t o r;
-	      loop q
-	    | Return -> r)
-	| None ->
-	  match is_marked Mark.wrap_mark v with
-	    | Some { f = Some f } ->
-	      let stack = (Wrap (f,v))::s in
-	      loop stack
-	    | Some { f = None } -> assert false
-	    | None ->
-	      let tag = Obj.tag v in
-	      if tag = Obj.closure_tag || tag = Obj.infix_tag || tag = Obj.lazy_tag || tag = Obj.object_tag
-	      then
-		( if tag = Obj.lazy_tag then failwith "lazy values must be forced before wrapping";
-		  if tag = Obj.object_tag then failwith "cannot wrap object values";
-		  if tag = Obj.closure_tag then failwith "cannot wrap functional values";
-		  failwith "cannot wrap functional values: infix tag" )
-	      else
-		begin
-		  let size = Obj.size v in
-		  let new_v = Obj.new_block tag size in
-		  T.add t v new_v;
-		  (* It is ok to do this because tag < no_scan_tag and it is
-		     not a closure ( either infix, normal or lazy ) *)
-		  let stack = ref s in
-		  for i = 0 to size - 1 do
-		    stack := (Do ((Obj.field v i),Set_field (new_v,i))) :: !stack;
-		  done;
-		  loop !stack
-		end
+        | Some r ->
+          (match action with
+            | Set_field (o,i) ->
+              Obj.set_field o i r;
+              loop q
+            | Replace o -> T.replace t o r;
+              loop q
+            | Return -> r)
+        | None ->
+          match is_marked Mark.wrap_mark v with
+            | Some { f = Some f } ->
+              let stack = (Wrap (f,v))::s in
+              loop stack
+            | Some { f = None } -> assert false
+            | None ->
+              let tag = Obj.tag v in
+              if tag = Obj.closure_tag || tag = Obj.infix_tag || tag = Obj.lazy_tag || tag = Obj.object_tag
+              then
+                ( if tag = Obj.lazy_tag then failwith "lazy values must be forced before wrapping";
+                  if tag = Obj.object_tag then failwith "cannot wrap object values";
+                  if tag = Obj.closure_tag then failwith "cannot wrap functional values";
+                  failwith "cannot wrap functional values: infix tag" )
+              else
+                begin
+                  let size = Obj.size v in
+                  let new_v = Obj.new_block tag size in
+                  T.add t v new_v;
+                  (* It is ok to do this because tag < no_scan_tag and it is
+                     not a closure ( either infix, normal or lazy ) *)
+                  let stack = ref s in
+                  for i = 0 to size - 1 do
+                    stack := (Do ((Obj.field v i),Set_field (new_v,i))) :: !stack;
+                  done;
+                  loop !stack
+                end
   in
   with_no_heap_move loop [Do (v,Return)]
 

--- a/src/lib/server/eliommod_persess.ml
+++ b/src/lib/server/eliommod_persess.ml
@@ -121,20 +121,20 @@ let rec find_or_create_persistent_cookie_
 
     let%lwt set_session_group =
       match cookie_scope with
-	| `Client_process n ->
-	  begin (* We create a group whose name is the
+        | `Client_process n ->
+          begin (* We create a group whose name is the
                    browser session cookie
                    and put the tab session into it. *)
-	    let%lwt r = find_or_create_persistent_cookie_
+            let%lwt r = find_or_create_persistent_cookie_
               ~set_max_in_group:
               (fst sitedata.Eliom_common.max_persistent_data_tab_sessions_per_group)
               ~cookie_scope:(`Session n)
               ~secure
               ~sp
               () in
-	    Lwt.return (Some r.Eliom_common.pc_value)
-	  end
-	| _  -> Lwt.return set_session_group in
+            Lwt.return (Some r.Eliom_common.pc_value)
+          end
+        | _  -> Lwt.return set_session_group in
 
     let fullsessgrp = fullsessgrp ~cookie_level ~sp set_session_group in
 

--- a/src/lib/server/eliommod_sersess.ml
+++ b/src/lib/server/eliommod_sersess.ml
@@ -56,24 +56,24 @@ let close_service_state ~scope ~secure ?sp () =
              remove it from the session group table.
              It will remove the entry in the session table *)
         begin
-	  match scope with
-	    | `Session_group _ ->
+          match scope with
+            | `Session_group _ ->
               begin
-		(* If we want to close all the group of browser sessions,
-		   the node is found in the group table: *)
-		match
-		  Eliommod_sessiongroups.Serv.find_node_in_group_of_groups
-		    !(c.Eliom_common.sc_session_group)
-		with
-		  | None -> Lwt_log.ign_error ~section:Lwt_log.eliom "No group of groups. Please report this problem."
-		  | Some (service_table, g) ->
+                (* If we want to close all the group of browser sessions,
+                   the node is found in the group table: *)
+                match
+                  Eliommod_sessiongroups.Serv.find_node_in_group_of_groups
+                    !(c.Eliom_common.sc_session_group)
+                with
+                  | None -> Lwt_log.ign_error ~section:Lwt_log.eliom "No group of groups. Please report this problem."
+                  | Some (service_table, g) ->
                     Eliommod_sessiongroups.Serv.remove g
-	      end
-	    | `Session _
-	    | `Client_process _ ->
+              end
+            | `Session _
+            | `Client_process _ ->
               Eliommod_sessiongroups.Serv.remove
-		c.Eliom_common.sc_session_group_node
-	end;
+                c.Eliom_common.sc_session_group_node
+        end;
         ior := Eliom_common.SCNo_data
       | _ -> ()
 
@@ -102,19 +102,19 @@ let rec find_or_create_service_cookie_ ?set_session_group
 
     let set_session_group =
       match cookie_scope with
-	| `Client_process n ->
-	  begin (* We create a group whose name is the
+        | `Client_process n ->
+          begin (* We create a group whose name is the
                    browser session cookie
                    and put the tab session into it. *)
             let v = find_or_create_service_cookie_
-	      ~cookie_scope:(`Session n)
+              ~cookie_scope:(`Session n)
               ~secure
               ~sp
               ()
             in
             Some v.Eliom_common.sc_value
-	  end
-	|  _ -> set_session_group
+          end
+        |  _ -> set_session_group
     in
     let fullsessgrp = fullsessgrp ~cookie_level ~sp set_session_group in
 

--- a/src/tools/eliomdep.ml
+++ b/src/tools/eliomdep.ml
@@ -96,7 +96,7 @@ let compile_intf file =
     preprocess_opt ~ocaml:true !ppopt
     @ eliom_synonyms @ !args
     @ (map_include !eliom_inc_dirs)
-		@ ["-intf"; file] )
+    @ ["-intf"; file] )
     (on_each_line add_build_dirs)
 
 let compile_impl file =
@@ -105,7 +105,7 @@ let compile_impl file =
     preprocess_opt ~ocaml:true !ppopt
     @ eliom_synonyms @ !args
     @ (map_include !eliom_inc_dirs)
-		@ ["-impl"; file] )
+    @ ["-impl"; file] )
     (on_each_line add_build_dirs)
 
 let server_pp_opt impl_intf =

--- a/src/tools/eliomdoc.ml
+++ b/src/tools/eliomdoc.ml
@@ -57,7 +57,7 @@ let compile_intf file =
       @ (get_default_args ())
       @ (get_common_include ())
       @ (map_include !eliom_inc_dirs)
-		  @ ["-intf"; file] ))
+      @ ["-intf"; file] ))
 
 let compile_impl file =
   wait (
@@ -68,7 +68,7 @@ let compile_impl file =
       @ (get_default_args ())
       @ (get_common_include ())
       @ (map_include !eliom_inc_dirs)
-		  @ ["-impl"; file] ))
+      @ ["-impl"; file] ))
 
 let server_pp_opt impl_intf =
   match !pp_mode with

--- a/src/tools/eliompp_lexer.mll
+++ b/src/tools/eliompp_lexer.mll
@@ -96,37 +96,39 @@ rule token = parse
   }
   | [^ '"' '{' '(' '\n']+
     as raw                      { RAW raw }
-  | '\n'			   		    { incr line; CHAR '\n' }
-  | '{'			   		        { CHAR '{' }
-  | '('			   		        { CHAR '(' }
-  | '*'			   		        { CHAR '*' }
-  | eof		                    { raise End_of_file }
+  | '\n'                        { incr line; CHAR '\n' }
+  | '{'                         { CHAR '{' }
+  | '('                         { CHAR '(' }
+  | '*'                         { CHAR '*' }
+  | eof                         { raise End_of_file }
 and cstring = parse
-  | '"'			                { add_char '"' }
-  | '\\' '"'		            { add_string "\\\""; cstring lexbuf }
-  | '\\' '\n' 		            { add_string "\\\n"; incr line; cstring lexbuf }
-  | ('\\' _) as s 		        { add_string s; cstring lexbuf }
-  | '\n' 		                { add_char '\n'; incr line; cstring lexbuf }
-  | [^ '"' '\\' '\n']+ as s	    { add_string s; cstring lexbuf }
-  | eof		                    { raise Unterminated_string }
+  | '"'                         { add_char '"' }
+  | '\\' '"'                    { add_string "\\\""; cstring lexbuf }
+  | '\\' '\n'                   { add_string "\\\n"; incr line; cstring lexbuf }
+  | ('\\' _) as s               { add_string s; cstring lexbuf }
+  | '\n'                        { add_char '\n'; incr line; cstring lexbuf }
+  | [^ '"' '\\' '\n']+ as s     { add_string s; cstring lexbuf }
+  | eof                         { raise Unterminated_string }
 and comment = parse
-  | "(*"		                { start_comment comment lexbuf; }
-  | "*)"		                {
-      add_string "*)"; decr comment_ref_count;
-      if not (in_comment ()) then () else comment lexbuf
-  }
+  | "(*"                        { start_comment comment lexbuf; }
+  | "*)"                        { add_string "*)";
+                                  decr comment_ref_count;
+                                  if not (in_comment ())
+                                  then ()
+                                  else comment lexbuf
+                                }
   | "(*)"                       { add_string "(*)"; comment lexbuf }
-  | '"'		                    {
+  | '"'                         {
       try
         start_cstring cstring lexbuf;
         comment lexbuf
       with Unterminated_string -> raise Unterminated_comment
   }
-  | '\n'						{ add_char '\n'; incr line; comment lexbuf }
-  | '*'						    { add_char '*'; comment lexbuf }
-  | '('						    { add_char '('; comment lexbuf }
-  | [^ '"' '*' '(' '\n']+ as s	{ add_string s; comment lexbuf }
-  | eof		                    { raise Unterminated_comment }
+  | '\n'                        { add_char '\n'; incr line; comment lexbuf }
+  | '*'                         { add_char '*'; comment lexbuf }
+  | '('                         { add_char '('; comment lexbuf }
+  | [^ '"' '*' '(' '\n']+ as s  { add_string s; comment lexbuf }
+  | eof                         { raise Unterminated_comment }
 and section = parse
   | '{' (ident as idt) '{'      { start_section ~idt section lexbuf }
   | "}}"                        {
@@ -149,10 +151,10 @@ and section = parse
         section lexbuf
       with Unterminated_string -> raise Unterminated_section
   }
-  | '\n'						{ add_char '\n'; incr line; section lexbuf }
-  | '('						    { add_char '('; section lexbuf }
-  | '}'						    { add_char '}'; section lexbuf }
-  | '{'						    { add_char '{'; section lexbuf }
+  | '\n'                        { add_char '\n'; incr line; section lexbuf }
+  | '('                         { add_char '('; section lexbuf }
+  | '}'                         { add_char '}'; section lexbuf }
+  | '{'                         { add_char '{'; section lexbuf }
   | [^ '"' '(' '\n' '}' '{']+
-    as s	                    { add_string s; section lexbuf }
-  | eof		                    { raise Unterminated_section }
+    as s                        { add_string s; section lexbuf }
+  | eof                         { raise Unterminated_section }


### PR DESCRIPTION
I suppose spaces it's the convention. It's so horrible to see different coding conventions when you try to understand in deep how Eliom works.

The same work must be done in other ocsigen projects. I saw tabs in some ml files in jsoo.

I didn't check for empty lines.
