### PR TITLE
Use routing for Eliom_service.reload_action_*hidden

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -430,11 +430,10 @@ let current_pseudo_fragment = ref ""
 let url_fragment_prefix = "!"
 let url_fragment_prefix_with_sharp = "#!"
 
-let default_reload_function () () =
-  Dom_html.window##.location##reload
-
 let reload_function = ref None
 let reload_functions = ref []
+
+let set_reload_function f = reload_function := Some f
 
 let change_url_string ~replace uri =
   current_uri := fst (Url.split_fragment uri);

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -330,7 +330,7 @@ val change_page_unknown :
 
 val init : unit -> unit
 
-val reload_function : (unit -> unit -> unit Lwt.t) option ref
+val set_reload_function : (unit -> unit -> unit Lwt.t) -> unit
 
 (** Lwt_log section for this module.
     Default level is [Lwt_log.Info].

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -70,7 +70,7 @@ let typed_apply ~service f gp pp l l' suffix =
     in
     (match Eliom_service.reload_fun service with
      | Some _ ->
-       Eliom_client.reload_function := Some (fun () () -> f g p)
+       Eliom_client.set_reload_function (fun () () -> f g p)
      | None ->
        ());
     f g p


### PR DESCRIPTION
`Eliom_service.reload_action_hidden` and `Eliom_service.reload_action_https_hidden` become consistent with their non-`hidden` counterparts by going through client-side routing (instead of calling the `reload_function`).

I think we can completely eliminate the `reload_function` stuff (now only needed for replaying the history). But I see no pressing need to do so now. We need to converge to a release.