### PR TITLE
Rename service attachment functions

### DIFF
--- a/doc/manual-wiki/server-links.wiki
+++ b/doc/manual-wiki/server-links.wiki
@@ -194,7 +194,7 @@ request, if the POST method is used).
                       "Version of the page without POST parameters"]])))
 
 let my_service_with_post_params =
-  Eliom_registration.Html.attach_post
+  Eliom_registration.Html.create_attached_post
     ~fallback:no_post_param_service
     ~post_params:Eliom_parameter.(string "value")
     (fun () value ->

--- a/doc/manual-wiki/server-services.wiki
+++ b/doc/manual-wiki/server-services.wiki
@@ -219,13 +219,13 @@ Form.post_form
 By default, the URL of links or forms to pathless services is the
 current page. If you want to combine the service call with a URL
 change, it is possible to attach a non-attached service to another
-service using function <<a_api| val Eliom_service.attach_existing>>.
+service using function <<a_api| val Eliom_service.attach>>.
 
 Example:
 
 <<code language="ocaml"|
 let service =
-  Eliom_service.attach_existing
+  Eliom_service.attach
     ~fallback:myfirstservice
     ~service:myget_coserv'
     ()
@@ -261,8 +261,8 @@ services, <<a_api | val Eliom_service.create >> .
 ===@@id="attached_services"@@ Attached services ===
 
 Attached services are created using the functions
-<<a_api| val Eliom_service.attach_get >> (GET method) and
-<<a_api| val Eliom_service.attach_post >> (POST method).
+<<a_api| val Eliom_service.create_attached_get >> (GET method) and
+<<a_api| val Eliom_service.create_attached_post >> (POST method).
 
 Anonymous GET attached services are often created dynamically with
 respect to previous interaction with the user (e.g. filling forms in

--- a/src/lib/eliom_comet.server.ml
+++ b/src/lib/eliom_comet.server.ml
@@ -269,7 +269,7 @@ struct
     Eliom_common.lazy_site_value_from_fun @@ fun () ->
     (*VVV Why isn't this a POST non-attached coservice? --Vincent *)
 
-    Comet.attach_post
+    Comet.create_attached_post
       ~post_params:Ecb.comet_request_param
       ~fallback:
         (Eliom_common.force_lazy_site_value fallback_global_service)
@@ -586,7 +586,7 @@ end = struct
           let hd_service =
             Eliom_comet_base.Internal_comet_service
               (* CCC ajouter possibilité d'https *)
-              (Eliom_service.attach_post
+              (Eliom_service.create_attached_post
                  (*VVV Why is it attached? --Vincent *)
                  ~post_params:Eliom_comet_base.comet_request_param
                  ~fallback:

--- a/src/lib/eliom_mkreg.server.ml
+++ b/src/lib/eliom_mkreg.server.ml
@@ -628,7 +628,7 @@ let create pages
     ~service ?error_handler page;
   service
 
-let attach_get pages
+let create_attached_get pages
     ?scope
     ?app
     ?options
@@ -649,7 +649,7 @@ let attach_get pages
     ?error_handler
     page =
   let service =
-    S.attach_get_unsafe
+    S.create_attached_get_unsafe
       ?name
       ?csrf_safe
       ?csrf_scope:(csrf_scope :> Eliom_common.user_scope option)
@@ -668,7 +668,7 @@ let attach_get pages
     ~service ?error_handler page;
   service
 
-let attach_post pages
+let create_attached_post pages
     ?scope
     ?app
     ?options
@@ -689,7 +689,7 @@ let attach_post pages
     ?error_handler
     page =
   let service =
-    S.attach_post_unsafe
+    S.create_attached_post_unsafe
       ?name
       ?csrf_safe
       ?csrf_scope:(csrf_scope :> Eliom_common.user_scope option)
@@ -729,9 +729,9 @@ struct
 
   let create ?app = create pages ?app
 
-  let attach_get ?app = attach_get pages ?app
+  let create_attached_get ?app = create_attached_get pages ?app
 
-  let attach_post ?app = attach_post pages ?app
+  let create_attached_post ?app = create_attached_post pages ?app
 
 end
 
@@ -754,8 +754,8 @@ struct
 
   let create ?app = create pages ?app
 
-  let attach_get ?app = attach_get pages ?app
+  let create_attached_get ?app = create_attached_get pages ?app
 
-  let attach_post ?app = attach_post pages ?app
+  let create_attached_post ?app = create_attached_post pages ?app
 
 end

--- a/src/lib/eliom_registration.server.ml
+++ b/src/lib/eliom_registration.server.ml
@@ -854,7 +854,7 @@ module Customize
       ?error_handler:(make_eh error_handler)
       (make_service_handler f)
 
-  let attach_get
+  let create_attached_get
       ?app
       ?scope
       ?options
@@ -874,7 +874,7 @@ module Customize
       ~get_params
       ?error_handler
       f =
-    R.attach_get
+    R.create_attached_get
       ?app
       ?scope
       ?options
@@ -895,7 +895,7 @@ module Customize
       ?error_handler:(make_eh error_handler)
       (make_service_handler f)
 
-  let attach_post
+  let create_attached_post
       ?app
       ?scope
       ?options
@@ -915,7 +915,7 @@ module Customize
       ~post_params
       ?error_handler
       f =
-    R.attach_post
+    R.create_attached_post
       ?app
       ?scope
       ?options
@@ -1073,7 +1073,7 @@ module Ocaml = struct
       ?error_handler:(make_eh error_handler)
       (make_service_handler f)
 
-  let attach_get
+  let create_attached_get
       ?app
       ?scope
       ?options
@@ -1094,7 +1094,7 @@ module Ocaml = struct
       ?error_handler
       f =
     Eliom_service.untype @@
-    M.attach_get
+    M.create_attached_get
       ?app
       ?scope
       ?options
@@ -1115,7 +1115,7 @@ module Ocaml = struct
       ?error_handler:(make_eh error_handler)
       (make_service_handler f)
 
-  let attach_post
+  let create_attached_post
       ?app
       ?scope
       ?options
@@ -1136,7 +1136,7 @@ module Ocaml = struct
       ?error_handler
       f =
     Eliom_service.untype @@
-    M.attach_post
+    M.create_attached_post
       ?app
       ?scope
       ?options

--- a/src/lib/eliom_registration_sigs.shared.mli
+++ b/src/lib/eliom_registration_sigs.shared.mli
@@ -184,10 +184,10 @@ module type S_with_create = sig
      'gn, 'pn, return)
       Eliom_service.t
 
-  (** Same as {!Eliom_service.attach_get} followed by {!register}.
+  (** Same as {!Eliom_service.create_attached_get} followed by {!register}.
       For {!register} see
       {% <<a_api| val Eliom_registration_sigs.S.register >> %}. *)
-  val attach_get :
+  val create_attached_get :
     ?app:string ->
     ?scope:[<Eliom_common.scope] ->
     ?options:options ->
@@ -218,10 +218,10 @@ module type S_with_create = sig
      [`WithoutSuffix], 'gn, unit, return)
       Eliom_service.t
 
-  (** Same as {!Eliom_service.attach_post} followed by {!register}.
+  (** Same as {!Eliom_service.create_attached_post} followed by {!register}.
       For {!register} see
       {% <<a_api| val Eliom_registration_sigs.S.register >> %}. *)
-  val attach_post :
+  val create_attached_post :
     ?app:string ->
     ?scope:[<Eliom_common.scope] ->
     ?options:options ->
@@ -312,8 +312,8 @@ module type S_poly_with_create = sig
      'gn, 'pn, 'a return)
       Eliom_service.t
 
-  (** See {!S.attach_get}. *)
-  val attach_get :
+  (** See {!S.create_attached_get}. *)
+  val create_attached_get :
     ?app:string ->
     ?scope:[<Eliom_common.scope] ->
     ?options:options ->
@@ -345,8 +345,8 @@ module type S_poly_with_create = sig
      [`WithoutSuffix], 'gn, unit, 'a return)
       Eliom_service.t
 
-  (** See {!S.attach_post}. *)
-  val attach_post :
+  (** See {!S.create_attached_post}. *)
+  val create_attached_post :
     ?app:string ->
     ?scope:[<Eliom_common.scope] ->
     ?options:options ->

--- a/src/lib/eliom_service.server.ml
+++ b/src/lib/eliom_service.server.ml
@@ -70,7 +70,7 @@ let plain_service
     ~reload_fun
     ()
 
-let attach
+let create_attached
     ?name
     ?(csrf_safe = false)
     ?csrf_scope
@@ -131,23 +131,23 @@ let attach
     reload_fun = Rf_client_fun
   }
 
-let attach_get =
-  attach ~meth:Get' ~post_params:Eliom_parameter.unit
+let create_attached_get =
+  create_attached ~meth:Get' ~post_params:Eliom_parameter.unit
 
-let attach_post
+let create_attached_post
     ?name ?csrf_safe ?csrf_scope ?csrf_secure
     ?max_use ?timeout ?https ?keep_nl_params
     ~fallback ~post_params
     () =
   let get_params = get_params_type fallback in
-  attach ~meth:Post'
+  create_attached ~meth:Post'
     ?name ?csrf_safe ?csrf_scope ?csrf_secure
     ?max_use ?timeout ?https ?keep_nl_params
     ~fallback ~post_params ~get_params ()
 
-let attach_get_unsafe = attach_get
+let create_attached_get_unsafe = create_attached_get
 
-let attach_post_unsafe = attach_post
+let create_attached_post_unsafe = create_attached_post
 
 let coservice'
     (type m) (type gp) (type gn) (type pp) (type pn) (type gp')

--- a/src/lib/eliom_service.server.mli
+++ b/src/lib/eliom_service.server.mli
@@ -113,14 +113,14 @@ val create :
   unit ->
   ('gp, 'pp, 'm, 'att, 'co, non_ext, reg, 'tipo, 'gn, 'pn, non_ocaml) t
 
-(** [attach_get ~fallback ~get_params ()] attaches a new service on
+(** [create_attached_get ~fallback ~get_params ()] attaches a new service on
     the path of [fallback]. The new service implements the GET method
     and accepts [get_params], in addition to an
     automatically-generated parameter that is used to identify the
     service and does not need to be provided by the
     programmer. [fallback] remains available. For a description of the
     optional parameters see {!create}. *)
-val attach_get :
+val create_attached_get :
   ?name:string ->
   ?csrf_safe: bool ->
   ?csrf_scope: [< Eliom_common.user_scope] ->
@@ -137,14 +137,14 @@ val attach_get :
   ('gp, unit, get, att, co, non_ext, reg, [`WithoutSuffix],
    'gn, unit, non_ocaml) t
 
-(** [attach_post ~fallback ~post_params ()] attaches a new service on
+(** [create_attached_post ~fallback ~post_params ()] attaches a new service on
     the path of [fallback]. The new service implements the POST method
     and accepts the GET parameters of [fallback], in addition to the
     POST parameters [post_params]. An automatically-generated
     parameter is used to identify the service and does not need to be
     provided by the programmer. [fallback] remains available. For a
     description of the optional parameters see {!create}. *)
-val attach_post :
+val create_attached_post :
   ?name:string ->
   ?csrf_safe: bool ->
   ?csrf_scope: [< Eliom_common.user_scope] ->
@@ -260,7 +260,7 @@ val create_unsafe :
   unit ->
   ('gp, 'pp, 'm, 'att, 'co, non_ext, reg, 'tipo, 'gn, 'pn, 'ret) t
 
-val attach_get_unsafe :
+val create_attached_get_unsafe :
   ?name:string ->
   ?csrf_safe: bool ->
   ?csrf_scope: [< Eliom_common.user_scope] ->
@@ -276,7 +276,7 @@ val attach_get_unsafe :
   unit ->
   ('gp, unit, get, att, co, non_ext, reg, 'tipo, 'gn, unit, _) t
 
-val attach_post_unsafe :
+val create_attached_post_unsafe :
   ?name:string ->
   ?csrf_safe: bool ->
   ?csrf_scope: [< Eliom_common.user_scope] ->

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -437,7 +437,7 @@ let non_attached_info = function
   | _ ->
     failwith "non_attached_info"
 
-let attach_existing :
+let attach :
   fallback:
   (unit, unit, get, att, _, non_ext, 'rg1,
    [< suff ], unit, unit, 'return1) t ->
@@ -452,7 +452,7 @@ let attach_existing :
     let fallbackkind = attached_info fallback in
     let open Eliom_common in
     let error_msg =
-      "attach_global_to_fallback' is not implemented for this kind of\
+      "attach' is not implemented for this kind of\
        service. Please report a bug if you need this."
     in
     let get_name = match na_name with

--- a/src/lib/eliom_service_sigs.shared.mli
+++ b/src/lib/eliom_service_sigs.shared.mli
@@ -241,12 +241,12 @@ module type S = sig
     (unit, 'b, 'meth, att, 'co, 'ext, non_reg,
      [ `WithoutSuffix ], unit, 'f, 'return) t
 
-  (** [attach_existing ~fallback ~service ()] attaches the preexisting
+  (** [attach ~fallback ~service ()] attaches the preexisting
       path-less service [service] on the URL of [fallback]. This
       allows creating a link to a pah-less service but with another
       URL than the current one. It is not possible to register
       something on the service returned by this function. *)
-  val attach_existing :
+  val attach :
     fallback:
       (unit, unit, get, att, _, non_ext, _,
        _, unit, unit, 'return1) t ->


### PR DESCRIPTION
```
attach_get      -> create_attached_get
attach_post     -> create_attached_post
attach_existing -> attach
```

CC @balat