### PR TITLE
[template][fix] update deprecated pcdata usage

### DIFF
--- a/pkg/distillery/basic.ppx/PROJECT_NAME.eliom
+++ b/pkg/distillery/basic.ppx/PROJECT_NAME.eliom
@@ -1,15 +1,15 @@
 [%%shared
-    open Eliom_lib
-    open Eliom_content
-    open Html.D
+open Eliom_lib
+open Eliom_content
+open Html.D
 ]
 
 module %%%MODULE_NAME%%%_app =
   Eliom_registration.App (
-    struct
-      let application_name = "%%%PROJECT_NAME%%%"
-      let global_data_path = None
-    end)
+  struct
+    let application_name = "%%%PROJECT_NAME%%%"
+    let global_data_path = None
+  end)
 
 let main_service =
   Eliom_service.create
@@ -21,10 +21,10 @@ let () =
   %%%MODULE_NAME%%%_app.register
     ~service:main_service
     (fun () () ->
-      Lwt.return
-        (Eliom_tools.F.html
-           ~title:"%%%PROJECT_NAME%%%"
-           ~css:[["css";"%%%PROJECT_NAME%%%.css"]]
-           Html.F.(body [
-             h1 [pcdata "Welcome from Eliom's distillery!"];
-           ])))
+       Lwt.return
+         (Eliom_tools.F.html
+            ~title:"%%%PROJECT_NAME%%%"
+            ~css:[["css";"%%%PROJECT_NAME%%%.css"]]
+            Html.F.(body [
+              h1 [txt "Welcome from Eliom's distillery!"];
+            ])))


### PR DESCRIPTION
Distillery basic template is using deprecated `pcdata`