### PR TITLE
caml_bytes_of_string -> caml_jsbytes_of_string.

### DIFF
--- a/src/lib/client/eliom_client.js
+++ b/src/lib/client/eliom_client.js
@@ -3,9 +3,9 @@
 //Provides: caml_unwrap_value_from_string mutable
 //Requires: caml_failwith, caml_marshal_constants
 //Requires: caml_int64_float_of_bits, caml_int64_of_bytes, caml_new_string
-//Requires: caml_bytes_of_string
+//Requires: caml_jsbytes_of_string
 var caml_unwrap_value_from_string = function (){
-  function StringReader (s, i) { this.s = caml_bytes_of_string(s); this.i = i; }
+  function StringReader (s, i) { this.s = caml_jsbytes_of_string(s); this.i = i; }
   StringReader.prototype = {
     read8u:function () { return this.s.charCodeAt(this.i++); },
     read8s:function () { return this.s.charCodeAt(this.i++) << 24 >> 24; },


### PR DESCRIPTION
Compile with js_of_ocaml master branch. Eventually, this will be needed, but probably not now.

Credits go to @vouillon 