### PR TITLE
put upper version boundaries on package dependencies

### DIFF
--- a/opam
+++ b/opam
@@ -13,12 +13,12 @@ depends: [
   "deriving" {>= "0.6"}
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {>= "3.0" < "3.3"}
   "js_of_ocaml-lwt"
   "js_of_ocaml-ocamlbuild" {build}
   "js_of_ocaml-ppx"
   ("js_of_ocaml-ppx" {<= "3.0.2"} | "js_of_ocaml-ppx_deriving_json")
-  "js_of_ocaml-tyxml"
+  "js_of_ocaml-tyxml" {< "3.2.0"}
   "lwt_log"
   "lwt_ppx"
   "lwt_camlp4"


### PR DESCRIPTION
compilation of eliom fails with js_of_ocaml-tyxml.3.2.0
compilation of ocsigen-start fails with js_of_ocaml.3.3.0

I'm looking into fixing these compatibility issues as to be able to lift these
constraints again soon.