### PR TITLE
[template][doc] fix doc for ocsipersist backend

### DIFF
--- a/pkg/distillery/basic.ppx/Makefile.options
+++ b/pkg/distillery/basic.ppx/Makefile.options
@@ -21,7 +21,7 @@ LOCAL_STATIC = static
 # The backend for persistent data. Can be dbm or sqlite.
 # Make sure you have the following packages installed
 # - *dbm* if you use dbm --> opam install dbm.
-# - *sqlite3* if you use sqlite --> opam install sqlite3.
+# - *sqlite* if you use sqlite --> opam install sqlite3.
 PERSISTENT_DATA_BACKEND = %%%PROJECT_DB%%%
 
 # Debug application (yes/no): Debugging info in compilation,


### PR DESCRIPTION
Using `sqlite3` as documented would put `ocsigenserver.ext.ocsipersist-sqlite3` as a dependency in the config file, which is not a valid ocsigen extension ( see https://github.com/ocsigen/ocsigenserver/blob/master/src/files/META.in#L145 )