### PR TITLE
Improvement of service client functions

### DIFF
--- a/src/lib/eliom_content.eliom
+++ b/src/lib/eliom_content.eliom
@@ -88,7 +88,7 @@ end
 
 ]
 
-let%shared set_client_fun = Eliom_service.set_client_fun
+let%client set_client_fun = Eliom_service.set_client_fun
 
 let%client wrap_client_fun f get_params post_params =
   let%lwt content = f get_params post_params in

--- a/src/lib/eliom_content.server.mli
+++ b/src/lib/eliom_content.server.mli
@@ -482,11 +482,3 @@ module Html : sig
      and type doc := F.doc
 
 end
-
-(**/**)
-
-val set_client_fun :
-  ?app:string ->
-  service:('a, 'b, _, _, _, _, _, _, _, _, _) Eliom_service.t ->
-  ('a -> 'b -> unit Lwt.t) Eliom_client_value.t ->
-  unit

--- a/src/lib/eliom_service.client.ml
+++ b/src/lib/eliom_service.client.ml
@@ -30,7 +30,20 @@ let xhr_with_cookies s =
       None
     | XSame_appl (_, tmpl) -> Some tmpl
 
+let client_fun service =
+  match service.client_fun with
+  | Some f -> !f
+  | None   -> assert false
+
 let has_client_fun service = client_fun service <> None
+
+let set_client_fun ?app ~service f =
+  Eliom_lib.Option.iter
+    (fun name -> service.send_appl_content <- XSame_appl (name, None))
+    app;
+  match service.client_fun with
+  | Some r -> r := Some f
+  | None   -> assert false
 
 let reload_fun :
   type gp pp .
@@ -40,7 +53,8 @@ let reload_fun :
     match Eliom_parameter.is_unit (post_params_type service) with
     | Eliom_parameter.U_yes ->
       (match service with
-       | { client_fun = Some f ; reload_fun = Rf_client_fun } ->
+       | { client_fun = Some {contents = Some f} ;
+           reload_fun = Rf_client_fun } ->
          Some f
        | _ ->
          None)

--- a/src/lib/eliom_service.client.mli
+++ b/src/lib/eliom_service.client.mli
@@ -28,6 +28,12 @@
 
 include Eliom_service_sigs.S
 
+val set_client_fun :
+  ?app:string ->
+  service:('a, 'b, _, _, _, _, _, _, _, _, _) t ->
+  ('a -> 'b -> unit Lwt.t) ->
+  unit
+
 (**/**)
 
 val reset_reload_fun : (_, _, _, _, _, _, _, _, _, _, _) t -> unit

--- a/src/lib/eliom_service.server.ml
+++ b/src/lib/eliom_service.server.ml
@@ -127,7 +127,7 @@ let create_attached
       (match keep_nl_params with
        | None -> fallback.keep_nl_params
        | Some k -> k);
-    client_fun = None;
+    client_fun = no_client_fun ();
     reload_fun = Rf_client_fun
   }
 
@@ -199,7 +199,7 @@ let coservice'
     keep_nl_params;
     send_appl_content = XNever;
     service_mark = service_mark ();
-    client_fun = None;
+    client_fun = no_client_fun ();
     reload_fun = Rf_client_fun
   }
 
@@ -409,5 +409,7 @@ let unregister ?scope ?secure
         !(Eliom_state.get_session_service_table ~sp ?secure ~scope ())
       in
       remove_service table service
+
+let client_fun _ = None
 
 let has_client_fun _ = false

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -135,7 +135,11 @@ type ('get, 'post, 'meth, 'attached, 'co, 'ext, 'reg,
   (* If the service has a client-side implementation, we put the
      generating function here: *)
   mutable client_fun :
-    ('get -> 'post -> unit Lwt.t) Eliom_client_value.t option;
+    ('get -> 'post -> unit Lwt.t) option ref Eliom_client_value.t option;
+  (* The function is in a client-side reference, so that it is shared
+     by all occurrences of the service sent from the server.
+     For some service, we cannot create the client value immediately;
+     this is done later on using [internal_set_client_fun].  *)
 
   mutable reload_fun : reload_fun;
 
@@ -172,15 +176,12 @@ let max_use s = s.max_use
 let timeout s = s.timeout
 let https s = s.https
 let priority s = s.priority
-let client_fun {client_fun} = client_fun
 
-let internal_set_client_fun ~service f = service.client_fun <- Some f
+let internal_set_client_fun ~service f =
+  service.client_fun <- Some [%client ref (Some ~%f)]
 
-let set_client_fun ?app ~service f =
-  Eliom_lib.Option.iter
-    (fun name -> service.send_appl_content <- XSame_appl (name, None))
-    app;
-  service.client_fun <- Some f
+let no_client_fun () : _ ref Eliom_client_value.t option =
+  Some [%client ref None]
 
 let is_external = function {kind = `External} -> true | _ -> false
 
@@ -219,7 +220,7 @@ let static_dir_ ?(https = false) () = {
   keep_nl_params = `None;
   service_mark = service_mark ();
   send_appl_content = XNever;
-  client_fun = None;
+  client_fun = Some [%client ref None];
   reload_fun = Rf_client_fun
 }
 
@@ -253,7 +254,7 @@ let get_static_dir_ ?(https = false)
   keep_nl_params;
   service_mark = service_mark ();
   send_appl_content = XNever;
-  client_fun = None;
+  client_fun = Some [%client ref None];
   reload_fun = Rf_client_fun
 }
 
