### PR TITLE
Add library_kind = "ppx_rewriter" to META for PPX libraries.

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -80,6 +80,7 @@ package "ppx" (
     plugin(ppx_driver,byte) = "ppx_eliom_server.cma"
     plugin(ppx_driver,native) = "ppx_eliom_server.cmxs"
     requires(ppx_driver) = "ocaml-migrate-parsetree ppx_tools_versioned"
+    library_kind = "ppx_rewriter"
   )
   package "client" (
     description = "Ppx syntax extension: client side"
@@ -89,6 +90,7 @@ package "ppx" (
     plugin(ppx_driver,byte) = "ppx_eliom_client.cma"
     plugin(ppx_driver,native) = "ppx_eliom_client.cmxs"
     requires(ppx_driver) = "ocaml-migrate-parsetree ppx_tools_versioned"
+    library_kind = "ppx_rewriter"
   )
   package "type" (
     description = "Ppx syntax extension: type inference"
@@ -98,6 +100,7 @@ package "ppx" (
     plugin(ppx_driver,byte) = "ppx_eliom_type.cma"
     plugin(ppx_driver,native) = "ppx_eliom_type.cmxs"
     requires(ppx_driver) = "ocaml-migrate-parsetree ppx_tools_versioned"
+    library_kind = "ppx_rewriter"
   )
 )
 


### PR DESCRIPTION
This is required by dune since version 2.2.
