### PR TITLE
Add Eliom_lib.Url.{path_of_url,path_of_url_string}

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -772,47 +772,12 @@ let route ~replace ?(keep_url = false)
     Eliom_request_info.get_sess_info := r;
     Lwt.fail e
 
-let path_of_url = function
-  | Url.Http  { Url.hu_path }
-  | Url.Https { Url.hu_path } ->
-    Some hu_path
-  | _ ->
-    None
-
-let path_of_url_string s =
-  match Url.url_of_string s with
-  | Some s ->
-    path_of_url s
-  | None ->
-    (* assuming relative URL and improvising because Url doesn't deal
-       with these *)
-    let s =
-      try
-        String.(sub s 0 (index s '?'))
-      with Not_found ->
-        s
-    in
-    Some (Url.split_path s)
-
-let current_path () =
-  match Url.Current.get () with
-  | Some path ->
-    path_of_url path
-  | None ->
-    None
-
 let after_action uri =
   let
     ({ Eliom_common.si_all_get_params ; si_all_post_params }
      as i_sess_info) =
     !Eliom_request_info.get_sess_info ()
-  and i_subpath =
-    match path_of_url_string uri with
-    | Some path ->
-      path
-    | None ->
-      failwith "after_action: cannot obtain path"
-  in
+  and i_subpath = Url.path_of_url_string uri in
   let info = {
     Eliom_route.i_sess_info ;
     i_subpath;

--- a/src/lib/eliom_lib.client.ml
+++ b/src/lib/eliom_lib.client.ml
@@ -64,6 +64,23 @@ module Url = struct
       print_endline "Warning: Eliom_lib.string_of_url_path ignores ~encode";
     String.concat "/" l
 
+  let path_of_url = function
+    | Url.Http  {Url.hu_path = path}
+    | Url.Https {Url.hu_path = path}
+    | Url.File  {Url.fu_path = path} ->
+      path
+
+  let path_of_url_string s =
+    match Url.url_of_string s with
+    | Some path ->
+      path_of_url path
+    | _ ->
+      (* assuming relative URL and improvising *)
+      split_path @@ try
+        String.(sub s 0 (index s '?'))
+      with Not_found ->
+        s
+
 end
 
 module Lwt_log = struct

--- a/src/lib/eliom_lib.client.mli
+++ b/src/lib/eliom_lib.client.mli
@@ -55,7 +55,12 @@ module Url : sig
   val get_ssl : string -> bool option
   val resolve : string -> string
   val add_get_args : string -> (string * string) list -> string
-  val string_of_url_path: encode:bool -> string list -> string
+  val string_of_url_path : encode:bool -> string list -> string
+  val path_of_url : url -> string list
+
+  (** Extracts path from a URL string. Works on a best-effort basis
+      for relative URLs *)
+  val path_of_url_string : string -> string list
 
 end
 

--- a/src/lib/eliom_request_info.client.ml
+++ b/src/lib/eliom_request_info.client.ml
@@ -81,22 +81,7 @@ let remove_first_slash path =
 let current_path_ = ref (remove_first_slash Url.Current.path)
 
 let set_current_path uri =
-  let uri = if uri = "./" then "" else uri in
-  let path =
-    match Url.url_of_string uri with
-    | Some (Url.Http url | Url.Https url) ->
-      url.Url.hu_path
-    | _ ->
-      match
-        try
-          Some (String.index uri '?')
-        with Not_found ->
-          None
-      with
-      | Some n -> Eliom_lib.Url.split_path String.(sub uri 0 n)
-      | None   -> Eliom_lib.Url.split_path uri
-  in
-  current_path_ := path
+  current_path_ := Url.path_of_url_string (if uri = "./" then "" else uri)
 
 let get_original_full_path_sp sp =
   (* returns current path, not the one when application started *)


### PR DESCRIPTION
Minor URL-related cleanup.

I added `Eliom_lib.path_of_url_string` by basically de-inlining variants of it from different modules.

The intermediate `Eliom_lib.path_of_url` function which operates on JSOO `url` types looks useful, so it is also exported.