### PR TITLE
change current_state_id after page change 

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -1212,6 +1212,7 @@ let () =
               try
                 if fst state_id <> session_id then raise Not_found;
                 let rf = List.assq (snd state_id) !reload_functions in
+                current_state_id := state_id;
                 reload_function := Some rf;
                 let%lwt () = 
                   run_onchangepage_callbacks ev (flush_onchangepage ()) in


### PR DESCRIPTION
Change current_state_id after page change when navigating through history so that the order of page change and state change will be consistent with other processes of changepage.  