### PR TITLE
Support running PPXes from driver.

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -75,15 +75,30 @@ package "ppx" (
   directory = "ppx"
   package "server" (
     description = "Ppx syntax extension: server side"
-    ppx = "ppx_eliom_server"
+    ppx(-ppx_driver,-custom_ppx) = "ppx_eliom_server"
+    archive(ppx_driver,byte) = "ppx_eliom_server.cma"
+    archive(ppx_driver,native) = "ppx_eliom_server.cmxa"
+    plugin(ppx_driver,byte) = "ppx_eliom_server.cma"
+    plugin(ppx_driver,native) = "ppx_eliom_server.cmxs"
+    requires(ppx_driver) = "ocaml-migrate-parsetree ppx_tools_versioned"
   )
   package "client" (
     description = "Ppx syntax extension: client side"
-    ppx = "ppx_eliom_client"
+    ppx(-ppx_driver,-custom_ppx) = "ppx_eliom_client"
+    archive(ppx_driver,byte) = "ppx_eliom_client.cma"
+    archive(ppx_driver,native) = "ppx_eliom_client.cmxa"
+    plugin(ppx_driver,byte) = "ppx_eliom_client.cma"
+    plugin(ppx_driver,native) = "ppx_eliom_client.cmxs"
+    requires(ppx_driver) = "ocaml-migrate-parsetree ppx_tools_versioned"
   )
   package "type" (
     description = "Ppx syntax extension: type inference"
-    ppx = "ppx_eliom_types"
+    ppx(-ppx_driver,-custom_ppx) = "ppx_eliom_types"
+    archive(ppx_driver,byte) = "ppx_eliom_type.cma"
+    archive(ppx_driver,native) = "ppx_eliom_type.cmxa"
+    plugin(ppx_driver,byte) = "ppx_eliom_type.cma"
+    plugin(ppx_driver,native) = "ppx_eliom_type.cmxs"
+    requires(ppx_driver) = "ocaml-migrate-parsetree ppx_tools_versioned"
   )
 )
 

--- a/src/_tags
+++ b/src/_tags
@@ -1,6 +1,7 @@
 <{lib,tools,ocamlbuild}/**/*>:warn(+A-4-6-7-9-27-37-39-40-42-44-48)
 true:keep_locs
 <lib/**/{client,server}*>:linkall
