### PR TITLE
Update example of basic menus using Eliom_tools

### DIFF
--- a/doc/manual-wiki/misc.wiki
+++ b/doc/manual-wiki/misc.wiki
@@ -28,9 +28,8 @@ The function <<a_api | value Eliom_content.Html.D.make_uri>>
 
 
 
-To simplify the creation of <<span class="code"|<link>>> tags
-      for CSS or <<span class="code"|<script>>> tags for Javascript,
-        use the following functions:
+To simplify the creation of {{{<link>}}} tags for CSS or {{{<script>}}}
+        tags for Javascript, use the following functions:
 
 
 
@@ -47,55 +46,62 @@ To simplify the creation of <<span class="code"|<link>>> tags
 
 ===@@id="basic_menu"@@Basic menus
 
+To generate a context-aware menu on your Web page, you can use the function
+<<a_api| val Eliom_tools.HTML5_TOOLS.menu>>. This function can be used from
+either of the modules {{{Eliom_tools.Html.D}}} or {{{Eliom_tools.Html.F}}}.
+(See <<a_manual chapter="clientserver-html" fragment="unique"|
+HTML element manipulation, by value and by reference>>).
 
-      To build a menu on your Web page, you can use the function
-          <<a_api| val Eliom_tools.menu >>.
-      First, define your menu like this:
+Here is a simple example:
 
-
-
-
-<<code language="ocaml"|let mymenu current =
-  Eliom_tools.menu ~classe:["menuprincipal"]
-    (home, %:xmllist< Home ~>>)
-    [
-     (infos, %:xmllist< More info ~>>);
-     (tutorial, %:xmllist< Documentation ~>>)
-   ] current
+<<code language="ocaml"|let mymenu =
+  let items =
+    [(home,     [pcdata "Home"]);
+     (info,     [pcdata "More info"]);
+     (tutorial, [pcdata "Documentation"])]
+  in
+    Eliom_tools.D.menu
+    ~classe:["menuprincipal"]
+    items
+    ~service:Eliom_service.reload_action
 >>
 
+{{{items}}} is a list of pairs correlating the services to be linked with the
+text to be displayed: {{{home}}}, {{{info}}}, and {{{tutorial}}} are our three
+services (generated, for example, by <<a_api| val Eliom_registration.App.create>>
+or <<a_api| val Eliom_service.create>>).
 
-Here, <<span class="code"|home>>,  <<span class="code"|infos>>,
-        and <<span class="code"|tutorial>> are your three pages (generated for example
-        by  <<a_api| val Eliom_service.App.create >>).
+The argument to the optional parameter {{{classe}}} adds the class
+{{{menuprincipal}}} to the resulting menu element.
 
+The argument to the optional parameter {{{service}}} determines which menu item
+to highlight. In this case, we use <<a_api| val Eliom_service.reload_action>> to
+highlight whichever service is currently being visited.
 
+{{{mymenu ()}}}, when viewed on the home page, will generate the following HTML:
 
-
-
-
-Then <<span class="code"|mymenu ~service:home>> will generate the following
-        code:
-
-
-          <<div class="pre"|<ul class="menu menuprincipal">
-  <li class="current first">Home
+<<code langauge="html"|<ul class="eliomtools_menu menuprincipal caml_r" data-eliom-id="x1TqwAXRlB1I">
+  <li class="eliomtools_current eliomtools_first">
+    Home
   </li>
-  <li><a href="infos">More info</a>
+  <li>
+    <a class="caml_c" href="info/" data-eliom-c-onclick="P7IUw76wowL1">
+      More info
+    </a>
   </li>
-  <li class="last"><a href="tutorial">Documentation</a>
+  <li class="eliomtools_last">
+    <a class="caml_c" href="tutorial/" data-eliom-c-onclick="P7IUw76wowL2">
+      Documentation
+    </a>
   </li>
 </ul>
 >>
 
-Personalize it in your CSS stylesheet.
+You may then personalize the element in your CSS stylesheet as normal.
 
-
-
- <<a_api| val Eliom_tools.menu >> takes a list of services without
-    GET parameters.
-    If you want one of the links to contain GET parameters, pre-apply
-    the service.
+Note: <<a_api| val Eliom_tools.D.menu>> takes a list of services without GET
+parameters. If you want one of the links to contain GET parameters, pre-apply
+the service.
 
 ===@@id="hier_menu"@@Hierarchical menus
 


### PR DESCRIPTION
This updates the example for using the `menu` function provided by `Eliom_tools` in the manual. The manual's example was apparently out of date with the code and the generated api docs. 

While updating the example and making the necessary changes, I took the liberty of making a few additions:

- Some slight tweaks to the language.
- Added some additional information to explain the optional parameters.
- Added a cross-reference to the documentation on "HTML element manipulation, by value and by reference", since a choice must now be made between using `Html_tools.F.menu` and `Html_tools.D.menu`.
- The current wiki markup is not generating inline code that is rendered correctly, so I changed the class attribute to inline code on this page to match the `teletype` class used on some other pages I consulted.

Any correction or guidance will be much appreciated.