### PR TITLE
Solve issue #596

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ BUILD=ocaml pkg/build.ml
 
 .PHONY: all byte opt builder
 all: $(BUILDER)
+ifeq ($(shell uname -o), Cygwin)
+	chmod -R 755 $OPAM_SWITCH_PREFIX/lib/js_of_ocaml-ppx_deriving_json
+endif
 	$(BUILD) manpage=false native=true native-dynlink=true
 byte: $(BUILDER)
 	$(BUILD) manpage=false native=false native-dynlink=false


### PR DESCRIPTION
When trying to link to js_of_ocaml-ppx_deriving_json the error was permission denied so I chmod It if necessary on Cygwin.
patch for https://github.com/ocsigen/eliom/issues/596