### PR TITLE
Remove client-side Eliom_service.attach

### DIFF
--- a/src/lib/eliom_service.server.ml
+++ b/src/lib/eliom_service.server.ml
@@ -231,6 +231,49 @@ let create_unsafe = create
 
 let create_ocaml = create
 
+let attach :
+  fallback:
+  (unit, unit, get, att, _, non_ext, 'rg1,
+   [< suff ], unit, unit, 'return1) t ->
+  service:
+  ('get, 'post, 'gp, non_att, co, non_ext, 'rg2,
+   [< `WithoutSuffix] as 'sf, 'gn, 'pn, 'return) t ->
+  unit ->
+  ('get, 'post, 'gp, att, co, non_ext, non_reg,
+   'sf, 'gn, 'pn, 'return) t =
+  fun ~fallback ~service () ->
+    let {na_name} = non_attached_info service in
+    let fallbackkind = attached_info fallback in
+    let open Eliom_common in
+    let error_msg =
+      "attach' is not implemented for this kind of\
+       service. Please report a bug if you need this."
+    in
+    let get_name = match na_name with
+      | SNa_get_ s -> SAtt_na_named s
+      | SNa_get' s -> SAtt_na_anon s
+      | SNa_get_csrf_safe a -> SAtt_na_csrf_safe a
+      | SNa_post_ s -> fallbackkind.get_name (*VVV check *)
+      | SNa_post' s -> fallbackkind.get_name (*VVV check *)
+      | SNa_post_csrf_safe a -> fallbackkind.get_name (*VVV check *)
+      | _ -> failwith error_msg
+    (*VVV Do we want to make possible to attach POST na coservices
+          on GET attached coservices? *)
+    and post_name = match na_name with
+      | SNa_get_ s -> SAtt_no
+      | SNa_get' s -> SAtt_no
+      | SNa_get_csrf_safe a -> SAtt_no
+      | SNa_post_ s -> SAtt_na_named s
+      | SNa_post' s -> SAtt_na_anon s
+      | SNa_post_csrf_safe a -> SAtt_na_csrf_safe a
+      | _ -> failwith error_msg
+    in {
+      service with
+      service_mark = service_mark ();
+      kind = `AttachedCoservice;
+      info = Attached {fallbackkind with get_name ; post_name }
+    }
+
 exception Wrong_session_table_for_CSRF_safe_coservice
 
 let eliom_appl_answer_content_type = "application/x-eliom"

--- a/src/lib/eliom_service.server.mli
+++ b/src/lib/eliom_service.server.mli
@@ -162,6 +162,22 @@ val create_attached_post :
   ('gp, 'pp, post, att, co, non_ext, reg, [`WithoutSuffix],
    'gn, 'pn, non_ocaml) t
 
+(** [attach ~fallback ~service ()] attaches the preexisting pathless
+    service [service] on the URL of [fallback]. This allows creating a
+    link to a pathless service but with another URL than the current
+    one. It is not possible to register something on the service
+    returned by this function. *)
+val attach :
+  fallback:
+    (unit, unit, get, att, _, non_ext, _,
+     _, unit, unit, 'return1) t ->
+  service:
+    ('get, 'post, 'meth, non_att, co, non_ext, _,
+     [< `WithoutSuffix] as 'sf, 'gn, 'pn, 'return) t ->
+  unit ->
+  ('get, 'post, 'meth, att, co, non_ext, non_reg,
+   'sf, 'gn, 'pn, 'return) t
+
 (** {2 Static loading of Eliom modules}
 
     This functionality allows one to register initialization functions

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -437,49 +437,6 @@ let non_attached_info = function
   | _ ->
     failwith "non_attached_info"
 
-let attach :
-  fallback:
-  (unit, unit, get, att, _, non_ext, 'rg1,
-   [< suff ], unit, unit, 'return1) t ->
-  service:
-  ('get, 'post, 'gp, non_att, co, non_ext, 'rg2,
-   [< `WithoutSuffix] as 'sf, 'gn, 'pn, 'return) t ->
-  unit ->
-  ('get, 'post, 'gp, att, co, non_ext, non_reg,
-   'sf, 'gn, 'pn, 'return) t =
-  fun ~fallback ~service () ->
-    let {na_name} = non_attached_info service in
-    let fallbackkind = attached_info fallback in
-    let open Eliom_common in
-    let error_msg =
-      "attach' is not implemented for this kind of\
-       service. Please report a bug if you need this."
-    in
-    let get_name = match na_name with
-      | SNa_get_ s -> SAtt_na_named s
-      | SNa_get' s -> SAtt_na_anon s
-      | SNa_get_csrf_safe a -> SAtt_na_csrf_safe a
-      | SNa_post_ s -> fallbackkind.get_name (*VVV check *)
-      | SNa_post' s -> fallbackkind.get_name (*VVV check *)
-      | SNa_post_csrf_safe a -> fallbackkind.get_name (*VVV check *)
-      | _ -> failwith error_msg
-    (*VVV Do we want to make possible to attach POST na coservices
-          on GET attached coservices? *)
-    and post_name = match na_name with
-      | SNa_get_ s -> SAtt_no
-      | SNa_get' s -> SAtt_no
-      | SNa_get_csrf_safe a -> SAtt_no
-      | SNa_post_ s -> SAtt_na_named s
-      | SNa_post' s -> SAtt_na_anon s
-      | SNa_post_csrf_safe a -> SAtt_na_csrf_safe a
-      | _ -> failwith error_msg
-    in {
-      service with
-      service_mark = service_mark ();
-      kind = `AttachedCoservice;
-      info = Attached {fallbackkind with get_name ; post_name }
-    }
-
 (** Create a main service (not a coservice), internal or external *)
 let main_service
     ~https

--- a/src/lib/eliom_service_sigs.shared.mli
+++ b/src/lib/eliom_service_sigs.shared.mli
@@ -241,22 +241,6 @@ module type S = sig
     (unit, 'b, 'meth, att, 'co, 'ext, non_reg,
      [ `WithoutSuffix ], unit, 'f, 'return) t
 
-  (** [attach ~fallback ~service ()] attaches the preexisting
-      path-less service [service] on the URL of [fallback]. This
-      allows creating a link to a pah-less service but with another
-      URL than the current one. It is not possible to register
-      something on the service returned by this function. *)
-  val attach :
-    fallback:
-      (unit, unit, get, att, _, non_ext, _,
-       _, unit, unit, 'return1) t ->
-    service:
-      ('get, 'post, 'meth, non_att, co, non_ext, _,
-       [< `WithoutSuffix] as 'sf, 'gn, 'pn, 'return) t ->
-    unit ->
-    ('get, 'post, 'meth, att, co, non_ext, non_reg,
-     'sf, 'gn, 'pn, 'return) t
-
   (** The function [add_non_localized_get_parameters ~params ~service]
       Adds non localized GET parameters [params] to [service]. See the
       Eliom manual for more information about {% <<a_manual


### PR DESCRIPTION
#400 addendum. I don't think client-side `Eliom_service.attach` makes sense, since the newly-attached service should also be available server-side on the appropriate path.