### PR TITLE
Improve error logging in OCaml services

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "eliom"
-version: "6.7.0"
+version: "6.7.1"
 maintainer: "dev@ocsigen.org"
 authors: "dev@ocsigen.org"
 synopsis: "Client/server Web framework"

--- a/src/lib/eliom_registration.server.ml
+++ b/src/lib/eliom_registration.server.ml
@@ -989,15 +989,16 @@ module Ocaml = struct
         try%lwt
           let%lwt res = f g p in
           Lwt.return (`Success res)
-          Lwt.return (`Failure (Printexc.to_string exc))
         with exn ->
+          let code = Printf.sprintf "%0x" (Random.int 0x1000000) in
           begin match name with
             | Some name ->
               Lwt_log_core.ign_error_f ~exn
-                "Uncaught exception in service %s" name
+                "Uncaught exception in service %s [%s]" name code
             | None ->
-              Lwt_log_core.ign_error_f ~exn "Uncaught exception"
+              Lwt_log_core.ign_error_f ~exn "Uncaught exception [%s]" code
           end;
+          Lwt.return (`Failure code)
       in
       prepare_data data
 


### PR DESCRIPTION
- output the name of the service, if available
- send a code to the client (which is also logged) instead of the exception, for security reasons