### PR TITLE
Client request fixes

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "eliom"
-version: "6.9.3"
+version: "6.9.4"
 maintainer: "dev@ocsigen.org"
 authors: "dev@ocsigen.org"
 synopsis: "Client/server Web framework"

--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -980,33 +980,6 @@ let route ({ Eliom_route.i_subpath ; i_get_params ; i_post_params } as info) =
     Eliom_request_info.get_sess_info := r;
     Lwt.fail e
 
-let perform_reload () =
-  Lwt_log.ign_debug ~section:section_page "Perform reload";
-  let uri = get_current_uri () in
-  let
-    ({ Eliom_common.si_all_get_params ; si_all_post_params }
-     as i_sess_info) =
-    !Eliom_request_info.get_sess_info ()
-  and i_subpath = Url.path_of_url_string uri in
-  let info = {
-    Eliom_route.i_sess_info ;
-    i_subpath;
-    i_meth = `Get;
-    i_get_params =
-      Eliom_common.remove_na_prefix_params si_all_get_params;
-    i_post_params = []
-  } in
-  (* similar (but simpler) sequence of attempts as server; see
-     server-side [Eliom_registration.Action.send] *)
-  try%lwt
-        Lwt.map snd (route info)
-  with _ ->
-    let info = {info with Eliom_route.i_get_params = []} in
-    try%lwt
-          Lwt.map snd (route info)
-    with _ ->
-      Lwt.return Eliom_service.No_contents
-
 let current_path_and_args () =
   let path_of_string s =
     match Url.path_of_path_string s with
@@ -1043,8 +1016,6 @@ let rec handle_result ~replace ~uri result =
   | Dom d ->
      change_url_string ~replace uri;
      set_content_local d
-  | Reload ->
-     handle_result ~replace ~uri (perform_reload ())
   | Redirect service ->
      change_page ~replace ~service () ()
   | Reload_action {hidden; https} ->

--- a/src/lib/eliom_parameter.client.ml
+++ b/src/lib/eliom_parameter.client.ml
@@ -166,7 +166,7 @@ let get_non_localized_get_parameters { name ; param } =
       (reconstruct_params_ param
          (try
             Eliom_lib.String.Table.find name
-              ((!Eliom_request_info.get_sess_info ()).si_nl_get_params)
+              ((Eliom_request_info.get_sess_info ()).si_nl_get_params)
           with Not_found ->
             [])
          [] false None)

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -220,7 +220,7 @@ module Action = Make (struct
   let send ?options page =
     match options with
     | Some `Reload | None ->
-      Lwt.return Eliom_service.Reload
+      Lwt.return Eliom_service.(Reload_action {hidden = false; https = false})
     | _ ->
       Lwt.return Eliom_service.No_contents
 

--- a/src/lib/eliom_registration.client.ml
+++ b/src/lib/eliom_registration.client.ml
@@ -80,10 +80,10 @@ let typed_apply ~service f gp pp l l' suffix =
 let wrap service att f _ suffix =
   let gp = Eliom_service. get_params_type service
   and pp = Eliom_service.post_params_type service
-  and l = (!Eliom_request_info.get_sess_info ()).si_all_get_but_nl
+  and l = (Eliom_request_info.get_sess_info ()).si_all_get_but_nl
   and l' =
     match
-      (!Eliom_request_info.get_sess_info ()).si_all_post_params
+      (Eliom_request_info.get_sess_info ()).si_all_post_params
     with
     | Some l ->
       l
@@ -111,7 +111,7 @@ let wrap_na
     non_att f _ suffix =
   let gp = Eliom_service.get_params_type service
   and pp = Eliom_service.post_params_type service
-  and si = !Eliom_request_info.get_sess_info ()
+  and si = Eliom_request_info.get_sess_info ()
   and filter l = fst Eliom_common.(split_prefix_param na_co_param_prefix l)
   in
   let l = filter si.si_all_get_but_nl

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -153,7 +153,6 @@ type ('get, 'post, 'meth, 'attached, 'co, 'ext, 'reg,
 and result =
     No_contents
   | Dom of Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
-  | Reload
   | Redirect :
       (unit, unit, get , _, _, _, _,
        [ `WithoutSuffix ], unit, unit, non_ocaml) t -> result

--- a/src/lib/eliom_service_sigs.shared.mli
+++ b/src/lib/eliom_service_sigs.shared.mli
@@ -153,7 +153,6 @@ module type S = sig
   and result =
       No_contents
     | Dom of Js_of_ocaml.Dom_html.element Js_of_ocaml.Js.t
-    | Reload
     | Redirect :
         (unit, unit, get , _, _, _, _,
          [ `WithoutSuffix ], unit, unit, non_ocaml) t -> result


### PR DESCRIPTION
Now that the page location is not updated immediately, we need to properly propagate the URI and the page parameters. In particular, this fixes reloads after a redirect.