### PR TITLE
A comment in Eliom_react.server.mli still uses the deriving camlp4 sy…

### DIFF
--- a/src/lib/eliom_react.server.mli
+++ b/src/lib/eliom_react.server.mli
@@ -85,7 +85,7 @@ sig
 
       Example of use:
       [let e_up = Eliom_react.Up.create
-        (Eliom_parameter.ocaml "a" Json.t<string>)
+        (Eliom_parameter.ocaml "a" [%derive.json: string])
       in
       ... {{ ignore ( %e_up "A") }} ...
       ]


### PR DESCRIPTION
…ntax.

This replaces an occurrence of "Json.t<string>" with
"[%derive.json: string]". This is only in a comment but appeared in the
documentation.