### PR TITLE
Eliom_client: possibility to lock/unlock request deserialisation

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -29,6 +29,9 @@ open Js_of_ocaml
 open Eliom_lib
 module Opt = Eliom_lib.Option
 
+let lock_request_handling = Eliom_request.lock
+let unlock_request_handling = Eliom_request.unlock
+
 type ('a, +'b) server_function = 'a -> 'b Lwt.t
 
 let only_replace_body = ref false

--- a/src/lib/eliom_client.client.mli
+++ b/src/lib/eliom_client.client.mli
@@ -23,6 +23,9 @@
 open Js_of_ocaml
 open Eliom_lib
 
+val lock_request_handling : unit -> unit
+val unlock_request_handling : unit -> unit
+
 (** {2 Mobile applications} *)
 
 (** Call this function if you want to be able to run your client side

--- a/src/lib/eliom_request.client.mli
+++ b/src/lib/eliom_request.client.mli
@@ -34,6 +34,10 @@ type 'a result
 val xml_result : Dom.element Dom.document Js.t result
 val string_result : string result
 
+val locked : bool React.signal
+val lock : unit -> unit
+val unlock : unit -> unit
+
 val send :
   ?with_credentials:bool ->
   ?expecting_process_page:bool ->


### PR DESCRIPTION
Adds two functions to Eliom_client that allow us to lock and unlock the handling of all HTTP responses. This has to be used with care obviously!
The purpose of these functions is to allow smooth animations which tend to stutter during the treatment of HTTP queries.
