### PR TITLE
Compile against modular JSOO

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -1,3 +1,11 @@
+opam pin add js_of_ocaml --dev-repo --no-action
+
+for pkg in camlp4 compiler lwt ocamlbuild ppx tyxml; do
+    opam pin add js_of_ocaml-$pkg \
+         https://github.com/ocsigen/js_of_ocaml.git \
+         --no-action
+done
+
 opam pin add --no-action eliom .
 opam install --deps-only eliom
 opam install --verbose eliom

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -1,11 +1,3 @@
-opam pin add js_of_ocaml --dev-repo --no-action
-
-for pkg in camlp4 compiler lwt ocamlbuild ppx tyxml; do
-    opam pin add js_of_ocaml-$pkg \
-         https://github.com/ocsigen/js_of_ocaml.git \
-         --no-action
-done
-
 opam pin add --no-action eliom .
 opam install --deps-only eliom
 opam install --verbose eliom

--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ depends: [
   "deriving" {>= "0.6"}
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml" {>= "dev"}
+  "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-lwt"
   "js_of_ocaml-ocamlbuild" {build}
   "js_of_ocaml-ppx"

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ depends: [
   "js_of_ocaml-ppx"
   "js_of_ocaml-tyxml"
   "tyxml" {>= "4.0.0"}
-  "ocsigenserver" {>= "2.8"}
+  "ocsigenserver" {>= "dev"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   ("dbm" | "sqlite3")

--- a/opam
+++ b/opam
@@ -13,7 +13,11 @@ depends: [
   "deriving" {>= "0.6"}
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml" {>= "2.8.2" & < "3.0"}
+  "js_of_ocaml" {>= "dev"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-tyxml"
   "tyxml" {>= "4.0.0"}
   "ocsigenserver" {>= "2.8"}
   "ipaddr" {>= "2.1"}

--- a/pkg/META
+++ b/pkg/META
@@ -57,7 +57,7 @@ package "client" (
   archive(byte) = "client.cma eliom_client_main.cmo"
 
   linkopts(javascript) = "+eliom.client/eliom_client.js"
-  linkopts(javascript) += "+js_of_ocaml/classlist.js"
+  linkopts(javascript) += "+js_of_ocaml-compiler/classlist.js"
 )
 
 package "syntax" (

--- a/pkg/META
+++ b/pkg/META
@@ -46,8 +46,9 @@ package "client" (
               ppx_deriving.runtime,
               js_of_ocaml,
               js_of_ocaml.deriving,
-              js_of_ocaml.tyxml,
-              js_of_ocaml.log,
+              js_of_ocaml-tyxml,
+              js_of_ocaml-lwt,
+              js_of_ocaml-lwt.logger,
               js_of_ocaml.weak,
               lwt.react,
               react,
@@ -98,8 +99,8 @@ package "syntax" (
     description = "Syntax extension: predefined commonly use syntaxes"
     version = "[distributed with Eliom]"
 
-    requires(syntax, preprocessor) = "js_of_ocaml.syntax,js_of_ocaml.deriving.syntax,lwt.syntax,tyxml.syntax"
-    requires(syntax, toploop) = "js_of_ocaml.syntax,js_of_ocaml.deriving.syntax,lwt.syntax,tyxml.syntax"
+    requires(syntax, preprocessor) = "js_of_ocaml.syntax,js_of_ocaml-camlp4.deriving,lwt.syntax,tyxml.syntax"
+    requires(syntax, toploop) = "js_of_ocaml.syntax,js_of_ocaml-camlp4.deriving,lwt.syntax,tyxml.syntax"
     archive(syntax, preprocessor) = "-ignore dummy"
   )
 

--- a/pkg/META
+++ b/pkg/META
@@ -13,7 +13,7 @@ package "server" (
               react,
               reactiveData,
               tyxml,
-              lwt.react,
+              lwt_react,
               cryptokit,
               reactiveData"
   archive(byte) = "server.cma"
@@ -50,7 +50,7 @@ package "client" (
               js_of_ocaml-lwt,
               js_of_ocaml-lwt.logger,
               js_of_ocaml.weak,
-              lwt.react,
+              lwt_react,
               react,
               reactiveData,
               tyxml.functor"

--- a/pkg/distillery/basic.ppx/Makefile.options
+++ b/pkg/distillery/basic.ppx/Makefile.options
@@ -11,9 +11,9 @@ SERVER_FILES := $(wildcard *.eliomi *.eliom)
 CLIENT_FILES := $(wildcard *.eliomi *.eliom)
 
 # OCamlfind packages for the server
-SERVER_PACKAGES := lwt.ppx js_of_ocaml.deriving.ppx
+SERVER_PACKAGES := lwt.ppx js_of_ocaml-ppx.deriving
 # OCamlfind packages for the client
-CLIENT_PACKAGES := lwt.ppx js_of_ocaml.ppx js_of_ocaml.deriving.ppx
+CLIENT_PACKAGES := lwt.ppx js_of_ocaml-ppx js_of_ocaml-ppx.deriving
 
 # Directory with files to be statically served
 LOCAL_STATIC = static

--- a/src/_tags
+++ b/src/_tags
@@ -2,32 +2,32 @@
 true:keep_locs
 
 <lib/type_dir/*.ml{,i}>:eliom_ppx,thread
-<lib/type_dir/*.ml>:package(js_of_ocaml.deriving.ppx,lwt.ppx)
+<lib/type_dir/*.ml>:package(js_of_ocaml-ppx.deriving,lwt.ppx)
 <lib/type_dir/*.ml>:package(js_of_ocaml.ppx)
 
 <lib/server/*.ml{,i}>:eliom_ppx
-<lib/server/*.ml>:package(js_of_ocaml.deriving.ppx,lwt.ppx)
+<lib/server/*.ml>:package(js_of_ocaml-ppx.deriving,lwt.ppx)
 <lib/server/*.ml>:package(js_of_ocaml.ppx)
 
 <lib/server/*.ml{,i}>:thread
 <lib/server/*.ml{,i}>:package(lwt,ocsigenserver,ocsigenserver.ext,tyxml.functor)
 <lib/server/*.ml{,i}>:package(react,js_of_ocaml)
 
-<lib/server/*.ml{,i}>:package(js_of_ocaml.deriving.ppx)
+<lib/server/*.ml{,i}>:package(js_of_ocaml-ppx.deriving)
 
 <lib/*.eliom{,i}>:eliom_ppx
 
 <lib/*.ml{,i}>:eliom_ppx
-<lib/client/*.ml>:package(js_of_ocaml.deriving.ppx,lwt.ppx,js_of_ocaml.log)
+<lib/client/*.ml>:package(js_of_ocaml-ppx.deriving,lwt.ppx,js_of_ocaml-lwt.logger)
 <lib/client/*.ml>:package(js_of_ocaml.ppx)
 
 <lib/client/*.ml{,i}>: eliom_ppx
 <lib/client/*.ml{,i}>:package(ocsigenserver.cookies,ocsigenserver.polytables,ocsigenserver.baselib.base)
 <lib/client/*.ml{,i}>:package(deriving.runtime,js_of_ocaml.deriving)
-<lib/client/*.ml{,i}>:package(lwt.react,tyxml.functor,js_of_ocaml.tyxml)
+<lib/client/*.ml{,i}>:package(lwt.react,tyxml.functor,js_of_ocaml.tyxml,js_of_ocaml-lwt,js_of_ocaml-lwt.logger)
 <lib/client/*.ml{,i}>:package(react,js_of_ocaml,reactiveData)
 
-<lib/client/*.ml{,i}>:package(js_of_ocaml.deriving.ppx)
+<lib/client/*.ml{,i}>:package(js_of_ocaml-ppx.deriving)
 
 <lib/server/monitor/*.ml>:package(lwt.ppx)
 <lib/server/monitor/*.ml{,i}>:thread

--- a/src/_tags
+++ b/src/_tags
@@ -11,7 +11,7 @@ true:keep_locs
 
 <lib/server/*.ml{,i}>:thread
 <lib/server/*.ml{,i}>:package(lwt,ocsigenserver,ocsigenserver.ext,tyxml.functor)
-<lib/server/*.ml{,i}>:package(react,js_of_ocaml)
+<lib/server/*.ml{,i}>:package(react,lwt_react,js_of_ocaml)
 
 <lib/server/*.ml{,i}>:package(js_of_ocaml-ppx.deriving)
 
@@ -24,7 +24,7 @@ true:keep_locs
 <lib/client/*.ml{,i}>: eliom_ppx
 <lib/client/*.ml{,i}>:package(ocsigenserver.cookies,ocsigenserver.polytables,ocsigenserver.baselib.base)
 <lib/client/*.ml{,i}>:package(deriving.runtime,js_of_ocaml.deriving)
-<lib/client/*.ml{,i}>:package(lwt.react,tyxml.functor,js_of_ocaml.tyxml,js_of_ocaml-lwt,js_of_ocaml-lwt.logger)
+<lib/client/*.ml{,i}>:package(lwt_react,tyxml.functor,js_of_ocaml.tyxml,js_of_ocaml-lwt,js_of_ocaml-lwt.logger)
 <lib/client/*.ml{,i}>:package(react,js_of_ocaml,reactiveData)
 
 <lib/client/*.ml{,i}>:package(js_of_ocaml-ppx.deriving)

--- a/src/lib/eliom_content_.client.ml
+++ b/src/lib/eliom_content_.client.ml
@@ -573,8 +573,7 @@ module Html = struct
         elt##.onscroll := (bool_cb f)
       let onreturn elt f =
         let f ev =
-          let key = ev##.keyCode in
-          if key = Keycode.return then f ev;
+          if Dom_html.Keyboard_code.(of_event ev = Enter) then f ev;
           true in
         onkeydown elt f
       let onchange elt f =

--- a/src/lib/eliom_request.client.ml
+++ b/src/lib/eliom_request.client.ml
@@ -24,6 +24,8 @@ exception Failed_request of int
 exception Program_terminated
 exception Non_xml_content
 
+module XmlHttpRequest = Js_of_ocaml_lwt.XmlHttpRequest
+
 let section = Lwt_log.Section.make "eliom:request"
 (* == ... *)
 

--- a/src/lib/eliom_request.client.ml
+++ b/src/lib/eliom_request.client.ml
@@ -96,9 +96,6 @@ let redirect_post url params =
   (* firefox accepts submit only on forms in the document *)
   f##submit
 
-let redirect_post_form_elt ?(post_args=[]) ?(form_arg=[]) url =
-  redirect_post url (form_arg@post_args)
-
 (* Forms cannot use PUT http method: do not redirect *)
 let redirect_put _url _params =
   Lwt_log.raise_error ~section "redirect_put not implemented"
@@ -128,10 +125,10 @@ let nl_template_string = "__nl_n_eliom-template.name"
 let send
     ?with_credentials
     ?(expecting_process_page = false) ?cookies_info
-    ?get_args ?post_args ?form_arg
+    ?get_args ?post_args
     ?progress ?upload_progress ?override_mime_type
     url result =
-  let rec aux i ?cookies_info ?(get_args=[]) ?post_args ?form_arg url =
+  let rec aux i ?cookies_info ?(get_args=[]) ?post_args url =
     let (https, path) = match cookies_info with
       | Some c -> c
       (* CCC Is it really necessary to allow to specify cookie_info here?
@@ -204,14 +201,6 @@ let send
       then (Eliom_common.nl_get_appl_parameter, "true")::get_args
       else get_args
     in
-    let form_contents =
-      match form_arg with
-        | None -> None
-        | Some form_arg ->
-          let contents = Form.empty_form_contents () in
-          List.iter (Form.append contents) form_arg;
-          Some contents
-    in
     let check_headers code headers =
       if expecting_process_page
       then
@@ -223,10 +212,18 @@ let send
       else true
     in
     try%lwt
-      let%lwt r = XmlHttpRequest.perform_raw_url
+      let%lwt r =
+        let contents =
+          match post_args with
+          | Some post_args ->
+            Some (`POST_form post_args)
+          | None ->
+            None
+        in
+        XmlHttpRequest.perform_raw_url
           ?with_credentials
           ?headers:(Some headers) ?content_type:None
-          ?post_args ~get_args ?form_arg:form_contents ~check_headers
+          ?contents ~get_args ~check_headers
           ?progress ?upload_progress ?override_mime_type url
       in
       (if Js.Unsafe.global##.___eliom_use_cookie_substitutes_ <> Js.undefined
@@ -254,9 +251,10 @@ let send
              with
                | None | Some "" -> Lwt.return (r.XmlHttpRequest.url, None)
                | Some uri ->
-                 (match post_args, form_arg with
-                   | None, None -> redirect_get uri
-                   | _, _ -> redirect_post_form_elt ?post_args ?form_arg url);
+                 redirect_post url
+                   (match post_args with
+                    | Some post_args -> post_args
+                    | None -> []);
                  Lwt.fail Program_terminated)
           | Some uri ->
             if i < max_redirection_level
@@ -287,9 +285,9 @@ let send
            us that the answer is not application content *)
         match headers Eliom_common.appl_name_header_name with
           | None | Some "" -> (* Empty appl_name for IE compat. *)
-            (match post_args, form_arg with
-              | None, None -> redirect_get url
-              | _, _ -> Lwt_log.raise_error ~section  "can't silently redirect a Post request to non application content");
+            (match post_args with
+              | None -> redirect_get url
+              | _ -> Lwt_log.raise_error ~section  "can't silently redirect a Post request to non application content");
             Lwt.fail Program_terminated
           | Some appl_name ->
             let current_appl_name = Eliom_process.get_application_name () in
@@ -304,7 +302,7 @@ let send
                 Lwt.fail (Failed_request code)
               end
   in
-  let%lwt (url, content) = aux 0 ?cookies_info ?get_args ?post_args ?form_arg url in
+  let%lwt (url, content) = aux 0 ?cookies_info ?get_args ?post_args url in
   let filter_url url =
     { url with Url.hu_arguments =
         List.filter (fun (e,_) -> e <> nl_template_string) url.Url.hu_arguments } in
@@ -340,7 +338,6 @@ let add_button_arg inj args form =
         else args
 (* END FORMDATA HACK *)
 
-
 (** Send a GET form with tab cookies and half/full XHR.
     If [~post_params] is present, the HTTP method will be POST,
     with form data in the URL.
@@ -367,12 +364,26 @@ let send_post_form
     ?progress ?upload_progress ?override_mime_type
     form url =
   (* BEGIN FORMDATA HACK *)
-  let post_args = add_button_arg (fun x -> `String x) post_args form in
+  let post_args =
+    match
+      add_button_arg (fun x -> `String x)
+        (Some (Form.form_elements form))
+        form,
+      post_args
+    with
+    | Some l, Some l' ->
+      Some (l @ l')
+    | Some l, _
+    | _, Some l ->
+      Some l
+    | None, None ->
+      None
+  in
   (* END FORMDATA HACK *)
   send ?with_credentials
     ?expecting_process_page ?cookies_info ?get_args ?post_args
     ?progress ?upload_progress ?override_mime_type
-    ~form_arg:(Form.form_elements form) url
+    url
 
 let http_get ?with_credentials ?expecting_process_page ?cookies_info
     ?progress ?upload_progress ?override_mime_type
@@ -398,6 +409,7 @@ let http_put ?with_credentials ?expecting_process_page ?cookies_info
 let http_delete ?with_credentials ?expecting_process_page ?cookies_info
     ?progress ?upload_progress ?override_mime_type
     url post_args =
+
   send ?with_credentials ?expecting_process_page ?cookies_info ~post_args
     ?progress ?upload_progress ?override_mime_type
     url

--- a/src/lib/eliom_request.client.mli
+++ b/src/lib/eliom_request.client.mli
@@ -38,7 +38,6 @@ val send :
   ?cookies_info:bool * string list ->
   ?get_args:(string * string) list ->
   ?post_args:(string * Eliommod_parameters.param) list ->
-  ?form_arg:((string * Form.form_elt) list) ->
   ?progress:(int -> int -> unit) ->
   ?upload_progress:(int -> int -> unit) ->
   ?override_mime_type:string ->

--- a/src/ocamlbuild/ocamlbuild_eliom.ml
+++ b/src/ocamlbuild/ocamlbuild_eliom.ml
@@ -134,6 +134,10 @@ module MakeIntern (I : INTERNALS)(Eliom : ELIOM) = struct
     dflag ["ocaml"; "infer_interface"; file_tag] ppflags;
     dflag ["ocaml"; "doc";             file_tag] ppflags_notype
 
+  let ocamlfind_query pkg =
+    let cmd = Printf.sprintf "ocamlfind query %s" (Filename.quote pkg) in
+    Ocamlbuild_pack.My_unix.run_and_open cmd input_line
+
   let copy_rule_server ?(eliom=true) =
     copy_rule_with_header
       (fun env dir name src file ->
@@ -143,6 +147,9 @@ module MakeIntern (I : INTERNALS)(Eliom : ELIOM) = struct
              :: get_syntaxes eliom `Server src
            );
          if eliom then flag_infer ~file ~name ~path `Server;
+         dflag ["ocaml"; "compile"; "file:" ^ file]
+           (S [A "-I";
+               A (ocamlfind_query "js_of_ocaml")]);
          Pathname.define_context dir [path];
          Pathname.define_context path [dir];
       )

--- a/src/tools/utils.ml
+++ b/src/tools/utils.ml
@@ -298,8 +298,7 @@ let get_client_lib ?kind:k () =
 let get_client_js () =
   [
     "+eliom.client/eliom_client.js" ;
-    "+js_of_ocaml/weak.js";
-    "+js_of_ocaml/classlist.js" (* ie9 support *)
+    "+js_of_ocaml-compiler/weak.js"
   ]
 
 (* Should be calld only with -dump... *)

--- a/src/tools/utils.ml
+++ b/src/tools/utils.ml
@@ -265,7 +265,9 @@ let get_common_include ?kind:k ?build_dir:dir ?package:p () =
   let dir = match dir with Some d -> d | None -> !build_dir in
   (match get_kind k with
    | `Server | `ServerOpt ->
-     map_include (List.map Findlib.package_directory (get_server_package ?kind:k ?package:p ()))
+     "js_of_ocaml" :: get_server_package ?kind:k ?package:p ()
+     |> List.map Findlib.package_directory
+     |> map_include
    | `Client ->
      map_include (List.map Findlib.package_directory (get_client_package ?kind:k ())))
   @ match dir with

--- a/tests/testsuite/_tags
+++ b/tests/testsuite/_tags
@@ -1,5 +1,5 @@
 <type_dir/*.ml{,i}>:package(eliom.server,eliom.server.monitor)
 <server/*.ml{,i}>:package(eliom.server,eliom.server.monitor)
-<**/*.ml{,i}>: syntax(camlp4o),package(ocsigenserver.baselib,js_of_ocaml.deriving.syntax,deriving.syntax.std,tyxml.syntax,reactiveData,react),package(lwt.syntax.log),ppopt(-lwt-debug)
+<**/*.ml{,i}>: syntax(camlp4o),package(ocsigenserver.baselib,js_of_ocaml-camlp4.deriving,deriving.syntax.std,tyxml.syntax,reactiveData,react),package(lwt.syntax.log),ppopt(-lwt-debug)
 <testsuite_client.{byte,js}>:package(eliom.client)
 true: debug


### PR DESCRIPTION
The transition is very smooth. We just need to depend on the new OPAM and Findlib packages and replace `XmlHttpRequest` by `Lwt_xmlHttpRequest`.

CC @hhugo