### PR TITLE
[ppx] Use type information from cmo files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 #  - OCAML_VERSION=4.04 PINS="ocsigenserver:https://github.com/ocsigen/ocsigenserver.git deriving:https://github.com/ocsigen/deriving.git" PACKAGE=eliom
 #  - OCAML_VERSION=4.05 PINS="ocsigenserver:https://github.com/ocsigen/ocsigenserver.git deriving:https://github.com/ocsigen/deriving.git" PACKAGE=eliom
 #  - OCAML_VERSION=4.06 PINS="ocsigenserver:https://github.com/ocsigen/ocsigenserver.git deriving:https://github.com/ocsigen/deriving.git" PACKAGE=eliom
-  - OCAML_VERSION=4.07 PACKAGE=eliom
+  - OCAML_VERSION=4.08 PACKAGE=eliom
 os:
   - linux
   - osx

--- a/opam
+++ b/opam
@@ -11,7 +11,7 @@ license: "LGPL-2.1 with OCaml linking exception"
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 build: [make]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.08.0"}
   "ocamlfind"
   "ppx_deriving"
   "ppx_tools" {>= "0.99.3"}

--- a/src/lib/eliom_cscache.eliom
+++ b/src/lib/eliom_cscache.eliom
@@ -15,7 +15,7 @@ let%server create_ () =
   fun () -> Eliom_reference.Volatile.get c
 
 let%server create () =
-  Eliom_shared.Value.create (create_ ())  [%client  create_ () ]
+  Eliom_shared.Value.create (create_ ())  [%client.unsafe create_ () ]
 
 let do_cache_raw cache id data =
   let c = Eliom_shared.Value.local cache () in
@@ -27,14 +27,14 @@ let do_cache cache id data = do_cache_raw cache id (Lwt.return data)
 
 let%server do_cache cache id v =
   do_cache cache id v;
-  ignore [%client ( do_cache ~%cache ~%id ~%v : unit)]
+  ignore [%client.unsafe ( do_cache ~%cache ~%id ~%v : unit)]
 
 let%server find cache get_data id =
   try Hashtbl.find ((Eliom_shared.Value.local cache) ()) id
   with Not_found ->
     let th =
       let%lwt v = get_data id in
