### PR TITLE
Eliom_comet: more memory-conscious implementation

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "eliom"
-version: "6.12.3"
+version: "6.12.4"
 maintainer: "dev@ocsigen.org"
 authors: "dev@ocsigen.org"
 synopsis: "Client/server Web framework"

--- a/src/lib/eliom_comet.server.mli
+++ b/src/lib/eliom_comet.server.mli
@@ -74,6 +74,11 @@ module Channel : sig
   val create : ?scope:[< comet_scope ] ->
     ?name:string -> ?size:int -> 'a Lwt_stream.t -> 'a t
 
+  (** [create_from_events e] returns a channel sending the values returned
+      by the event stream [e]. *)
+  val create_from_events : ?scope:[< comet_scope ] ->
+    ?name:string -> ?size:int -> 'a React.event -> 'a t
+
   (** [create_unlimited s] creates a channel which does not read
       immediately on the stream. It is read only when the client
       requests it: use it if the data you send depends on the time of

--- a/src/lib/eliom_react.server.ml
+++ b/src/lib/eliom_react.server.ml
@@ -50,9 +50,8 @@ struct
         | None -> e
         | Some t -> E.limit (fun () -> Lwt_unix.sleep t) e)
     in
-    let stream =
-      Lwt.with_value Eliom_common.sp_key None @@ fun () -> E.to_stream ee in
-    let channel = Eliom_comet.Channel.create ?scope ?name ?size stream in
+    let channel =
+      Eliom_comet.Channel.create_from_events ?scope ?name ?size ee in
     (channel,Eliom_common.make_unwrapper Eliom_common.react_down_unwrap_id)
 
   let wrap_stateless channel =
@@ -79,8 +78,8 @@ struct
         | None -> e
         | Some t -> E.limit (fun () -> Lwt_unix.sleep t) e)
     in
-    let stream = E.to_stream ee in
-    Stateless (Eliom_comet.Channel.create ~scope:`Site ?name ?size stream)
+    Stateless (Eliom_comet.Channel.create_from_events
+                 ~scope:`Site ?name ?size ee)
 
   let of_react ?scope ?throttling ?name ?size (e : 'a E.t) =
     let t =


### PR DESCRIPTION
- use queues rather than Lwt streams internally when possible
- possibility to create a channel directly from a React event stream