### PR TITLE
Notifs: cleaning Eliom_notif (first step)

### DIFF
--- a/src/lib/eliom_notif.server.ml
+++ b/src/lib/eliom_notif.server.ml
@@ -1,5 +1,11 @@
 open Lwt
 
+(* We use a hashtable associating resourceid to a weak set of
+   (userid option, notif_ev) corresponding to each tab that want to
+   get updates of this box.
+   We keep a strong reference on these data in process state.
+*)
+
 module type S = sig
   type identity
   type key
@@ -224,7 +230,7 @@ module Make (A : ARG) : S
         | Some content -> send_e (key, content); Lwt.return ()
         | None -> Lwt.return ()
     in
-    (* on all tabs registered on this data *)
+    (* on all tabs listening on this resource *)
     I.iter f key
 
   let client_ev () =

--- a/src/lib/eliom_notif.server.ml
+++ b/src/lib/eliom_notif.server.ml
@@ -12,17 +12,17 @@ module type S = sig
   type server_notif
   type client_notif
   val init : unit -> unit Lwt.t
-  val deinit : unit -> unit Lwt.t
+  val deinit : unit -> unit
   val listen : key -> unit
   val unlisten : key -> unit
   module Ext : sig
     val unlisten :
       ?sitedata:Eliom_common.sitedata ->
-      ([< `Client_process ], [< `Data | `Pers ]) Eliom_state.Ext.state
+      ([< `Client_process ], [< `Data ]) Eliom_state.Ext.state
       -> key -> unit
   end
   val notify : ?notfor:[`Me | `Id of identity] -> key -> server_notif -> unit
-  val client_ev : unit -> (key * client_notif) Eliom_react.Down.t Lwt.t
+  val client_ev : unit -> (key * client_notif) Eliom_react.Down.t
   val clean : unit -> unit
 end
 
@@ -123,16 +123,17 @@ module Make (A : ARG) : S
 
   end
 
-  let identity_r : (A.identity * notification_react) option Eliom_reference.eref =
-    Eliom_reference.eref
+  let identity_r
+    : (A.identity * notification_react) option Eliom_reference.Volatile.eref =
+    Eliom_reference.Volatile.eref
       ~scope:Eliom_common.default_process_scope
       None
 
   (* notif_e consists in a server side react event,
      its client side counterpart,
      and the server side function to trigger it. *)
-  let notif_e : notification_react Eliom_reference.eref =
-    Eliom_reference.eref_from_fun
+  let notif_e : notification_react Eliom_reference.Volatile.eref =
+    Eliom_reference.Volatile.eref_from_fun
       ~scope:Eliom_common.default_process_scope
       (fun () ->
          let e, send_e = React.E.create () in
@@ -155,54 +156,49 @@ module Make (A : ARG) : S
        because the table resourceid -> (identity, notif_ev) option
        is weak.
     *)
-    Eliom_reference.get notif_e >>= fun notif_e ->
-    Eliom_reference.set identity_r (Some (identity, notif_e))
+    let notif_e = Eliom_reference.Volatile.get notif_e in
+    Eliom_reference.Volatile.set identity_r (Some (identity, notif_e))
 
   let set_current_identity () =
     A.get_identity () >>= fun identity ->
-    set_identity identity
+    set_identity identity;
+    Lwt.return ()
 
   let init : unit -> unit Lwt.t = fun () ->
     set_current_identity ()
 
-  let deinit : unit -> unit Lwt.t = fun () ->
-    Eliom_reference.set identity_r None
+  let deinit () = Eliom_reference.Volatile.set identity_r None
 
+  let listen (key : A.key) =
+    let identity = Eliom_reference.Volatile.get identity_r in
+    I.add identity key
 
-  let listen (key : A.key) = Lwt.async (fun () ->
-    Eliom_reference.get identity_r >>= fun identity ->
-    I.add identity key;
-    Lwt.return ()
-  )
-
-  let unlisten (id : A.key) = Lwt.async (fun () ->
-    Eliom_reference.get identity_r >>= fun identity ->
-    I.remove identity id;
-    Lwt.return ()
-  )
+  let unlisten (id : A.key) =
+    let identity = Eliom_reference.Volatile.get identity_r in
+    I.remove identity id
 
   module type Ext = sig
     val unlisten :
       ?sitedata:Eliom_common.sitedata ->
-      ([< `Session | `Session_group ], [< `Data | `Pers ]) Eliom_state.Ext.state
+      ([< `Session | `Session_group ], [< `Data ]) Eliom_state.Ext.state
       -> key -> unit
   end
 
   module Ext = struct
