### PR TITLE
Fix Eliom_client.change_page_uri loop for wrong links

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -1046,8 +1046,12 @@ let change_page_uri ?replace full_uri =
     | _ ->
       failwith "invalid url"
   with _ ->
-    (Lwt_log.ign_debug ~section "Change page uri: resort to server";
-     change_page_uri_a full_uri)
+    if is_client_app () then
+      (Lwt_log.ign_debug ~section "Change page uri: can't find service";
+       Lwt.return ())
+    else
+      (Lwt_log.ign_debug ~section "Change page uri: resort to server";
+       change_page_uri_a full_uri)
 
 (* Functions used in "onsubmit" event handler of <form>.  *)
 


### PR DESCRIPTION
Comes up in the context of mobile apps that handle external links.

- Browser would call app
- App would fail to route, fall back to server call and thus load browser
- Browser would call app
- ...

See ocsigen/ocsigen-start#424 for more context.