### PR TITLE
Remove calendarlib dependency

### DIFF
--- a/opam
+++ b/opam
@@ -15,7 +15,6 @@ depends: [
   "ppx_tools" {>= "0.99.3"}
   "js_of_ocaml" {>= "2.8.2"}
   "tyxml" {>= "4.0.0"}
-  "calendar"
   "ocsigenserver" {>= "2.8"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/src/_tags
+++ b/src/_tags
@@ -31,7 +31,7 @@ true:keep_locs
 
 <lib/server/monitor/*.ml>:package(lwt.ppx)
 <lib/server/monitor/*.ml{,i}>:thread
-<lib/server/monitor/*.ml{,i}>:package(lwt,ocsigenserver,ocsigenserver.ext,tyxml,calendar)
+<lib/server/monitor/*.ml{,i}>:package(lwt,ocsigenserver,ocsigenserver.ext,tyxml)
 <lib/server/monitor/*.ml{,i}>:I(src/lib/server)
 
 <syntax/pa_*.*>: syntax(camlp4o),package(camlp4.quotations.o,camlp4.extend,bytes)


### PR DESCRIPTION
I just realized that the dependency on `calendarlib` is redundant, as witnessed by the Jenkins build of this PR, which will succeed.

Unfortunately, to build without `calendarlib` we need a tiny modification of `src/_tags`. That is, to fix the version in `opam-repository`, we would either need a bugfix release with a new tarball, or a patch in `opam-repository`. It is not too critical, so I think we should just aim for a bugfix release in a month or so (but do it this time).