### PR TITLE
Store dom elements,  memorize scroll position and add page transition animation

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -490,7 +490,7 @@ let set_reload_function f = reload_function := Some f
 
 let history_doms = ref []
 
-let set_history_dom () = 
+let push_history_dom () = 
   let d = Dom_html.document##.documentElement in
   let id = snd !current_state_id in
   history_doms :=

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -225,14 +225,14 @@ val onload : (unit -> unit) -> unit
 val lwt_onload : unit -> unit Lwt.t
 
 
-(** [Onchangepage_event] is a record of some parameters related to
+(** [changepage_event] is a record of some parameters related to
     page changes. [in_cache] is true if the dom of the page is cached.
     [current_uri] is the uri of the current page and [target_uri] 
     is the uri of the next page. [current_id] is the state_id of
     the current page and [target_id] is the state_id of the next page.
     [target_id] is not [None] if and only if the onchangepage event
     takes place during a navigation in history. *)
-type onchangepage_event = 
+type changepage_event = 
   {in_cache:bool; 
    current_uri:string; 
    target_uri:string; 
@@ -244,7 +244,7 @@ type onchangepage_event =
 
     Just like onpreload, handlers registered with onchangepage only
     apply to the next page change. *)
-val onchangepage : (onchangepage_event -> unit Lwt.t) -> unit
+val onchangepage : (changepage_event -> unit Lwt.t) -> unit
 
 (** [onbeforeunload f] registers [f] as a handler to be called before
     changing the page the next time. If [f] returns [Some s], then we

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -315,6 +315,11 @@ val init : unit -> unit
 
 val set_reload_function : (unit -> unit -> unit Lwt.t) -> unit
 
+(** Stock the dom of the current page, which will be used when going 
+    back to this page through [window.history.back]
+*)
+val set_history_dom : unit -> unit
+
 (** Lwt_log section for this module.
     Default level is [Lwt_log.Info].
     Use [Lwt_log.Section.set_level Eliom_client.log_section Lwt_log.Debug]

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -318,7 +318,7 @@ val set_reload_function : (unit -> unit -> unit Lwt.t) -> unit
 (** Stock the document/body of the current page, which will be used when going 
     back to this page in history. 
     A typical use case of this function is stocking the dom when leaving 
-    a page. i.e. [Eliom_client.onunload( Eliom_client.push_history_dom )]
+    a page. i.e. [Eliom_client.onchangepage Eliom_client.push_history_dom ]
 *)
 val push_history_dom :  unit -> unit 
 
@@ -327,10 +327,12 @@ val push_history_dom :  unit -> unit
     to list page, we need usually a parameter (e.g. a screenshot of the list 
     page) to realize the animation of page transition and the parameter is 
     generally created just before we leave the list page in order to stock the
-    latest information (such as the scroll position). In the normal case, to 
-    do this, we register an onchangepage handler in the beginning of the service 
+    latest information (such as the scroll position). Normally, to do this, we 
+    register an onchangepage handler in the beginning of the handler of the service 
     that generates the list page. However, when we reload the list page by replacing 
     the current document/body with the one stocked in cache, the handler will be lost.
+    So we need a specific function to re-register the handler everytime the list
+    page is reloaded from cache.    
 
     Suppose also that we have a hashtable which maps a state_id into a parameter 
     (e.g. a screenshot) corresponding to the page characterized by the state_id. 

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -316,9 +316,11 @@ val init : unit -> unit
 val set_reload_function : (unit -> unit -> unit Lwt.t) -> unit
 
 (** Stock the dom of the current page, which will be used when going 
-    back to this page through [window.history.back]
+    back to this page in history. 
+    A typical use case of this function is stocking the dom when leaving 
+    a page. i.e. [Eliom_client.onunload( Eliom_client.push_history_dom )]
 *)
-val set_history_dom : unit -> unit
+val push_history_dom : unit -> unit
 
 (** Lwt_log section for this module.
     Default level is [Lwt_log.Info].

--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -53,7 +53,7 @@ let create_buffer () =
 
 let run_callbacks handlers = List.iter (fun f -> f ()) handlers
 
-type onchangepage_event = 
+type changepage_event = 
   {in_cache:bool; 
    current_uri:string; 
    target_uri:string; 
@@ -61,12 +61,7 @@ type onchangepage_event =
    target_id:int option}
 
 let run_onchangepage_callbacks ev handlers =
-  let rec aux = function
-  | [] -> Lwt.return_unit
-  | h :: s ->
-    let%lwt () = h ev
-    in aux s
-  in aux handlers
+  Lwt_list.iter_s (fun h -> h ev) handlers
 
 let (onload, _, flush_onload, push_onload) :
   ((unit -> unit) -> unit) *
@@ -77,9 +72,9 @@ let (onload, _, flush_onload, push_onload) :
   create_buffer ()
 
 let
-  (onchangepage : (onchangepage_event -> unit Lwt.t) -> unit),
+  (onchangepage : (changepage_event -> unit Lwt.t) -> unit),
   _,
-  (flush_onchangepage : unit -> (onchangepage_event -> unit Lwt.t) list),
+  (flush_onchangepage : unit -> (changepage_event -> unit Lwt.t) list),
   _
   = create_buffer ()
 

--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -53,6 +53,12 @@ let create_buffer () =
 
 let run_callbacks handlers = List.iter (fun f -> f ()) handlers
 
+type onchangepage_event = 
+  {back:bool; current_uri:string; target_uri:string}
+
+let run_onchangepage_callbacks onchangepage_event handlers =
+  List.iter (fun f -> f onchangepage_event) handlers
+
 let (onload, _, flush_onload, push_onload) :
   ((unit -> unit) -> unit) *
   (unit -> (unit -> unit) list) *
@@ -62,9 +68,9 @@ let (onload, _, flush_onload, push_onload) :
   create_buffer ()
 
 let
-  (onchangepage : (unit -> unit) -> unit),
+  (onchangepage : (onchangepage_event -> unit) -> unit),
   _,
-  (flush_onchangepage : unit -> (unit -> unit) list),
+  (flush_onchangepage : unit -> (onchangepage_event -> unit) list),
   _
   = create_buffer ()
 


### PR DESCRIPTION
I add a list `history_doms` in Eliom_client. By adding dom elements into the list, one can read it from the storage when going back in history. In this way, we avoid reloading the page and make the memorization of the scroll position possible. 

I add also two functions `history_changepage_handler` and `animation_function` in Eliom_client, by customizing these two functions, we can realize the page transition animation when navigating back in history. 