-      ignore [%client ( do_cache ~%cache ~%id ~%v : unit)];
+      ignore [%client.unsafe ( do_cache ~%cache ~%id ~%v : unit)];
       Lwt.return v
     in
     (* On server side, we put immediately in table the thread that is

--- a/src/lib/eliom_form.eliom
+++ b/src/lib/eliom_form.eliom
@@ -132,7 +132,7 @@ module Make_links (Html : Html) = struct
       in
       let href = Html.a_href href in
       if get_xhr xhr then
-        let f = [%client fun ev ->
+        let f = [%client.unsafe fun ev ->
           if not (Eliom_client.middleClick ev) then begin
             Dom.preventDefault ev;
             Dom_html.stopPropagation ev;
@@ -588,7 +588,7 @@ module Make (Html : Html) = struct
     let a =
       let a = (a :> Html_types.form_attrib attrib list) in
       if get_xhr xhr then
-        let hdlr = [%client
+        let hdlr = [%client.unsafe
           (make_hdlr_get ~%service : client_form_handler)
         ] in
         let info = make_info ~https `Form_get service hdlr in
@@ -608,7 +608,7 @@ module Make (Html : Html) = struct
     let a =
       let a = (a :> Html_types.form_attrib attrib list) in
       if get_xhr xhr then
-        let hdlr = [%client
+        let hdlr = [%client.unsafe
           (make_hdlr_get ~%service : client_form_handler)
         ] in
         let info = make_info ~https `Form_get service hdlr in
@@ -628,7 +628,7 @@ module Make (Html : Html) = struct
     let a =
       let a = (a :> Html_types.form_attrib attrib list) in
       if get_xhr xhr then
-        let hdlr = [%client
+        let hdlr = [%client.unsafe
           (make_hdlr_post ~%service ~%getparams : client_form_handler)
         ] in
         let info = make_info ~https `Form_post service hdlr in
@@ -649,7 +649,7 @@ module Make (Html : Html) = struct
     let a =
       let a = (a :> Html_types.form_attrib attrib list) in
       if get_xhr xhr then
-        let hdlr = [%client
+        let hdlr = [%client.unsafe
           (make_hdlr_post ~%service ~%getparams : client_form_handler)
         ] in
         let info = make_info ~https `Form_post service hdlr in

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -415,7 +415,7 @@ let keep_nl_params s = s.keep_nl_params
 let untype s =
   (s
    :  ('get, 'post, 'meth, 'attached, 'co, 'ext,
-       'tipo, 'getnames, 'postnames, 'register, _) t
+       'tipo, 'getnames, 'postnames, 'register, _) t 
    :> ('get, 'post, 'meth, 'attached, 'co, 'ext,
        'tipo, 'getnames, 'postnames,'register, _) t)
 

--- a/src/lib/eliom_service_base.eliom
+++ b/src/lib/eliom_service_base.eliom
@@ -192,7 +192,7 @@ let priority s = s.priority
 
 let internal_set_client_fun
       ~service (f : ('get -> 'post -> result Lwt.t) Eliom_client_value.t) =
-  service.client_fun <- Some [%client ref (Some ~%f)]
+  service.client_fun <- Some [%client.unsafe ref (Some ~%f)]
 
 let is_external = function {kind = `External} -> true | _ -> false
 
@@ -333,7 +333,7 @@ let preapply ~service getparams =
            });
     client_fun =
       Some
-        [%client ref
+        [%client.unsafe ref
             (match ~%service.client_fun with
              | Some {contents = Some f} -> Some (fun () pp -> f ~%getparams pp)
              | _ -> None)
@@ -390,7 +390,7 @@ let add_non_localized_get_parameters ~params ~service = {
     Eliom_parameter.nl_prod service.get_params_type params;
   client_fun =
     Some
-    [%client
+    [%client.unsafe
        ref
          (match ~%service.client_fun with
           | Some {contents = Some f} -> Some (fun (g, _) p -> f g p)
@@ -403,7 +403,7 @@ let add_non_localized_post_parameters ~params ~service = {
     Eliom_parameter.nl_prod service.post_params_type params;
   client_fun =
     Some
-    [%client
+    [%client.unsafe
       ref
         (match ~%service.client_fun with
          | Some {contents = Some f} -> Some (fun g (p, _) -> f g p)
@@ -457,7 +457,7 @@ let%server no_client_fun () : _ ref Eliom_client_value.t option =
   (* It only makes sense to create a client value when in a global
      context. *)
   if Eliom_syntax.global_context () then
-    Some [%client ref None]
+    Some [%client.unsafe ref None]
   else
     None
 

--- a/src/lib/eliom_shared.eliom
+++ b/src/lib/eliom_shared.eliom
@@ -332,7 +332,7 @@ module React = struct
     let value (x : 'a t) =
       Value.create
         (FakeReact.S.value (Value.local x))
-        [%client ( FakeReact.S.value (Value.local ~%x) : 'a)]
+        [%client.unsafe ( FakeReact.S.value (Value.local ~%x) : 'a)]
 
     (*VVV What is the good default value for reset_default?  Setting
       default to true may be difficult to understand.  I prefer
@@ -340,9 +340,9 @@ module React = struct
     let create ?default ?(reset_default = false) ?(eq : _ Value.t option) x =
       let cv, synced = match default with
         | None ->
-           [%client  FakeReact.S.create ?eq:~%eq ~%x ], true
+           [%client.unsafe  FakeReact.S.create ?eq:~%eq ~%x ], true
         | Some v ->
-          [%client (
+          [%client.unsafe (
             match (~%v : (_ * (?step:_ -> _ -> _)) option) with
              | Some ((_, set) as s) ->
                (* The reactive data is already on client side.  But
@@ -359,17 +359,17 @@ module React = struct
       in
       let v, f = FakeReact.S.create ~synced x in
       let si =
-        Value.create v [%client ( fst ~%cv : 'a FakeReact.S.t)]
+        Value.create v [%client.unsafe ( fst ~%cv : 'a FakeReact.S.t)]
       and up =
         Value.create f
-          [%client ( snd ~%cv : ?step:React.step -> 'a -> unit)]
+          [%client.unsafe ( snd ~%cv : ?step:React.step -> 'a -> unit)]
       in
       (si, up)
 
     let map ?eq (f : ('a -> 'b) Value.t) (s : 'a t) : 'b t =
       Value.create
         (FakeReact.S.map (Value.local f) (Value.local s))
-        [%client ( FakeReact.S.map ?eq:~%eq ~%f ~%s : 'b FakeReact.S.t)]
+        [%client.unsafe ( FakeReact.S.map ?eq:~%eq ~%f ~%s : 'b FakeReact.S.t)]
 
     let fmap ?(eq : ('b -> 'b -> bool) Value.t option)
         (f : ('a -> 'b option) Value.t) (i : 'b Value.t) (s : 'a t)
@@ -377,32 +377,35 @@ module React = struct
       Value.create
         (FakeReact.S.fmap
            (Value.local f) (Value.local i) (Value.local s))
-        [%client ( FakeReact.S.fmap ?eq:~%eq ~%f ~%i ~%s : 'b FakeReact.S.t)]
+        [%client.unsafe
+            ( FakeReact.S.fmap ?eq:~%eq ~%f ~%i ~%s : 'b FakeReact.S.t)]
 
     let merge ?eq (f : ('a -> 'b -> 'a) Value.t)
         (acc : 'a) (l : 'b t list) : 'a t =
       Value.create
         (FakeReact.S.merge (Value.local f) acc (List.map Value.local l))
-        [%client ( FakeReact.S.merge ?eq:~%eq ~%f ~%acc ~%l : 'a FakeReact.S.t)]
+        [%client.unsafe
+            ( FakeReact.S.merge ?eq:~%eq ~%f ~%acc ~%l : 'a FakeReact.S.t)]
 
     let const (v : 'a) : 'a t =
       Value.create
         (FakeReact.S.const ~synced:true v)
-        [%client ( React.S.const ~%v : 'a FakeReact.S.t)]
+        [%client.unsafe ( React.S.const ~%v : 'a FakeReact.S.t)]
 
     let l2 ?eq (f : ('a -> 'b -> 'c) Value.t)
         (s1 : 'a t) (s2 : 'b t) : 'c t =
       Value.create
         (FakeReact.S.l2 (Value.local f)
            (Value.local s1) (Value.local s2))
-        [%client ( React.S.l2 ?eq:~%eq ~%f ~%s1 ~%s2 : 'd FakeReact.S.t)]
+        [%client.unsafe ( React.S.l2 ?eq:~%eq ~%f ~%s1 ~%s2 : 'd FakeReact.S.t)]
 
     let l3 ?eq (f : ('a -> 'b -> 'c -> 'd) Value.t)
         (s1 : 'a t) (s2 : 'b t) (s3 : 'c t) : 'd t =
       Value.create
         (FakeReact.S.l3 (Value.local f)
            (Value.local s1) (Value.local s2) (Value.local s3))
-        [%client ( React.S.l3 ?eq:~%eq ~%f ~%s1 ~%s2 ~%s3 : 'd FakeReact.S.t)]
+        [%client.unsafe
+            ( React.S.l3 ?eq:~%eq ~%f ~%s1 ~%s2 ~%s3 : 'd FakeReact.S.t)]
 
     let l4 ?eq (f : ('a -> 'b -> 'c -> 'd -> 'e) Value.t)
         (s1 : 'a t) (s2 : 'b t) (s3 : 'c t) (s4 : 'd t) : 'e t =
@@ -410,7 +413,8 @@ module React = struct
         (FakeReact.S.l4 (Value.local f)
            (Value.local s1) (Value.local s2) (Value.local s3)
            (Value.local s4))
-        [%client ( React.S.l4 ?eq:~%eq ~%f ~%s1 ~%s2 ~%s3 ~%s4 : 'e FakeReact.S.t)]
+        [%client.unsafe
+            ( React.S.l4 ?eq:~%eq ~%f ~%s1 ~%s2 ~%s3 ~%s4 : 'e FakeReact.S.t)]
 
     let l5 ?eq (f : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) Value.t)
         (s1 : 'a t) (s2 : 'b t) (s3 : 'c t) (s4 : 'd t) (s5 : 'e t)
@@ -419,7 +423,7 @@ module React = struct
         (FakeReact.S.l5 (Value.local f)
            (Value.local s1) (Value.local s2) (Value.local s3)
            (Value.local s4) (Value.local s5))
-        [%client (
+        [%client.unsafe (
            React.S.l5 ?eq:~%eq ~%f ~%s1 ~%s2 ~%s3 ~%s4 ~%s5 : 'f FakeReact.S.t)]
 
     let l6 ?eq
@@ -431,7 +435,7 @@ module React = struct
         (FakeReact.S.l6 (Value.local f)
            (Value.local s1) (Value.local s2) (Value.local s3)
            (Value.local s4) (Value.local s5) (Value.local s6))
-        [%client (
+        [%client.unsafe (
            React.S.l6 ?eq:~%eq ~%f ~%s1 ~%s2 ~%s3 ~%s4 ~%s5 ~%s6 : 'g FakeReact.S.t)]
 
     let switch ?eq (s : 'a t t) : 'a t =
@@ -444,7 +448,7 @@ module React = struct
          FakeReact.S.value |>
          FakeReact.S.create ~synced:false |>
          fst)
-        [%client ( React.S.switch ?eq:~%eq ~%s : 'a FakeReact.S.t)]
+        [%client.unsafe ( React.S.switch ?eq:~%eq ~%s : 'a FakeReact.S.t)]
 
     let synced s = Value.local s |> FakeReact.S.synced
 
@@ -462,7 +466,7 @@ module React = struct
         Lwt.return
           (Value.create
              (fst (FakeReact.S.create ~synced server_result))
-             [%client (
+             [%client.unsafe (
                 React.S.Lwt.map_s_init
                   ~init:~%server_result ?eq:~%eq ~%f ~%s : 'b FakeReact.S.t)])
 
@@ -476,7 +480,7 @@ module React = struct
         Lwt.return
           (Value.create
              (fst (FakeReact.S.create ~synced server_result))
-             [%client (
+             [%client.unsafe (
                 React.S.Lwt.l2_s_init
                   ~init:~%server_result ?eq:~%eq ~%f ~%s1 ~%s2 : 'c FakeReact.S.t)])
 
@@ -498,7 +502,7 @@ module React = struct
         Lwt.return
           (Value.create
              (fst (FakeReact.S.create ~synced server_result))
-             [%client (
+             [%client.unsafe (
                 React.S.Lwt.l3_s_init ?eq:~%eq
                   ~init:~%server_result
                   ~%f ~%s1 ~%s2 ~%s3 : 'd FakeReact.S.t)])
@@ -521,7 +525,7 @@ module React = struct
         Lwt.return
           (Value.create
              (fst (FakeReact.S.create ~synced server_result))
-             [%client (
+             [%client.unsafe (
                 React.S.Lwt.l4_s_init ?eq:~%eq ~init:~%server_result
                   ~%f ~%s1 ~%s2 ~%s3 ~%s4 : 'e FakeReact.S.t)])
 
@@ -545,7 +549,7 @@ module React = struct
         Lwt.return
           (Value.create
              (fst (FakeReact.S.create ~synced server_result))
-             [%client (
+             [%client.unsafe (
                 React.S.Lwt.l5_s_init ?eq:~%eq ~init:~%server_result
                   ~%f ~%s1 ~%s2 ~%s3 ~%s4 ~%s5 : 'f FakeReact.S.t)])
 
@@ -570,7 +574,7 @@ module React = struct
         Lwt.return
           (Value.create
              (fst (FakeReact.S.create ~synced server_result))
-             [%client (
+             [%client.unsafe (
                 React.S.Lwt.l6_s_init ?eq:~%eq ~init:~%server_result
                   ~%f ~%s1 ~%s2 ~%s3 ~%s4 ~%s5 ~%s6 : 'g FakeReact.S.t)])
 
@@ -588,7 +592,7 @@ module React = struct
         Lwt.return
           (Value.create
              (fst (FakeReact.S.create ~synced server_result))
-             [%client (
+             [%client.unsafe (
                 React.S.Lwt.merge_s_init
                   ~init:~%server_result ?eq:~%eq ~%f ~%acc ~%l : 'a FakeReact.S.t)])
 
@@ -603,9 +607,9 @@ module ReactiveData = struct
     let create ?default ?(reset_default = false) x =
       let cv, synced = match default with
         | None ->
-           [%client  FakeReactiveData.RList.create ~%x ], true
+           [%client.unsafe  FakeReactiveData.RList.create ~%x ], true
         | Some v ->
-          [%client (
+          [%client.unsafe (
              match ~%v with
              | Some ((_, handle) as s) ->
                if ~%reset_default then ReactiveData.RList.set handle ~%x;
@@ -617,16 +621,16 @@ module ReactiveData = struct
       in
       let sv = FakeReactiveData.RList.create ~synced x in
       Value.create (fst sv)
-        [%client ( fst ~%cv : 'a FakeReactiveData.RList.t)],
+        [%client.unsafe ( fst ~%cv : 'a FakeReactiveData.RList.t)],
       Value.create (snd sv)
-        [%client ( snd ~%cv : 'b FakeReactiveData.RList.handle)]
+        [%client.unsafe ( snd ~%cv : 'b FakeReactiveData.RList.handle)]
 
     let concat a b =
       let sv =
         FakeReactiveData.RList.concat
           (Value.local a)
           (Value.local b)
-      and cv = [%client (
+      and cv = [%client.unsafe (
         FakeReactiveData.RList.concat ~%a ~%b
       : 'a FakeReactiveData.RList.t)] in
       Value.create sv cv
@@ -634,20 +638,21 @@ module ReactiveData = struct
     let singleton_s s =
       Value.create
         (FakeReactiveData.RList.singleton_s (Value.local s))
-        [%client (
+        [%client.unsafe (
            FakeReactiveData.RList.singleton_s (Value.local ~%s) : 'a FakeReactiveData.RList.t)]
 
     let value (s : 'a t) =
       Value.create
         (FakeReactiveData.RList.value (Value.local s))
-        [%client ( FakeReactiveData.RList.value (Value.local ~%s) : 'a list)]
+        [%client.unsafe
+            ( FakeReactiveData.RList.value (Value.local ~%s) : 'a list)]
 
     let signal ?eq (s : 'a t) =
       let sv =
         let eq = Ocsigen_lib.Option.map Value.local eq in
         FakeReactiveData.RList.signal ?eq (Value.local s)
       and cv =
-        [%client (
+        [%client.unsafe (
           FakeReactiveData.RList.signal ?eq:~%eq (Value.local ~%s) : 'a list FakeReact.S.t)]
       in
       Value.create sv cv
@@ -655,7 +660,7 @@ module ReactiveData = struct
     let map f s =
       Value.create
         (FakeReactiveData.RList.map (Value.local f) (Value.local s))
-        [%client (
+        [%client.unsafe (
            FakeReactiveData.RList.map (Value.local ~%f) (Value.local ~%s) : 'a FakeReactiveData.RList.t)]
 
     let from_signal ?eq (s : 'a list React.S.t) : 'a t =
@@ -663,7 +668,8 @@ module ReactiveData = struct
         let eq = Ocsigen_lib.Option.map Value.local eq in
         FakeReactiveData.RList.from_signal ?eq (Value.local s)
       and cv =
-         [%client  ReactiveData.RList.from_signal ?eq:~%eq (Value.local ~%s) ]
+        [%client.unsafe
+            ReactiveData.RList.from_signal ?eq:~%eq (Value.local ~%s) ]
       in
       Value.create sv cv
 
@@ -675,7 +681,7 @@ module ReactiveData = struct
         | None ->
           create []
       in
-      let _ = [%client (
+      let _ = [%client.unsafe (
         let f x = ReactiveData.RList.cons x (Value.local ~%h) in
         ignore (React.E.map f ~%e)
       : unit)] in
@@ -693,7 +699,7 @@ module ReactiveData = struct
         Lwt.return
           (Value.create
              (fst (FakeReactiveData.RList.create ~synced server_result))
-              [%client  ReactiveData.RList.Lwt.map_p_init
+              [%client.unsafe  ReactiveData.RList.Lwt.map_p_init
                   ~init:~%server_result ~%f ~%l ])
 
     end

--- a/src/lib/eliom_shared_content.eliom
+++ b/src/lib/eliom_shared_content.eliom
@@ -192,7 +192,7 @@ module Xml = struct
       Eliom_content_core.Xml.node ?a name |>
       name_node
     in
-    let _ = [%client (
+    let _ = [%client.unsafe (
       let f = Eliom_client_core.rebuild_node' ~%ns in
       let e = f ~%e
       and l = ReactiveData.RList.map f ~%l in
@@ -310,7 +310,7 @@ module Svg = struct
         Eliom_content_core.Svg.D.toelt |>
         Eliom_content_core.Xml.make_request_node ~reset:false
       and synced = React.S.synced s in
-      let _ = [%client (
+      let _ = [%client.unsafe (
         let s =
           Eliom_shared.React.S.map
             (fun s ->
@@ -436,7 +436,7 @@ module Html = struct
         Eliom_content_core.Html.D.toelt |>
         Eliom_content_core.Xml.make_request_node ~reset:false
       and synced = React.S.synced s in
-      let _ = [%client (
+      let _ = [%client.unsafe (
         let s =
           Eliom_shared.React.S.map
             (fun s ->
@@ -463,7 +463,8 @@ module Html = struct
 
     let filter_attrib a s =
       let init = if local_value s then Some a else None
-      and c =  [%client  Eliom_content_core.Html.R.filter_attrib ~%a ~%s ] in
+      and c =
+        [%client.unsafe Eliom_content_core.Html.R.filter_attrib ~%a ~%s ] in
       Eliom_content_core.Html.D.client_attrib ?init c
 
     include

--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -31,14 +31,16 @@ module Pass = struct
 
   let push_escaped_binding, flush_escaped_bindings =
     let server_arg_ids = ref [] in
-    let is_unknown gen_id =
-      List.for_all
-        (fun (gen_id', _) -> gen_id.txt <> gen_id'.txt)
-        !server_arg_ids
-    in
-    let push gen_id (expr : expression) =
-      if is_unknown gen_id then
-        server_arg_ids := (gen_id, expr) :: !server_arg_ids
+    let push gen_id (expr : expression) get_type =
+      match
+        List.find_opt (fun (gen_id', _, _) -> gen_id.txt = gen_id'.txt)
+          !server_arg_ids
+      with
+      | Some (_, _, typ) -> typ
+      | None ->
+         let typ = get_type () in
+         server_arg_ids := (gen_id, expr, typ) :: !server_arg_ids;
+         typ
     in
     let flush () =
       let res = List.rev !server_arg_ids in
@@ -59,9 +61,9 @@ module Pass = struct
 
   let push_client_value_data, flush_client_value_datas =
     let client_value_datas = ref [] in
-    let push gen_num gen_id expr (args : string Location.loc list) =
+    let push loc gen_num gen_id expr (args : string Location.loc list) =
       client_value_datas :=
-        (gen_num, gen_id, expr, args) :: !client_value_datas
+        (loc, gen_num, gen_id, expr, args) :: !client_value_datas
     in
     let flush () =
       let res = List.rev !client_value_datas in
@@ -70,20 +72,26 @@ module Pass = struct
     in
     push, flush
 
-  let find_escaped_ident id =
-    if Mli.exists () then Mli.find_escaped_ident id else [%type: _]
+  let find_escaped_ident loc id =
+    if Mli.exists () then Mli.find_escaped_ident id
+    else if Cmo.exists () then Cmo.find_escaped_ident loc
+    else [%type: _]
 
-  let find_injected_ident id =
-    if Mli.exists () then Mli.find_injected_ident id else [%type: _]
+  let find_injected_ident loc id =
+    if Mli.exists () then Mli.find_injected_ident id
+    else if Cmo.exists () then Cmo.find_injected_ident loc
+    else [%type: _]
 
-  let find_fragment id =
-    if Mli.exists () then Mli.find_fragment id else [%type: _]
+  let find_fragment loc id =
+    if Mli.exists () then Mli.find_fragment id
+    else if Cmo.exists () then Cmo.find_fragment loc
+    else [%type: _]
 
   let register_client_closures client_value_datas =
     let registrations =
       List.map
-        (fun (num, id, expr, args) ->
-           let typ = find_fragment id in
+        (fun (loc, num, id, expr, args) ->
+           let typ = find_fragment loc id in
            let args = List.map Pat.var args in
            [%expr
              Eliom_client_core.Syntax_helpers.register_client_closure
@@ -108,9 +116,9 @@ module Pass = struct
     | _ ->
       let bindings =
         List.map
-          (fun (_num, id, expr, args) ->
+          (fun (loc, _num, id, expr, args) ->
              let patt = Pat.var id in
-             let typ = find_fragment id in
+             let typ = find_fragment loc id in
              let args = List.map Pat.var args in
              let expr =
                [%expr
@@ -169,14 +177,25 @@ module Pass = struct
     [ item ] @
     may_close_server_section ~no_fragment item
 
-  let fragment ?typ:_ ~context ~num ~id expr =
+  let fragment ~loc ?typ ~context ~num ~id expr =
 
-    let loc = expr.pexp_loc in
     let frag_eid = eid id in
     let escaped_bindings = flush_escaped_bindings () in
 
-    push_client_value_data num id expr
-      (List.map fst escaped_bindings);
+    begin match typ with
+      | Some _ -> ()
+      | None when not (Mli.exists () || Cmo.exists ()) -> ()
+      | None ->
+        match find_fragment loc id with
+        | { ptyp_desc = Ptyp_var _ } ->
+          Location.raise_errorf ~loc
+            "The types of client values must be monomorphic from its usage \
+             or from its type annotation"
+        | _ -> ()
+    end;
+
+    push_client_value_data loc num id expr
+      (List.map (fun (gen_id, _, _) -> gen_id) escaped_bindings);
 
     match context, escaped_bindings with
     | `Server, _ ->
@@ -187,13 +206,13 @@ module Pass = struct
     | `Shared, _ ->
       let bindings =
         List.map
-          (fun (gen_id, expr) ->
+          (fun (gen_id, expr, _) ->
              Vb.mk ~loc:expr.pexp_loc (Pat.var gen_id) expr )
           escaped_bindings
       in
       let args =
         format_args @@ List.map
-          (fun (id, _) -> eid id)
+          (fun (id, _, _) -> eid id)
           escaped_bindings
       in
       Exp.let_ ~loc
@@ -203,7 +222,7 @@ module Pass = struct
 
 
 
-  let escape_inject ?ident ~(context:Context.escape_inject) ~id expr =
+  let escape_inject ~loc:loc0 ?ident ~(context:Context.escape_inject) ~id expr =
     let loc = expr.pexp_loc in
     let frag_eid = eid id in
 
@@ -226,16 +245,18 @@ module Pass = struct
 
     (* [%%server [%client ~%( ... ) ] ] *)
     | `Escaped_value _section ->
-      let typ = find_escaped_ident id in
-      let typ = assert_no_variables typ in
-      push_escaped_binding id expr;
-      [%expr ([%e frag_eid] : [%t typ]) ][@metaloc loc]
-
+       let typ =
+         push_escaped_binding id expr (fun () ->
+             let typ = find_escaped_ident loc0 id in
+             let typ = assert_no_variables typ in
+             typ)
+       in
+       [%expr ([%e frag_eid] : [%t typ]) ][@metaloc loc]
 
     (* [%%server ... %x ... ] *)
     | `Injection _section ->
       mark_injection () ;
-      let typ = find_injected_ident id in
+      let typ = find_injected_ident loc0 id in
       let typ = assert_no_variables typ in
       let ident = match ident with
         | None   -> [%expr None]

--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -234,7 +234,8 @@ module Pass = struct
               "The type of this injected value contains a type variable \
                that could be wrongly inferred."
           in
-          { typ with ptyp_attributes = attr :: typ.ptyp_attributes }
+          { typ with ptyp_attributes = attr :: typ.ptyp_attributes;
+                     ptyp_loc = loc }
         | typ -> AM.default_mapper.typ mapper typ
       in
       let m = { AM.default_mapper with typ } in

--- a/src/ppx/ppx_eliom_server.ml
+++ b/src/ppx/ppx_eliom_server.ml
@@ -32,6 +32,32 @@ open Ppx_eliom_utils
 
 module Pass = struct
 
+  let push_nongen_str_item, flush_nongen_str_item =
+    let typing_strs = ref [] in
+    let add loc id is_fragment =
+      let typ =
+        if is_fragment then [%type: _ Eliom_client_value.t ][@metaloc loc]
+        else [%type: _][@metaloc loc]
+      in
+      typing_strs :=
+        (if Mli.exists () then
+           [%stri let [%p Pat.var id] = fun y -> (y : [%t typ] :> [%t typ])]
+         else
+           [%stri let [%p Pat.var id] =
+              let x = Stdlib.ref None in
+              fun y ->
+              if false then x := Some y;
+              (y : [%t typ] :> [%t typ])
+           ])
+        :: !typing_strs
+    in
+    let flush () =
+      let res = !typing_strs in
+      typing_strs := [];
+      [%stri open struct [%%s res] end]
+    in
+    add, flush
+
   let one_char_location loc =
     {loc
     with Location.loc_end =
@@ -48,8 +74,9 @@ module Pass = struct
       let res = List.rev !args in
       args := [];
       let aux (loc, id, arg) =
+        push_nongen_str_item loc id false;
         [%expr Eliom_syntax.escaped_value
-            [%e [%expr ((fun x -> x) [%e arg ])]
+            [%e [%expr ([%e eid id] [%e arg ])]
                 [@metaloc one_char_location loc]]]
         [@metaloc loc]
       in
@@ -129,10 +156,12 @@ module Pass = struct
              | None -> [%expr None]
              | Some i -> [%expr Some [%e AC.str i ]] in
            let (_, num) = Mli.get_injected_ident_info txt in
+           let f_id = {txt = txt ^ "_f"; loc} in
+           push_nongen_str_item loc f_id false;
            [%expr
              ([%e AC.int num],
               Eliom_lib.to_poly [%e
-                                    [%expr (fun x -> x) [%e frag_eid ]]
+                                    [%expr [%e eid f_id] [%e frag_eid ]]
                                     [@metaloc one_char_location loc0]
                 ],
               [%e loc_expr], [%e ident ]) :: [%e sofar ]
@@ -153,13 +182,17 @@ module Pass = struct
   let client_str item =
     let all_injections = flush_injections () in
     let loc = item.pstr_loc in
+    let str =
     match all_injections with
     | [] -> []
     | l  ->
       bind_injected_idents l ::
-      [ close_client_section loc all_injections ]
+        [ close_client_section loc all_injections ]
+    in
+    flush_nongen_str_item () :: str
 
   let server_str no_fragment item =
+    flush_nongen_str_item () ::
     let loc = item.pstr_loc in
     item ::
     may_close_server_section ~no_fragment loc
@@ -171,12 +204,15 @@ module Pass = struct
       item ::
       may_close_server_section ~no_fragment loc
     in
-    match all_injections with
-    | [] -> cl
-    | l ->
-      bind_injected_idents l ::
-      cl @
-      [ close_client_section loc all_injections ]
+    let str =
+      match all_injections with
+      | [] -> cl
+      | l ->
+         bind_injected_idents l ::
+           cl @
+           [ close_client_section loc all_injections ]
+    in
+    flush_nongen_str_item () :: str
 
   let fragment ~loc ?typ ~context:_ ~num ~id _ =
     let typ =
@@ -185,8 +221,9 @@ module Pass = struct
       | None -> [%type: _]
     in
     let e = format_args @@ flush_escaped_bindings () in
+    push_nongen_str_item loc id true;
     [%expr
-        (fun x -> (x : _ Eliom_client_value.t :> _ Eliom_client_value.t))
+        [%e eid id]
         [%e
             [%expr
                 ( (Eliom_syntax.client_value

--- a/src/ppx/ppx_eliom_server.ml
+++ b/src/ppx/ppx_eliom_server.ml
@@ -34,13 +34,13 @@ module Pass = struct
 
   let push_nongen_str_item, flush_nongen_str_item =
     let typing_strs = ref [] in
-    let add loc id is_fragment =
+    let add ~fragment ~unsafe loc id =
       let typ =
-        if is_fragment then [%type: _ Eliom_client_value.t ][@metaloc loc]
+        if fragment then [%type: _ Eliom_client_value.t ][@metaloc loc]
         else [%type: _][@metaloc loc]
       in
       typing_strs :=
-        (if Mli.exists () then
+        (if unsafe || Mli.exists () then
            [%stri let [%p Pat.var id] = fun y -> (y : [%t typ] :> [%t typ])]
          else
            [%stri let [%p Pat.var id] =
@@ -66,15 +66,15 @@ module Pass = struct
 
   let push_escaped_binding, flush_escaped_bindings =
     let args = ref [] in
-    let push loc orig_expr id =
-      if List.for_all (function _, id', _ -> id.txt <> id'.txt) !args then
-        args := (loc, id, orig_expr) :: !args;
+    let push loc orig_expr id ~unsafe =
+      if List.for_all (function _, id', _, _ -> id.txt <> id'.txt) !args then
+        args := (loc, id, orig_expr, unsafe) :: !args;
     in
     let flush () =
       let res = List.rev !args in
       args := [];
-      let aux (loc, id, arg) =
-        push_nongen_str_item loc id false;
+      let aux (loc, id, arg, unsafe) =
+        push_nongen_str_item ~fragment:false ~unsafe loc id;
         [%expr Eliom_syntax.escaped_value
             [%e [%expr ([%e eid id] [%e arg ])]
                 [@metaloc one_char_location loc]]]
@@ -87,12 +87,12 @@ module Pass = struct
   module SSet = Set.Make (String)
 
   let push_injection, flush_injections =
-    let buffer : (_ * _ * _ * _) list ref = ref [] in
+    let buffer : (_ * _ * _ * _ * _) list ref = ref [] in
     let gen_ids = ref SSet.empty in
-    let push loc ?ident id orig_expr =
+    let push loc ?ident id ~unsafe orig_expr =
       if not (SSet.mem id !gen_ids) then
         (gen_ids := SSet.add id !gen_ids;
-         buffer := (loc, id, orig_expr,ident) :: !buffer)
+         buffer := (loc, id, orig_expr, ident, unsafe) :: !buffer)
     in
     let flush_all () =
       let res = List.rev !buffer in
@@ -104,13 +104,13 @@ module Pass = struct
     let flush () =
       let all = flush_all () in
       let novel =
-        let is_fresh (_, gen_id, _,_) =
+        let is_fresh (_, gen_id, _,_, _) =
           not (SSet.mem gen_id !global_known)
         in
         List.filter is_fresh all
       in
       List.iter
-        (function _, gen_id, _, _ ->
+        (function _, gen_id, _, _, _ ->
            global_known := SSet.add gen_id !global_known)
         novel;
       all
@@ -124,7 +124,7 @@ module Pass = struct
     assert (injections <> []);
     let bindings =
       List.map
-        (fun (_, txt, expr,_) ->
+        (fun (_, txt, expr, _, _) ->
            let loc = expr.pexp_loc in
            Vb.mk ~loc (Pat.var ~loc {txt;loc}) expr)
         injections
@@ -148,7 +148,7 @@ module Pass = struct
     assert (injections <> []) ;
     let injection_list =
       List.fold_right
-        (fun (loc0, txt, expr, ident) sofar ->
+        (fun (loc0, txt, expr, ident, unsafe) sofar ->
            let loc = expr.pexp_loc in
            let loc_expr = position loc in
            let frag_eid = eid {txt;loc} in
@@ -157,7 +157,7 @@ module Pass = struct
              | Some i -> [%expr Some [%e AC.str i ]] in
            let (_, num) = Mli.get_injected_ident_info txt in
            let f_id = {txt = txt ^ "_f"; loc} in
-           push_nongen_str_item loc f_id false;
+           push_nongen_str_item ~fragment:false ~unsafe loc f_id;
            [%expr
              ([%e AC.int num],
               Eliom_lib.to_poly [%e
@@ -214,14 +214,14 @@ module Pass = struct
     in
     flush_nongen_str_item () :: str
 
-  let fragment ~loc ?typ ~context:_ ~num ~id _ =
+  let fragment ~loc ?typ ~context:_ ~num ~id ~unsafe _ =
     let typ =
       match typ with
       | Some typ -> typ
       | None -> [%type: _]
     in
     let e = format_args @@ flush_escaped_bindings () in
-    push_nongen_str_item loc id true;
+    push_nongen_str_item ~fragment:true ~unsafe loc id;
     [%expr
         [%e eid id]
         [%e
@@ -235,13 +235,14 @@ module Pass = struct
         ]
     ][@metaloc loc]
 
-  let escape_inject ~loc ?ident ~(context:Context.escape_inject) ~id expr =
+  let escape_inject
+        ~loc ?ident ~(context:Context.escape_inject) ~id ~unsafe expr =
     match context with
     | `Escaped_value _ ->
-      push_escaped_binding loc expr id;
+      push_escaped_binding loc expr id ~unsafe;
       [%expr assert false ]
     | `Injection _ ->
-      push_injection loc ?ident id.txt expr;
+      push_injection loc ?ident id.txt ~unsafe expr;
       eid id
 
   let set_global ~loc b =

--- a/src/ppx/ppx_eliom_type.ml
+++ b/src/ppx/ppx_eliom_type.ml
@@ -105,7 +105,7 @@ module Pass = struct
     [%str let () = [%e flush_typing_expr () ] ] [@metaloc loc] @
     [ item ]
 
-  let fragment ~loc ?typ ~context:_ ~num:_ ~id expr =
+  let fragment ~loc ?typ ~context:_ ~num:_ ~id ~unsafe:_ expr =
     let frag_eid = eid id in
     push_typing_str_item expr id;
     let typ = match typ with
@@ -122,7 +122,8 @@ module Pass = struct
       | None -> assert false
     ]
 
-  let escape_inject ~loc:_ ?ident:_ ~(context:Context.escape_inject) ~id expr =
+  let escape_inject
+        ~loc:_ ?ident:_ ~(context:Context.escape_inject) ~id ~unsafe:_ expr =
     push_typing_str_item expr id;
     push_typing_expr expr id;
     match context with

--- a/src/ppx/ppx_eliom_type.ml
+++ b/src/ppx/ppx_eliom_type.ml
@@ -105,8 +105,7 @@ module Pass = struct
     [%str let () = [%e flush_typing_expr () ] ] [@metaloc loc] @
     [ item ]
 
-  let fragment ?typ ~context:_ ~num:_ ~id expr =
-    let loc = expr.pexp_loc in
+  let fragment ~loc ?typ ~context:_ ~num:_ ~id expr =
     let frag_eid = eid id in
     push_typing_str_item expr id;
     let typ = match typ with
@@ -123,7 +122,7 @@ module Pass = struct
       | None -> assert false
     ]
 
-  let escape_inject ?ident:_ ~(context:Context.escape_inject) ~id expr =
+  let escape_inject ~loc:_ ?ident:_ ~(context:Context.escape_inject) ~id expr =
     push_typing_str_item expr id;
     push_typing_expr expr id;
     match context with

--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -1,3 +1,4 @@
+open Config
 open Migrate_parsetree
 open Ast_408
 open Parsetree
@@ -271,6 +272,162 @@ module Mli = struct
 
 end
 
+module Cmo = struct
+
+  let file = ref None
+
+  let exists () = !file <> None
+
+  let record_events events evl =
+    let open Instruct in
+    List.iter
+      (fun ev ->
+        match ev with
+        | {ev_loc = {loc_start = {Lexing.pos_fname; pos_cnum};
+                     loc_end = {Lexing.pos_cnum = pos_cnum'}};
+           ev_kind = Event_after ty} ->
+           if pos_cnum' = pos_cnum + 1 then
+             Hashtbl.add events (pos_fname, pos_cnum) ty
+        | _ -> ())
+      evl
+
+  let get_file () = match !file with Some f -> f | None -> assert false
+
+  let load () =
+    let file = get_file () in
+    match open_in file with
+    | exception Sys_error s ->
+      Location.raise_errorf
+        ~loc:(Location.in_file file)
+        "Eliom: Error while loading types: %s" s
+    | ic ->
+       let open Cmo_format in
+       let buffer = really_input_string ic (String.length cmo_magic_number) in
+       if buffer <> cmo_magic_number then
+         Location.raise_errorf
+           ~loc:(Location.in_file file)
+           "Eliom: Error while loading types: not an object file";
+       let cu_pos = input_binary_int ic in
+       seek_in ic cu_pos;
+       let cu = (input_value ic : compilation_unit) in
+       if cu.cu_debug = 0 then
+         Location.raise_errorf
+           ~loc:(Location.in_file file)
+           "Eliom: Error while loading types: no debugging information";
+       seek_in ic cu.cu_debug;
+       let evl = (input_value ic : Instruct.debug_event list) in
+       let events = Hashtbl.create 100 in
+       record_events events evl;
+       close_in ic;
+       events
+
+  let events = lazy (load ())
+
+  let label_of_string s =
+    if s = "" then
+      Asttypes.Nolabel
+    else if s.[0] = '?' then
+      Asttypes.Optional (String.sub s 1 (String.length s - 1))
+    else
+      Asttypes.Labelled s
+
+  let rec ident_of_out_ident id =
+    let open Outcometree in
+    let open Longident in
+    match id with
+    | Oide_apply (id, id') ->
+       Lapply (ident_of_out_ident id, ident_of_out_ident id')
+    | Oide_dot (id, nm) ->
+       Ldot (ident_of_out_ident id, nm)
+    | Oide_ident {printed_name = nm} ->
+       Lident nm
+
+  let counter = ref 0
+
+  let rec type_of_out_type ty =
+    let open Outcometree in
+    let open Parsetree in
+    let map = Hashtbl.create 1 in
+    let var x =
+      try Hashtbl.find map x with Not_found ->
+        let x' = Printf.sprintf "%s%s_%d" inferred_type_prefix x !counter in
+        incr counter;
+        Hashtbl.add map x x';
+        x'
+    in
+    let rec type_of_out_type ty =
+      match ty with
+      | Otyp_var (_, s) ->
+         Typ.var (var s)
+      | Otyp_arrow (lab, ty1, ty2) ->
+         Typ.arrow (label_of_string lab)
+           (type_of_out_type ty1) (type_of_out_type ty2)
+      | Otyp_tuple tyl ->
+         Typ.tuple (List.map type_of_out_type tyl)
+      | Otyp_constr (id, tyl) ->
+         Typ.constr (Location.mkloc (ident_of_out_ident id) Location.none)
+           (List.map type_of_out_type tyl)
+      | Otyp_object (fields, rest) ->
+         let fields =
+           List.map
+             (fun (label, ty) ->
+               {pof_desc = Otag (Location.mkloc label Location.none,
+                                 type_of_out_type ty);
+                pof_loc = Location.none;
+                pof_attributes = []})
+             fields
+         in
+         Typ.object_ (fields) (if rest = None then Closed else Open)
+      | Otyp_class (_, id, tyl) ->
+         Typ.class_ (Location.mkloc (ident_of_out_ident id) Location.none)
+           (List.map type_of_out_type tyl)
+      | Otyp_alias (ty, s) ->
+         Typ.alias (type_of_out_type ty) (var s)
+      | Otyp_variant (_, Ovar_typ ty, closed, tags) ->
+         Typ.variant [Rf.mk (Rinherit (type_of_out_type ty))]
+           (if closed then Closed else Open) tags
+      | Otyp_variant (_, Ovar_fields lst, closed, tags) ->
+         let row_fields =
+           List.map
+             (fun (label, const, tyl) ->
+               Rf.mk (Rtag (Location.mkloc label Location.none,
+                            const,
+                            List.map type_of_out_type tyl)))
+             lst
+         in
+         Typ.variant row_fields (if closed then Closed else Open) tags
+      | Otyp_poly (sl, ty) ->
+         Typ.poly (List.map (fun v -> Location.mkloc (var v) Location.none) sl)
+           (type_of_out_type ty)
+      | Otyp_abstract | Otyp_open | Otyp_sum _ | Otyp_manifest _
+        | Otyp_record _ | Otyp_module _ | Otyp_attribute _ | Otyp_stuff _ ->
+         assert false
+    in
+    type_of_out_type ty
+
+  let typ ty =
+    let open Versions.Convert(OCaml_current)(OCaml_408) in
+    let ty = Printtyp.tree_of_type_scheme ty in
+    type_of_out_type (copy_out_type ty)
+
+  let find err loc =
+    let {Lexing.pos_fname; pos_cnum} = loc.Location.loc_start in
+    try
+      typ (Hashtbl.find (Lazy.force events) (pos_fname, pos_cnum))
+    with Not_found ->
+      Typ.extension ~loc @@ AM.extension_of_error @@ Location.errorf ~loc
+        "Error: Inferred type of %s not found. You need to regenerate %s."
+        err (get_file ())
+
+  let find_escaped_ident = find "escaped ident"
+  let find_injected_ident = find "injected ident"
+  let find_fragment loc =
+    match Mli.get_fragment_type (find "client value" loc) with
+    | Some ty -> ty
+    | None -> assert false
+
+end
+
 (** Context convenience module. *)
 module Context = struct
 
@@ -285,7 +442,7 @@ module Context = struct
     | "client" | "client.start"
     | "eliom.client" | "eliom.client.start" -> `Client
     | _ -> invalid_arg "Eliom ppx: Not a context"
-  
+
   let rpc_of_string = function
     | "crpc"-> `Connected_rpc
     | "crpc_opt" -> `Connected_rpc_o
@@ -314,6 +471,8 @@ let driver_args = [
     "FILE Load inferred types from FILE.";
   "-notype", Arg.Unit (fun () -> Mli.type_file := None),
     " Unset explicitly set path from which to load inferred types.";
+  "-server-cmo", Arg.String (fun file -> Cmo.file := Some file),
+    "FILE Load inferred types from server cmo file FILE."
 ]
 
 (** Signature of specific code of a preprocessor. *)
@@ -333,13 +492,13 @@ module type Pass = sig
 
   (** How to handle "[\%client ...]" and "[\%shared ...]" expr. *)
   val fragment:
-    ?typ:core_type -> context:Context.server ->
+    loc:Location.t -> ?typ:core_type -> context:Context.server ->
     num:string -> id:string Location.loc ->
     expression -> expression
 
   (** How to handle escaped "~%ident" inside a fragment. *)
   val escape_inject:
-    ?ident:string -> context:Context.escape_inject ->
+    loc:Location.t -> ?ident:string -> context:Context.escape_inject ->
     id:string Location.loc ->
     expression -> expression
 
@@ -514,7 +673,7 @@ module Rpc = struct
       args_list
 
   let rec args_parser expr arg_list =
-    let loc = expr.pexp_loc in 
+    let loc = expr.pexp_loc in
     match expr with
     | [%expr fun () -> [%e? expr']] ->
         args_parser expr'
@@ -528,14 +687,14 @@ module Rpc = struct
         args_parser expr' ((pattern, typ, label) :: arg_list)
     | { pexp_desc = Pexp_fun (_, None, p, _) } ->
         print_error ~loc:p.ppat_loc Missing_argument_type
-    | e -> 
+    | e ->
       (
       match arg_list with
       | [] ->
           print_error ~loc:e.pexp_loc No_arguments
       | arg_list ->
           List.rev arg_list, loc )
-  
+
   let eliom_rpc_expression ~loc (rpc_name, fun_name, args_list, _pat_of_args, _typ_of_args, _expr_of_args)=
     let apply =
       apply_function_expr ~loc fun_name
@@ -629,7 +788,7 @@ module Rpc = struct
       |> format_args
     in
     let rec expr_mapper args_list =
-        match args_list with 
+        match args_list with
       | [] ->
           let rpc_name =
             Exp.constant (Pconst_string (rpc_name fun_name_pattern, None))
@@ -664,10 +823,10 @@ module Rpc = struct
                    args_list
         in
         let rec expr_mapper args_list =
-          match args_list with 
+          match args_list with
           |[] -> apply_function_expr ~loc ident.txt _apply
           |(pattern,_,label):: args_list'-> Exp.fun_ label None pattern (expr_mapper args_list')
-        in 
+        in
         ([ [%stri
              let [%p pattern] = [%e expr_mapper args_list]]
         [@metaloc loc]])
@@ -769,7 +928,7 @@ module Make (Pass : Pass) = struct
       let num = Name.fragment_num side_val.pexp_loc in
       let id = Location.mkloc (Name.fragment_ident num) side_val.pexp_loc in
       in_context context (`Fragment c)
-        (Pass.fragment ?typ ~context:c ~num ~id % mapper.AM.expr mapper)
+        (Pass.fragment ~loc ?typ ~context:c ~num ~id % mapper.AM.expr mapper)
         (exp_add_attrs attr side_val)
 
     (* ~%( ... ) ] *)
@@ -786,7 +945,7 @@ module Make (Pass : Pass) = struct
           in
           let new_context = `Injection c in
           in_context context new_context
-            (Pass.escape_inject ?ident ~context:new_context ~id %
+            (Pass.escape_inject ~loc ?ident ~context:new_context ~id %
              mapper.AM.expr mapper)
             inj
         | `Fragment c ->
@@ -796,7 +955,7 @@ module Make (Pass : Pass) = struct
           in
           let new_context = `Escaped_value c in
           in_context context new_context
-            (Pass.escape_inject ?ident ~context:new_context ~id %
+            (Pass.escape_inject ~loc ?ident ~context:new_context ~id %
              mapper.AM.expr mapper)
             inj
         | `Server ->
@@ -890,21 +1049,21 @@ module Make (Pass : Pass) = struct
         let c = Context.of_string txt in
         let l = flatmap (dispatch_str c mapper) strs in
         maybe_reset_injected_idents c ; l
-      | Pstr_extension (({txt}, PStr strs), _) 
+      | Pstr_extension (({txt}, PStr strs), _)
         when is_annotation txt ["cw_rpc"; "crpc" ;"crpc_opt";"rpc"] ->
-        let rpc_type = Context.rpc_of_string txt in 
+        let rpc_type = Context.rpc_of_string txt in
         let c = `Server in
-        let l = flatmap (dispatch_str c mapper) strs in 
+        let l = flatmap (dispatch_str c mapper) strs in
         let c = `Client in
         let l' =
           flatmap (dispatch_str c mapper)
-            (flatmap (Rpc.generate_client_struct_item rpc_type) strs) 
-        in 
+            (flatmap (Rpc.generate_client_struct_item rpc_type) strs)
+        in
         let l''= if (rpc_type =`Connected_rpc || rpc_type =`Connected_rpc_o)
-        then let c = `Server in 
+        then let c = `Server in
               flatmap (dispatch_str c mapper)
             (flatmap (Rpc.generate_server_struct_item rpc_type) strs)
-        else [] 
+        else []
         in
         let list = List.flatten [l;l';l''] in
         maybe_reset_injected_idents c ;

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -49,6 +49,16 @@ module Mli : sig
 
 end
 
+module Cmo : sig
+
+  val exists : unit -> bool
+
+  val find_escaped_ident : Location.t -> core_type
+  val find_injected_ident : Location.t -> core_type
+  val find_fragment : Location.t -> core_type
+
+end
+
 (** Signature of specific code of a preprocessor. *)
 module type Pass = sig
 
@@ -70,13 +80,13 @@ module type Pass = sig
 
   (** How to handle "[%client ...]" and "[%shared ...]" expr. *)
   val fragment:
-    ?typ:core_type -> context:Context.server ->
+    loc:Location.t -> ?typ:core_type -> context:Context.server ->
     num:string -> id:string Location.loc ->
     expression -> expression
 
   (** How to handle escaped "~%ident" inside a fragment. *)
   val escape_inject:
-    ?ident:string -> context:Context.escape_inject ->
+    loc:Location.t -> ?ident:string -> context:Context.escape_inject ->
     id:string Location.loc ->
     expression -> expression
 

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -29,7 +29,7 @@ module Context : sig
     | `Server (* [%%server ... ] *)
     | `Client (* [%%client ... ] *)
     | `Shared (* [%%shared  ... ] *)
-    | `Fragment of server (* [%client ... ] *)
+    | `Fragment of server * bool (* [%client ... ] *)
     | `Escaped_value of server (* [%%server [%client ~%( ... ) ] ] *)
     | `Injection of client (* [%%client ~%( ... ) ] *)
   ]
@@ -81,13 +81,13 @@ module type Pass = sig
   (** How to handle "[%client ...]" and "[%shared ...]" expr. *)
   val fragment:
     loc:Location.t -> ?typ:core_type -> context:Context.server ->
-    num:string -> id:string Location.loc ->
+    num:string -> id:string Location.loc -> unsafe:bool ->
     expression -> expression
 
   (** How to handle escaped "~%ident" inside a fragment. *)
   val escape_inject:
     loc:Location.t -> ?ident:string -> context:Context.escape_inject ->
-    id:string Location.loc ->
+    id:string Location.loc -> unsafe:bool ->
     expression -> expression
 
   val prelude : Location.t -> structure


### PR DESCRIPTION
By suitably instrumenting the server code to take advantage of the type information included in the debugging information contained in `.cmo` files, one can propagate server-side types to the client without having to type the code three times.

I have not updateed `eliomc` / `js_of_eliom` yet since I'm considering switching to `dune`.