### PR TITLE
Client-side non-localized parameters

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -920,7 +920,11 @@ let route ~replace ?(keep_url = false)
     if not keep_url then
       change_url_string ~replace (make_uri i_subpath i_get_params);
     update_session_info i_get_params (Some i_post_params);
-    Eliom_route.call_service info
+    Eliom_route.call_service
+      { info with
+        Eliom_route.i_get_params =
+          Eliom_common.(remove_prefixed_param nl_param_prefix)
+            i_get_params }
   with e ->
     Eliom_request_info.get_sess_info := r;
     Lwt.fail e

--- a/src/lib/eliom_parameter.client.ml
+++ b/src/lib/eliom_parameter.client.ml
@@ -153,3 +153,20 @@ let all_suffix_user ~of_string ~to_string n =
 let reconstruct_params_form l y =
   reconstruct_params_form (M.of_assoc_list l) y >>= fun (v, _) ->
   Some v
+
+let get_non_localized_get_parameters { name ; param } =
+  (* Simplified version of the server-side code that
+     - only deals with GET params
+     - doesn't cache the result
+     - doesn't deal with files *)
+  try
+    Some
+      (reconstruct_params_ param
+         (try
+            Eliom_lib.String.Table.find name
+              ((!Eliom_request_info.get_sess_info ()).si_nl_get_params)
+          with Not_found ->
+            [])
+         [] false None)
+  with Eliom_common.Eliom_Wrong_parameter | Not_found ->
+    None

--- a/src/lib/eliom_parameter.client.mli
+++ b/src/lib/eliom_parameter.client.mli
@@ -40,3 +40,7 @@ val all_suffix_user :
 
 val reconstruct_params_form :
   (string * Form.form_elt) list -> ('a, _, _) params_type -> 'a option
+
+val get_non_localized_get_parameters :
+  ('a, [ `WithoutSuffix ], 'b) non_localized_params ->
+  'a option

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -80,7 +80,7 @@ let typed_apply ~service f gp pp l l' suffix =
 let wrap service att f _ suffix =
   let gp = Eliom_service. get_params_type service
   and pp = Eliom_service.post_params_type service
-  and l = (!Eliom_request_info.get_sess_info ()).si_all_get_params
+  and l = (!Eliom_request_info.get_sess_info ()).si_all_get_but_nl
   and l' =
     match
       (!Eliom_request_info.get_sess_info ()).si_all_post_params
@@ -117,7 +117,7 @@ let wrap_na
     s <> Eliom_common.naservice_name &&
     s <> Eliom_common.naservice_num
   in
-  let l = filter si.si_all_get_params
+  let l = filter si.si_all_get_but_nl
   and l' =
     match si.si_all_post_params with
     | Some l ->


### PR DESCRIPTION
- Fix client-side routing with NL params (not taken into account)
- Implement `Eliom_parameter.get_non_localized_get_parameters`