### PR TITLE
History handling: fix template serialization

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -1265,10 +1265,7 @@ let () =
          target_uri = full_uri;
          origin_id = !active_page.page_id.state_index;
          target_id = Some target_id } in
-      let tmpl = (if state.template = Js.string ""
-                  then None
-                  else Some (Js.to_string state.template))
-      in
+      let tmpl = state.template in
       Lwt.ignore_result @@
         with_progress_cursor @@
           let uri, fragment = Url.split_fragment full_uri in

--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -665,7 +665,7 @@ let rec rebuild_rattrib node ra = match Xml.racontent ra with
 
 type state =
   (* TODO store cookies_info in state... *)
-  { template : Js.js_string Js.t;
+  { template : string option;
     position : Eliommod_dom.position;
   }
 
@@ -781,10 +781,7 @@ let set_state i (v:state) =
     (fun s -> s##(setItem (state_key i) (Json.output v)))
 let update_state () =
   set_state !active_page.page_id
-    { template =
-        (match Eliom_request_info.get_request_template () with
-         | Some tmpl -> Js.bytestring tmpl
-         | None -> Js.string  "");
+    { template = Eliom_request_info.get_request_template ();
       position = Eliommod_dom.getDocumentScroll () }
 
 (* TODO: Registering a global "onunload" event handler breaks the


### PR DESCRIPTION
Json.unsafe_input convert JavaScript strings to OCaml strings, so it is incorrect to store the template as a JavaScript string in the state.