### PR TITLE
Propagate preapp params in Eliom_service.attach

### DIFF
--- a/src/lib/eliom_service.server.ml
+++ b/src/lib/eliom_service.server.ml
@@ -271,6 +271,7 @@ let attach :
       service with
       service_mark = service_mark ();
       kind = `AttachedCoservice;
+      pre_applied_parameters = fallback.pre_applied_parameters;
       info = Attached {fallbackkind with get_name ; post_name }
     }
 


### PR DESCRIPTION
Consider the following services:

```ocaml
let get_service =
  Eliom_service.create
    ~path:(Eliom_service.Path ["share"])
    ~meth:(Eliom_service.Get Eliom_parameter.(string "g"))
    ()                                                 

let preapplied_service = Eliom_service.preapply get_service "g"

let nonatt_service =
  Eliom_service.create
    ~name:"action_link"
    ~path:Eliom_service.No_path
    ~meth:(Eliom_service.Get (Eliom_parameter.string "h"))
    ()

let attached_na_service =
  Eliom_service.attach
    ~fallback:preapplied_service
    ~service:nonatt_service
    ()
```

The following URL is wrong:

```ocaml
Eliom_uri.make_string_uri
  ~hostname:"canonical"
  ~absolute:true
  ~service:attached_na_service "h"
```

It doesn't contain the GET parameter `g`.

The fix is trivial. We need it for sending custom activation links in Be Sport.