### PR TITLE
Support for new Js_of_ocaml string format

### DIFF
--- a/src/lib/client/eliom_client.js
+++ b/src/lib/client/eliom_client.js
@@ -242,7 +242,6 @@ var caml_unwrap_value_from_string = function (){
         v[d] = intern_rec (v, d);
       }
     }
-    s.offset = reader.i;
     if(intern_obj_table[0][0].length != 3)
       caml_failwith ("unwrap_value: incorrect value");
     return intern_obj_table[0][0][2];


### PR DESCRIPTION
We don't use this `offset` attribute