### PR TITLE
Permit suffix params in Eliom_service.create_attached_post

### DIFF
--- a/src/lib/eliom_service.server.mli
+++ b/src/lib/eliom_service.server.mli
@@ -154,12 +154,12 @@ val create_attached_post :
   ?https:bool ->
   ?keep_nl_params:[ `All | `Persistent | `None ] ->
   fallback:
-    ('gp, unit, get, att, non_co, non_ext, _,
-     [`WithoutSuffix], 'gn, unit, non_ocaml) t ->
+    ('gp, unit, get, att, non_co, non_ext, _, 'suff,
+     'gn, unit, non_ocaml) t ->
   post_params:
     ('pp, [`WithoutSuffix], 'pn) Eliom_parameter.params_type ->
   unit ->
-  ('gp, 'pp, post, att, co, non_ext, reg, [`WithoutSuffix],
+  ('gp, 'pp, post, att, co, non_ext, reg, 'suff,
    'gn, 'pn, non_ocaml) t
 
 (** [attach ~fallback ~service ()] attaches the preexisting pathless


### PR DESCRIPTION
Eliom 6.0 does not allow attaching services on fallbacks that have POST parameters. There is no technical reason to disallow this case, it is just a small negligence on my part with respect to the type constraints. 