### PR TITLE
Eliom_client.make_uri produces full URL

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -810,19 +810,31 @@ let update_session_info all_get_params all_post_params =
 
 let make_uri subpath params =
   let base =
-    match subpath with
-    | _ :: _ ->
-      String.concat "/" subpath
-    | [] ->
-      "/"
+    if is_client_app () then
+      match subpath with
+      | _ :: _ ->
+        String.concat "/" subpath
+      | [] ->
+        "/"
+    else
+      let path =
+        match subpath with
+        | _ :: _ ->
+          String.concat "/" subpath
+        | [] ->
+          ""
+      and port =
+        match Url.Current.port with
+        | Some port ->
+          Printf.sprintf ":%d" port
+        | None ->
+          ""
+      in
+      Printf.sprintf "%s//%s%s/%s"
+        Url.Current.protocol Url.Current.host
+        port path
   and params = List.map (fun (s, s') -> s, `String (Js.string s')) params in
-  match
-    Eliom_uri.make_string_uri_from_components (base, params, None)
-  with
-  | "" ->
-    "/"
-  | s ->
-    s
+  Eliom_uri.make_string_uri_from_components (base, params, None)
 
 let follow_up = ref None
 

--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -474,17 +474,17 @@ let set_reload_function f = reload_function := Some f
 
 let history_doms = ref []
 
-let push_history_dom () = 
+let push_history_dom () =
   let id = snd !current_state_id in
-  let d = 
-    if !only_replace_body 
-    then Dom_html.document##.body 
+  let d =
+    if !only_replace_body
+    then Dom_html.document##.body
     else Dom_html.document##.documentElement in
   history_doms :=
     (id, d) ::
     (List.filter (fun (id', _) -> id <> id') !history_doms)
 
-let is_in_cache state_id = 
+let is_in_cache state_id =
   fst state_id = session_id &&
   List.mem_assoc (snd state_id) !history_doms
 
@@ -513,7 +513,7 @@ let change_url_string ~replace uri =
     else begin
       update_state();
       let state_id = next_state_id () in
-      history_doms := 
+      history_doms :=
         List.filter (fun (id, _) -> id <= snd !current_state_id)
           !history_doms;
       reload_functions :=
@@ -673,12 +673,12 @@ let set_content_local ?offset ?fragment new_page =
 let set_content ~replace ?uri ?offset ?fragment ?state_id content =
   Lwt_log.ign_debug ~section "Set content";
   (* TODO: too early? *)
-  let target_uri = 
+  let target_uri =
     match uri with
-    | None -> !current_uri 
+    | None -> !current_uri
     | Some uri -> uri in
   let%lwt () =
-    run_onchangepage_callbacks 
+    run_onchangepage_callbacks
       { in_cache = is_in_cache !current_state_id;
         current_uri = !current_uri;
         target_uri;
@@ -695,9 +695,9 @@ let set_content ~replace ?uri ?offset ?fragment ?state_id content =
       Eliom_lib.Option.iter (set_uri ~replace ?fragment) uri;
       (* update current_state_id after calling onchangepage handlers
          of the current page and before calling onload handlers of the
-         next page. state_id is not [None] when [set_content] is 
+         next page. state_id is not [None] when [set_content] is
          called from [goto_uri]. *)
-      Eliom_lib.Option.iter 
+      Eliom_lib.Option.iter
         (fun state_id -> current_state_id := state_id) state_id;
       (* Convert the DOM nodes from XML elements to HTML elements. *)
       let fake_page =
@@ -972,8 +972,8 @@ let change_page (type m)
            in
            let l = ocamlify_params l in
            update_session_info l l';
-           let%lwt () = 
-             run_onchangepage_callbacks 
+           let%lwt () =
+             run_onchangepage_callbacks
                {in_cache = is_in_cache !current_state_id;
                 current_uri = !current_uri;
                 target_uri = uri;
@@ -1164,16 +1164,16 @@ let _ =
 
 (* == Navigating through the history... *)
 
-(* Given a state_id, [replace_page_in_history] returns a replace function. 
+(* Given a state_id, [replace_page_in_history] returns a replace function.
    The current page will be replaced by the page associated with the state_id
    when the replace function is called *)
 let replace_page_from_cache id =
   let d = List.assq id !history_doms in
-  if !only_replace_body 
+  if !only_replace_body
   then Dom.replaceChild
     Dom_html.document##.documentElement d  Dom_html.document##.body
   else Dom.replaceChild
-    Dom_html.document d Dom_html.document##.documentElement 
+    Dom_html.document d Dom_html.document##.documentElement
 
 let () =
 
@@ -1184,9 +1184,9 @@ let () =
       let state = get_state state_id in
       let current_id = snd !current_state_id in
       let target_id = snd state_id in
-      let ev = 
-        {in_cache = is_in_cache !current_state_id; 
-         current_uri = !current_uri; 
+      let ev =
+        {in_cache = is_in_cache !current_state_id;
+         current_uri = !current_uri;
          target_uri = full_uri;
          current_id;
          target_id = Some target_id } in
@@ -1203,7 +1203,7 @@ let () =
               Eliom_request_info.set_current_path uri;
               try
                 if not (is_in_cache state_id) then raise Not_found;
-                let%lwt () = 
+                let%lwt () =
                   run_onchangepage_callbacks ev (flush_onchangepage ()) in
                 current_state_id := state_id;
                 replace_page_from_cache target_id;
@@ -1214,10 +1214,10 @@ let () =
                 scroll_to_fragment ~offset:state.position fragment;
                 (* When we use iPhone, we need to wait for one more
                    [request_animation_frame] before scrolling.The
-                   function [scroll_to_fragment] is called twice. In 
-                   other words, we want to call [scroll_to_fragment] 
-                   as early as possible so that the scroll position 
-                   will not jump after the second [request_animation_frame] 
+                   function [scroll_to_fragment] is called twice. In
+                   other words, we want to call [scroll_to_fragment]
+                   as early as possible so that the scroll position
+                   will not jump after the second [request_animation_frame]
                    if the dom has already be painted after the first one. *)
                 Lwt.return_unit
               with Not_found ->
@@ -1225,7 +1225,7 @@ let () =
                 if fst state_id <> session_id then raise Not_found;
                 let rf = List.assq (snd state_id) !reload_functions in
                 reload_function := Some rf;
-                let%lwt () = 
+                let%lwt () =
                   run_onchangepage_callbacks ev (flush_onchangepage ()) in
                 current_state_id := state_id;
                 rf () () >>
@@ -1249,8 +1249,8 @@ let () =
                     Eliom_request.xml_result in
                 let%lwt () =
                   set_content
-                    ~replace:false 
-                    ~offset:state.position 
+                    ~replace:false
+                    ~offset:state.position
                     ?fragment ~state_id content in
                 Lwt.return_unit
             end else


### PR DESCRIPTION
Previously (under specific circumstances), we would interpret the incomplete URL as relative to the current (via `Eliom_lib.Url.resolve`), and that would cause trouble.