### PR TITLE
Fix absolute calls to non-attached coservices

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -1224,3 +1224,5 @@ let () =
        call_ocaml_service ~absolute:true ~service ())
 
 let get_application_name = Eliom_process.get_application_name
+
+let set_client_html_file = Eliom_common.set_client_html_file

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -281,6 +281,11 @@ type ('a, +'b) server_function = 'a -> 'b Lwt.t
     saved in the history. *)
 val change_page_uri : ?replace:bool -> string -> unit Lwt.t
 
+(** Set the name of the HTML file loading our client app. The default
+    is "eliom.html". A wrong value will not allow the app to
+    initialize itself correctly. *)
+val set_client_html_file : string -> unit
+
 (**/**)
 
 (** [change_page_unknown path get_params post_params] calls the

--- a/src/lib/eliom_common.client.ml
+++ b/src/lib/eliom_common.client.ml
@@ -61,3 +61,8 @@ module To_and_of_shared = struct
   let to_and_of tao = tao
 
 end
+
+let
+  client_html_file,    set_client_html_file =
+  let r = ref "eliom.html" in
+  (fun () -> !r  ),    (fun s  -> assert !is_client_app; r := s)

--- a/src/lib/eliom_common.server.ml
+++ b/src/lib/eliom_common.server.ml
@@ -1403,3 +1403,6 @@ module To_and_of_shared = struct
   }
 
 end
+
+let client_html_file () =
+  failwith "client_html_file is only defined on client"

--- a/src/lib/eliom_common.server.mli
+++ b/src/lib/eliom_common.server.mli
@@ -738,3 +738,8 @@ module To_and_of_shared : sig
   val to_and_of : 'a t -> 'a to_and_of
 
 end
+
+(*/*)
+
+(** Raises exception on server, only relevant for client apps *)
+val client_html_file : unit -> string


### PR DESCRIPTION
Fixes #468, which disregarded the path for all non-attached POST coservice calls with `absolute = true`.

We now store the client HTML file name (default: `eliom.html`), match the URL against that, and modify if necessary.

Needed for ocsigen/ocsigen-start#416 to work correctly.