### PR TITLE
Add configuration file options to load the application script asynchronously

### DIFF
--- a/doc/manual-wiki/workflow-configuration.wiki
+++ b/doc/manual-wiki/workflow-configuration.wiki
@@ -385,6 +385,17 @@ The syntax is:
 * {{{<ipv4subnetmask value="255.255.128.0"/>}}}
 * {{{<ipv6subnetmask value="ff:ff:ff:ff:ff:ff::"/>}}}
 
+=== Application script attributes
+
+One can choose to set the {{{defer}}} or {{{async}}} attributes of the
+script element referencing the application code, so that HTML
+rendering is not blocked while the script is downloaded.
+
+The syntax is:
+* {{{<applicationscript defer="true" async="false"/>}}}
+
+Both attributes are optional and default to {{{false}}}.
+
 ==Per site configuration options
 
 === Disabling XHR-links

--- a/src/lib/eliom_common.server.ml
+++ b/src/lib/eliom_common.server.ml
@@ -481,6 +481,7 @@ and sitedata =
    dlist_ip_table : dlist_ip_table;
    mutable ipv4mask : int option * bool;
    mutable ipv6mask : int option * bool;
+   mutable application_script : bool (* defer *) * bool; (* async *)
  }
 
 and dlist_ip_table = (page_table ref * page_table_key, na_key_serv)

--- a/src/lib/eliom_common.server.mli
+++ b/src/lib/eliom_common.server.mli
@@ -547,6 +547,7 @@ and sitedata = {
   dlist_ip_table : dlist_ip_table;
   mutable ipv4mask : int option * bool;
   mutable ipv6mask : int option * bool;
+  mutable application_script : bool (* defer *) * bool; (* async *)
 }
 
 type 'a lazy_site_value (** lazy site values, are lazy values with

--- a/src/lib/eliom_registration.server.ml
+++ b/src/lib/eliom_registration.server.ml
@@ -1209,7 +1209,11 @@ module Eliom_appl_reg_make_param
 
   let eliom_appl_script_id : [ `Script ] Eliom_content.Html.Id.id =
     Eliom_content.Html.Id.new_elt_id ~global:true ()
-  let application_script ?(defer = false) ?(async = false) () =
+  let application_script ?defer ?async () =
+    let (defer', async') =
+      (Eliom_request_info.get_sitedata ()).Eliom_common.application_script in
+    let defer = match defer with Some b -> b | None -> defer' in
+    let async = match async with Some b -> b | None -> async' in
     let a =
       (if defer then [Eliom_content.Html.D.a_defer ()] else [])
         @


### PR DESCRIPTION
We could already achieve this by including the application script element explicitly, but this is simpler this way.

Also, we can use the same `defer` settings for global data (#529).