+<ppx/ppx_eliom_{client,server,type}*>:linkall
 
 <lib/type_dir/*.ml{,i}>:eliom_ppx,thread
 <lib/type_dir/*.ml>:package(js_of_ocaml-ppx.deriving,lwt_ppx)

--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -261,3 +261,7 @@ module Pass = struct
 end
 
 include Make(Pass)
+
+let () =
+  Migrate_parsetree.Driver.register ~name:"ppx_eliom_client" ~args:driver_args
+    Migrate_parsetree.Versions.ocaml_408 mapper

--- a/src/ppx/ppx_eliom_client.mli
+++ b/src/ppx/ppx_eliom_client.mli
@@ -1,2 +1,2 @@
-
-val mapper : string list -> Migrate_parsetree.Ast_408.Ast_mapper.mapper
+val mapper :
+  Migrate_parsetree.Versions.OCaml_408.types Migrate_parsetree.Driver.rewriter

--- a/src/ppx/ppx_eliom_client_ex.ml
+++ b/src/ppx/ppx_eliom_client_ex.ml
@@ -1,8 +1,2 @@
-open Migrate_parsetree
-
-let migration =
-  Versions.migrate Versions.ocaml_408 Versions.ocaml_current
-
-let () =
-  Compiler_libs.Ast_mapper.run_main
-    (fun args -> migration.copy_mapper (Ppx_eliom_client.mapper args))
+open Ppx_eliom_client [@@warning "-33"]
+let () = Migrate_parsetree.Driver.run_as_ppx_rewriter ()

--- a/src/ppx/ppx_eliom_server.ml
+++ b/src/ppx/ppx_eliom_server.ml
@@ -218,3 +218,7 @@ module Pass = struct
 end
 
 include Make(Pass)
+
+let () =
+  Migrate_parsetree.Driver.register ~name:"ppx_eliom_server" ~args:driver_args
+    Migrate_parsetree.Versions.ocaml_408 mapper

--- a/src/ppx/ppx_eliom_server.mli
+++ b/src/ppx/ppx_eliom_server.mli
@@ -1,2 +1,2 @@
-
-val mapper : string list -> Migrate_parsetree.Ast_408.Ast_mapper.mapper
+val mapper :
+  Migrate_parsetree.Versions.OCaml_408.types Migrate_parsetree.Driver.rewriter

--- a/src/ppx/ppx_eliom_server_ex.ml
+++ b/src/ppx/ppx_eliom_server_ex.ml
@@ -1,8 +1,2 @@
-open Migrate_parsetree
-
-let migration =
-  Versions.migrate Versions.ocaml_408 Versions.ocaml_current
-
-let () =
-  Compiler_libs.Ast_mapper.run_main
-    (fun args -> migration.copy_mapper (Ppx_eliom_server.mapper args))
+open Ppx_eliom_server [@@warning "-33"]
+let () = Migrate_parsetree.Driver.run_as_ppx_rewriter ()

--- a/src/ppx/ppx_eliom_type.ml
+++ b/src/ppx/ppx_eliom_type.ml
@@ -141,3 +141,7 @@ module Pass = struct
 end
 
 include Make(Pass)
+
+let () =
+  Migrate_parsetree.Driver.register ~name:"ppx_eliom_types" ~args:driver_args
+    Migrate_parsetree.Versions.ocaml_408 mapper

--- a/src/ppx/ppx_eliom_type.mli
+++ b/src/ppx/ppx_eliom_type.mli
@@ -1,2 +1,2 @@
-
-val mapper : string list -> Migrate_parsetree.Ast_408.Ast_mapper.mapper
+val mapper :
+  Migrate_parsetree.Versions.OCaml_408.types Migrate_parsetree.Driver.rewriter

--- a/src/ppx/ppx_eliom_types_ex.ml
+++ b/src/ppx/ppx_eliom_types_ex.ml
@@ -1,8 +1,2 @@
-open Migrate_parsetree
-
-let migration =
-  Versions.migrate Versions.ocaml_408 Versions.ocaml_current
-
-let () =
-  Compiler_libs.Ast_mapper.run_main
-    (fun args -> migration.copy_mapper (Ppx_eliom_type.mapper args))
+open Ppx_eliom_type [@@warning "-33"]
+let () = Migrate_parsetree.Driver.run_as_ppx_rewriter ()

--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -300,12 +300,12 @@ module Context = struct
 end
 
 
-let match_args = function
-  | [ ] -> ()
-  | [ "-type" ; type_file ] -> Mli.type_file := Some type_file
-  | [ "-notype" ] -> Mli.type_file := None
-  | args -> Location.raise_errorf ~loc:Location.(in_file !input_name)
-           "Wrong arguments:@ %s" (String.concat " " args)
+let driver_args = [
+  "-type", Arg.String (fun type_file -> Mli.type_file := Some type_file),
+    "FILE Load inferred types from FILE.";
+  "-notype", Arg.Unit (fun () -> Mli.type_file := None),
+    " Unset explicitly set path from which to load inferred types.";
+]
 
 (** Signature of specific code of a preprocessor. *)
 module type Pass = sig
@@ -678,8 +678,7 @@ module Make (Pass : Pass) = struct
     in
     flatmap f sigs
 
-  let mapper args =
-    let () = match_args args in
+  let mapper _config _cookies =
     let c = ref `Server in
     {AM.default_mapper
      with

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -85,6 +85,9 @@ module type Pass = sig
 
 end
 
+val driver_args : (Arg.key * Arg.spec * Arg.doc) list
+
 module Make (P : Pass) : sig
-  val mapper : string list -> Ast_mapper.mapper
+  val mapper :
+    Migrate_parsetree.Versions.OCaml_408.types Migrate_parsetree.Driver.rewriter
 end


### PR DESCRIPTION
This registers PPXes with the PPX driver and reimplements the command version by invoking the driver.

This will be useful for compiling Eliom projects with dune, esp. once it gets more stable support for generated rules.