### PR TITLE
Fix hostname used by client app

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -121,6 +121,23 @@ let onunload_fun _ =
 
 let onbeforeunload_fun _ = run_onbeforeunload ()
 
+let set_base_url () =
+  let {
+    Eliom_common.cpi_hostname ;
+    cpi_original_full_path ;
+    cpi_server_port ;
+    cpi_ssl ;
+  } = Eliom_process.get_info () in
+  let proto = if cpi_ssl then "https" else "http"
+  and host =
+    if cpi_server_port = 80 then
+      cpi_hostname
+    else
+      Printf.sprintf "%s:%d" cpi_hostname cpi_server_port
+  and path = String.concat "/" cpi_original_full_path in
+  Eliom_process.set_base_url
+    (Printf.sprintf "%s://%s/%s" proto host path)
+
 (* Function called (in Eliom_client_main), once when starting the app.
    Either when sent by a server or initiated on client side.
 
@@ -166,13 +183,7 @@ let init () =
   (* The first time we load the page, we record the initial URL in a client
      side ref, in order to set <base> (on client-side) in header for each
      pages. *)
-  Eliom_process.set_base_url
-    (String.concat
-       ""
-       [ Js.to_string (Dom_html.window##.location##.protocol)
-       ; "//"
-       ; Js.to_string (Dom_html.window##.location##.host)
-       ; Js.to_string (Dom_html.window##.location##.pathname) ]);
+  set_base_url ();
   insert_base Dom_html.document;
   (* </base> *)
 

--- a/src/lib/eliom_process.client.ml
+++ b/src/lib/eliom_process.client.ml
@@ -78,7 +78,8 @@ let appl_name =
           Eliom_common.appl_name_cookie_name
           (Cookies.find
              (get_sitedata ()).Eliom_types.site_dir
-             (Eliommod_cookies.get_table (Some Url.Current.host))))
+             (Eliommod_cookies.get_table
+                (Some (get_info ()).cpi_hostname))))
      in v)
 
 let set_base_url, get_base_url =


### PR DESCRIPTION
The underlying issues were reported by @klakplok.

The first patch fixes a mismatch between the default hostname of the app (`defaulthostname` tag) and the one in the URL. The hostname is used as a key in the data structure that stores process info. As a result of the mismatch, reading the app name would fail, and thus all calls to app services would fail.

The second patch uses the process info sent by the server for building the initial `<base>` tag. I don't think that using host and path that appear in the URL is meaningful; we could just omit `<base>`.