### PR TITLE
Re-raise server-side exceptions (besides sending them to the client)

### DIFF
--- a/src/lib/eliom_registration.server.ml
+++ b/src/lib/eliom_registration.server.ml
@@ -990,6 +990,8 @@ module Ocaml = struct
           let%lwt res = f g p in
           Lwt.return (`Success res)
         with exc ->
+          (* prints exception and stack trace on the server console *)
+          Lwt.async (fun () -> Lwt.fail exc);
           Lwt.return (`Failure (Printexc.to_string exc))
       in
       prepare_data data


### PR DESCRIPTION
This pull request is useful to raise awareness of exceptions which occur server-side.
Unfortunately stack traces do not work yet. They only show the innermost code position, which is rather useless. This might be related to: https://caml.inria.fr/mantis/view.php?id=6556