### PR TITLE
Eliom_client: do not execute onload after ocaml services (server fuctions)

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -404,11 +404,10 @@ let call_ocaml_service
       get_params post_params in
   let%lwt () = Lwt_mutex.lock load_mutex in
   set_loading_phase ();
-  push_onload ();
   let%lwt content, request_data = unwrap_caml_content content in
   do_request_data request_data;
   reset_request_nodes ();
-  let load_callbacks = flush_onload () @ [broadcast_load_end] in
+  let load_callbacks = [broadcast_load_end] in
   Lwt_mutex.unlock load_mutex;
   run_callbacks load_callbacks;
   match content with


### PR DESCRIPTION
Please read carefully (only 6 lines).
@vouillon @vasilisp 

The onload was done after RPCs which is wrong.
I hope I removed the right lines (and that it will not break anything).
Do not release this in 6.0 branch before testing on alpha.besport.com...