### PR TITLE
Always use current location to build <base>

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -122,29 +122,13 @@ let onunload_fun _ =
 let onbeforeunload_fun _ = run_onbeforeunload ()
 
 let set_base_url () =
-  Eliom_process.set_base_url @@
-  if is_client_app () then
-    String.concat
-      ""
-      [ Js.to_string (Dom_html.window##.location##.protocol)
-      ; "//"
-      ; Js.to_string (Dom_html.window##.location##.host)
-      ; Js.to_string (Dom_html.window##.location##.pathname) ]
-  else
-    let {
-      Eliom_common.cpi_hostname ;
-      cpi_original_full_path ;
-      cpi_server_port ;
-      cpi_ssl ;
-    } = Eliom_process.get_info () in
-    let proto = if cpi_ssl then "https" else "http"
-    and host =
-      if cpi_server_port = 80 then
-        cpi_hostname
-      else
-        Printf.sprintf "%s:%d" cpi_hostname cpi_server_port
-    and path = String.concat "/" cpi_original_full_path in
-    Printf.sprintf "%s://%s/%s" proto host path
+  Eliom_process.set_base_url
+    (String.concat
+       ""
+       [ Js.to_string (Dom_html.window##.location##.protocol)
+       ; "//"
+       ; Js.to_string (Dom_html.window##.location##.host)
+       ; Js.to_string (Dom_html.window##.location##.pathname) ])
 
 (* Function called (in Eliom_client_main), once when starting the app.
    Either when sent by a server or initiated on client side.

--- a/src/lib/eliom_request.client.ml
+++ b/src/lib/eliom_request.client.ml
@@ -143,6 +143,13 @@ let send
       | None -> (* decoding failed: it is a relative link *)
         Some Url.Current.host
     in
+    let host =
+      match host with
+      | Some host when host = Url.Current.host ->
+        Some (Eliom_process.get_info ()).Eliom_common.cpi_hostname
+      | _ ->
+        host
+    in
     let cookies = Eliommod_cookies.get_cookies_to_send host https path in
     let headers = match cookies with
       | [] -> []


### PR DESCRIPTION
Partially reverts #488 (its `<base>` part).

The host manipulation in `Eliom_request` is an effort to generate `X-Eliom-Process-Cookies` correctly even if we access the app via an alternate hostname (i.e., one other than the server's default as per
the configuration file). Using the default hostname for `<base>` was meant as a workaround for the same issue.