-    let unlisten ?sitedata state (key : A.key) = Lwt.async @@ fun () ->
-      let%lwt uc = Eliom_reference.Ext.get state identity_r in
-      Lwt.return @@ I.remove uc key
+    let unlisten ?sitedata state (key : A.key) =
+      let uc = Eliom_reference.Volatile.Ext.get state identity_r in
+      I.remove uc key
   end
 
   let notify ?notfor key content =
     let f = fun (identity, ((_, send_e) as notif)) ->
-      let%lwt blocked = match notfor with
+      let blocked = match notfor with
         | Some `Me ->
             (*TODO: fails outside of a request*)
-            Eliom_reference.get notif_e >>= fun notif_e ->
-            Lwt.return (notif == notif_e)
-        | Some (`Id id) -> Lwt.return (identity = id)
-        | None -> Lwt.return false
+            let notif_e = Eliom_reference.Volatile.get notif_e in
+            notif == notif_e
+        | Some (`Id id) -> identity = id
+        | None -> false
       in
       if blocked
       then Lwt.return ()
@@ -215,9 +211,8 @@ module Make (A : ARG) : S
     I.iter f key
 
   let client_ev () =
-    Eliom_reference.get notif_e >>= fun notif_e ->
-    Lwt.return notif_e >>= fun (ev, _) ->
-    Lwt.return ev
+    let (ev, _) = Eliom_reference.Volatile.get notif_e in
+    ev
 
   let clean () =
     let f key weak_tbl =

--- a/src/lib/eliom_notif.server.mli
+++ b/src/lib/eliom_notif.server.mli
@@ -1,7 +1,7 @@
 (** Server to client notifications.
 
-    This module makes possible for client side applications to be
-    notified of changes on some indexed data on the server.
+    This module makes it possible for client side applications to be
+    notified of changes on some indexed data (resources) on the server.
 
     Apply functor [Make] or [Make_Simple] for each type of data you want to be
     able to listen on. Each client starts listening on one piece of data by
@@ -16,6 +16,8 @@
 
     The functor will also create a client side react signal that will
     be updated every time the client is notified.
+
+    See module Os_notif in Ocsigen Start for an example of use.
 *)
 
 (* TODO: allow for specifying the scope instead of hard-wiring

--- a/src/lib/eliom_notif.server.mli
+++ b/src/lib/eliom_notif.server.mli
@@ -106,9 +106,8 @@ sig
   val client_ev : unit -> (key * client_notif) Eliom_react.Down.t Lwt.t
 
 
-  (** Call [clean ()] to launch an asynchronous thread clearing the tables
-      from empty data. *)
-  val clean : unit -> unit Lwt.t
+  (** Call [clean ()] to clear the tables from empty data. *)
+  val clean : unit -> unit
 
 end
 

--- a/src/lib/eliom_notif.server.mli
+++ b/src/lib/eliom_notif.server.mli
@@ -57,7 +57,7 @@ sig
   val init : unit -> unit Lwt.t
 
   (** Deinitialise/deactivate the notification module for the current client. *)
-  val deinit : unit -> unit Lwt.t
+  val deinit : unit -> unit
 
   (** Make client process listen on data whose index is [key] *)
   val listen : key -> unit
@@ -71,7 +71,7 @@ sig
       [sitedata] by itself, otherwise it needs to be supplied by the caller. *)
     val unlisten :
       ?sitedata:Eliom_common.sitedata ->
-      ([< `Client_process ], [< `Data | `Pers ]) Eliom_state.Ext.state
+      ([< `Client_process ], [< `Data ]) Eliom_state.Ext.state
       -> key -> unit
   end
 
@@ -103,7 +103,7 @@ sig
            ]
 
   *)
-  val client_ev : unit -> (key * client_notif) Eliom_react.Down.t Lwt.t
+  val client_ev : unit -> (key * client_notif) Eliom_react.Down.t
 
 
   (** Call [clean ()] to clear the tables from empty data. *)


### PR DESCRIPTION
@vasilisp I removed some weird things in the cade. Read each commit separately (and carefully). I think it does not change the semantics at all.

There are still things to be checked. 

1. For example the `clean` function that was supposed to be asynchronous by was not. (Why do we need that? do we need to call that in BS or OS?
2. In the original version `notif_e` as a triple, not a pair, and there was an explanation why. How is this solved now?