@@ -319,11 +320,12 @@ let preapply ~service getparams =
            };
        | k -> k);
     client_fun =
-      match service.client_fun with
-      | Some f ->
-        Some  [%client fun () pp -> (~%f : _ -> _ -> _) ~%getparams pp ]
-      | None ->
-        None
+      Some
+        [%client ref
+            (match ~%service.client_fun with
+             | Some {contents = Some f} -> Some (fun () pp -> f ~%getparams pp)
+             | _ -> None)
+        ]
   }
 
 let reload_action_aux https = {
@@ -375,9 +377,12 @@ let add_non_localized_get_parameters ~params ~service = {
   get_params_type =
     Eliom_parameter.nl_prod service.get_params_type params;
   client_fun =
-    match service.client_fun with
-    | None -> None
-    | Some f -> Some [%client fun (g, _) p -> (~%f : _ -> _ -> _) g p ]
+    Some
+    [%client
+       ref
+         (match ~%service.client_fun with
+          | Some {contents = Some f} -> Some (fun (g, _) p -> f g p)
+          | _ -> None)]
 }
 
 let add_non_localized_post_parameters ~params ~service = {
@@ -385,9 +390,12 @@ let add_non_localized_post_parameters ~params ~service = {
   post_params_type =
     Eliom_parameter.nl_prod service.post_params_type params;
   client_fun =
-    match service.client_fun with
-    | None -> None
-    | Some f -> Some [%client fun g (p, _) -> (~%f : _ -> _ -> _) g p ]
+    Some
+    [%client
+      ref
+        (match ~%service.client_fun with
+         | Some {contents = Some f} -> Some (fun g (p, _) -> f g p)
+         | _ -> None)]
 }
 
 let keep_nl_params s = s.keep_nl_params
@@ -449,8 +457,7 @@ let main_service
     ?(keep_nl_params = `None)
     ?(priority = default_priority)
     ~get_params
-    (type pp) ~(post_params : (pp, _, _) Eliom_parameter.params_type)
-    ?(client_fun : (_ -> pp -> unit Lwt.t) Eliom_client_value.t option)
+    ~post_params
     ~reload_fun
     () = {
   pre_applied_parameters = Eliom_lib.String.Table.empty, [];
@@ -473,16 +480,15 @@ let main_service
   keep_nl_params;
   service_mark = service_mark ();
   send_appl_content = XNever;
-  client_fun;
+  client_fun = Some [%client ref None];
   reload_fun;
 }
 
 let extern
-    (type m) (type gp) (type gn) (type pp) (type pn) (type gp')
     ?keep_nl_params
     ~prefix
     ~path
-    ~(meth : (m, gp, gn, pp, pn, _, gp') meth)
+    ~meth
     () =
   let get_params, post_params = params_of_meth meth in
   let suffix = Eliom_parameter.contains_suffix get_params in

--- a/src/lib/eliom_service_sigs.shared.mli
+++ b/src/lib/eliom_service_sigs.shared.mli
@@ -381,12 +381,6 @@ module type S = sig
   val xhr_with_cookies :
     (_, _, _, _, _, _, _, _, _, _, _) t -> string option option
 
-  val set_client_fun :
-    ?app:string ->
-    service:('a, 'b, _, _, _, _, _, _, _, _, _) t ->
-    ('a -> 'b -> unit Lwt.t) Eliom_client_value.t ->
-    unit
-
   val internal_set_client_fun :
     service : ('a, 'b, _, _, _, _, _, _, _, _, _) t ->
     ('a -> 'b -> unit Lwt.t) Eliom_client_value.t ->


### PR DESCRIPTION
Put client functions in a client-side reference. So, several instances of a same service sent from the server to the client will always share the same client function.