### PR TITLE
Implement Eliom_client.onchangepage

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -643,6 +643,8 @@ let set_content_local ?offset ?fragment new_page =
 (* Function to be called for server side services: *)
 let set_content ~replace ?uri ?offset ?fragment content =
   Lwt_log.ign_debug ~section "Set content";
+  (* TODO: too early? *)
+  run_callbacks (flush_onchangepage ());
   match content with
   | None -> Lwt.return ()
   | Some content ->
@@ -909,6 +911,7 @@ let change_page (type m)
            in
            let l = ocamlify_params l in
            update_session_info l l';
+           run_callbacks (flush_onchangepage ());
            let%lwt () = f get_params post_params in
            change_url_string_protected ~replace uri;
            do_follow_up uri

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -224,6 +224,13 @@ val onload : (unit -> unit) -> unit
 (** Returns a Lwt thread that waits until the next page is loaded. *)
 val lwt_onload : unit -> unit Lwt.t
 
+(** Run some code *before* the next page change, that is, before each
+    call to a page-producing service handler.
+
+    Just like onpreload, handlers registered with onchangepage only
+    apply to the next page change. *)
+val onchangepage : (unit -> unit) -> unit
+
 (** [onbeforeunload f] registers [f] as a handler to be called before
     changing the page the next time. If [f] returns [Some s], then we
     ask the user to confirm quitting. We try to use [s] in the

--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -61,6 +61,13 @@ let (onload, _, flush_onload, push_onload) :
   =
   create_buffer ()
 
+let
+  (onchangepage : (unit -> unit) -> unit),
+  _,
+  (flush_onchangepage : unit -> (unit -> unit) list),
+  _
+  = create_buffer ()
+
 let onunload, _, flush_onunload, _ = create_buffer ()
 
 let onbeforeunload, run_onbeforeunload, flush_onbeforeunload =


### PR DESCRIPTION
Permits running callbacks before a page-producing service handler is called.

See https://github.com/ocsigen/ocsigen-start/issues/417 for motivation.