### PR TITLE
rework cookie garbage collection

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "eliom"
-version: "6.12.4"
+version: "6.13.0"
 maintainer: "dev@ocsigen.org"
 authors: "dev@ocsigen.org"
 synopsis: "Client/server Web framework"
@@ -25,7 +25,7 @@ depends: [
   "lwt_log"
   "lwt_ppx"
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "2.10"}
+  "ocsigenserver" {>= "2.17.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "dbm" | "sqlite3"

--- a/src/lib/eliom_state.server.ml
+++ b/src/lib/eliom_state.server.ml
@@ -1244,8 +1244,7 @@ module Ext = struct
 
   let get_persistent_cookie_info
       ((_, _, cookie) : ([< Eliom_common.cookie_level ], [ `Pers ]) state) =
-    Lazy.force Eliommod_persess.persistent_cookies_table >>= fun table ->
-    Ocsipersist.find table cookie >>= fun v ->
+    Eliom_common.Persistent_cookies.Cookies.find cookie >>= fun v ->
     Lwt.return (cookie, v)
 
   let discard_state ~state =
@@ -1448,8 +1447,7 @@ module Ext = struct
     | None -> TNone
     | Some t -> TSome t
     in
-    Lazy.force Eliom_common.persistent_cookies_table >>= fun table ->
-    Ocsipersist.add table cookie (fullstname, exp, ti, sessgrp)
+    Eliom_common.Persistent_cookies.add cookie (fullstname, exp, ti, sessgrp)
 
   let get_service_cookie_timeout ~cookie:(_, (_, _, _, r, _, _)) =
     !r
@@ -1469,8 +1467,8 @@ module Ext = struct
 
   let unset_persistent_data_cookie_timeout
       ~cookie:(cookie, (fullstname, exp, _, sessgrp)) =
-    Lazy.force Eliom_common.persistent_cookies_table >>= fun table ->
-    Ocsipersist.add table cookie (fullstname, exp, TGlobal, sessgrp)
+    Eliom_common.Persistent_cookies.Cookies.add cookie
+      (fullstname, exp, TGlobal, sessgrp)
 
 
   let get_session_group_list () =

--- a/src/lib/server/eliommod_cookies.ml
+++ b/src/lib/server/eliommod_cookies.ml
@@ -152,8 +152,7 @@ let get_cookie_info
         lazy
           (catch
              (fun () ->
-               Lazy.force Eliom_common.persistent_cookies_table >>= fun table ->
-               Ocsipersist.find table value >>=
+               Eliom_common.Persistent_cookies.Cookies.find value >>=
                fun (full_state_name, persexp, perstimeout, sessgrp) ->
 
                  Eliommod_sessiongroups.Pers.up value sessgrp >>= fun () ->

--- a/src/lib/server/eliommod_pagegen.ml
+++ b/src/lib/server/eliommod_pagegen.ml
@@ -148,9 +148,7 @@ let update_cookie_table ?now sitedata (ci, sci) =
                       oldv = newc.Eliom_common.pc_value ->
                     catch
                       (fun () ->
-                        Lazy.force Eliommod_persess.persistent_cookies_table >>= fun table ->
-                        Ocsipersist.replace_if_exists
-                          table
+                        Eliom_common.Persistent_cookies.replace_if_exists
                           newc.Eliom_common.pc_value
                           (name,
                            newexp,
@@ -161,9 +159,7 @@ let update_cookie_table ?now sitedata (ci, sci) =
                         (* someone else closed the session *)
                         | e -> fail e)
                   | _ ->
-                    Lazy.force Eliommod_persess.persistent_cookies_table >>= fun table ->
-                    Ocsipersist.add
-                      table
+                    Eliom_common.Persistent_cookies.add
                       newc.Eliom_common.pc_value
                       (name,
                        newexp,
@@ -249,7 +245,7 @@ let gen is_eliom_extension sitedata = function
                        .Ocsigen_request_info
                        .meth req.Ocsigen_extensions.request_info) ->
   let req = Eliom_common.patch_request_info req in
-  let now = Unix.time () in
+  let now = Unix.gettimeofday () in
   Eliom_common.get_session_info req previous_extension_err
   >>= fun (ri, si, previous_tab_cookies_info) ->
   let (all_cookie_info, closedsessions) =

--- a/src/lib/server/eliommod_persess.ml
+++ b/src/lib/server/eliommod_persess.ml
@@ -39,7 +39,8 @@ let compute_cookie_info sitedata secure_o secure_ci cookie_info =
 
 
 let perstables = Eliom_common.perstables
-let persistent_cookies_table = Eliom_common.persistent_cookies_table
+
+module Persistent_cookies = Eliom_common.Persistent_cookies
 
 let number_of_persistent_tables () =
   List.length !perstables
@@ -140,8 +141,7 @@ let rec find_or_create_persistent_cookie_
   (* We do not need to verify if it already exists.
      make_new_session_id does never generate twice the same cookie. *)
     let usertimeout = ref Eliom_common.TGlobal (* See global table *) in
-    Lazy.force persistent_cookies_table >>= fun table ->
-    Ocsipersist.add table c
+    Persistent_cookies.add c
       (full_st_name,
        None (* Some 0. *) (* exp on server - We'll change it later *),
        Eliom_common.TGlobal (* timeout - see global config *),

--- a/src/lib/server/eliommod_persess.mli
+++ b/src/lib/server/eliommod_persess.mli
@@ -18,11 +18,22 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+open Eliom_common
+
 val perstables : string list ref
-val persistent_cookies_table :
-  (Eliom_common.full_state_name * float option * Eliom_common.timeout *
-   Eliom_common.perssessgrp option)
-  Ocsipersist.table Lwt.t Lazy.t
+
+module Persistent_cookies : sig
+  type cookie = full_state_name * float option * timeout * perssessgrp option
+  module Cookies : Ocsipersist.TABLE
+    with type key = string and type value = cookie
+  module Expiry_dates : Ocsipersist.TABLE
+    with type key = float and type value = string
+  val add : string -> cookie -> unit Lwt.t
+  val replace_if_exists : string -> cookie -> unit Lwt.t
+  val garbage_collect :
+    section:Lwt_log_core.Section.t -> (Cookies.key -> unit Lwt.t) -> unit Lwt.t
+end
+
 val number_of_persistent_tables : unit -> int
 val number_of_persistent_table_elements : unit -> (string * int) list Lwt.t
 val close_persistent_state2 :

--- a/src/lib/server/eliommod_sessadmin.ml
+++ b/src/lib/server/eliommod_sessadmin.ml
@@ -94,8 +94,7 @@ let close_all_data_states ~scope ~secure sitedata =
 
 
 let close_all_persistent_states2 full_st_name sitedata =
-  Lazy.force Eliommod_persess.persistent_cookies_table >>=
-  Ocsipersist.iter_table
+  Eliom_common.Persistent_cookies.Cookies.iter
     (fun k ((scope, _, _) as full_st_name2, old_exp, old_t, sessiongrp) ->
       if full_st_name = full_st_name2 && old_t = Eliom_common.TGlobal
       then Eliommod_persess.close_persistent_state2
@@ -195,8 +194,7 @@ let update_pers_exp full_st_name sitedata old_glob_timeout new_glob_timeout =
       close_all_persistent_states2 full_st_name sitedata
   | _ ->
     let now = Unix.time () in
-    Lazy.force Eliommod_persess.persistent_cookies_table >>= fun table ->
-    Ocsipersist.iter_table
+    Eliom_common.Persistent_cookies.Cookies.iter
       (fun k ((scope, _, _) as full_st_name2, old_exp, old_t, sessgrp) ->
         if full_st_name = full_st_name2 && old_t =
           Eliom_common.TGlobal
@@ -211,8 +209,9 @@ let update_pers_exp full_st_name sitedata old_glob_timeout new_glob_timeout =
           | Some t when t <= now ->
               Eliommod_persess.close_persistent_state2
                 ~scope sitedata sessgrp k
-          | _ -> Ocsipersist.add table k (full_st_name2, newexp,
-                   Eliom_common.TGlobal, sessgrp) >>= Lwt_unix.yield
+          | _ ->
+            Eliom_common.Persistent_cookies.add k
+              (full_st_name2, newexp, Eliom_common.TGlobal, sessgrp) >>=
+            Lwt_unix.yield
         else return_unit
       )
-      table

--- a/src/lib/server/eliommod_sessexpl.ml
+++ b/src/lib/server/eliommod_sessexpl.ml
@@ -57,12 +57,8 @@ let iter_data_cookies f =
 
     (** Iterator on persistent cookies *)
 let iter_persistent_cookies f =
-  Lazy.force Eliommod_persess.persistent_cookies_table >>=
-  Ocsipersist.iter_table
-    (fun k v ->
-      f (k, v) >>=
-      Lwt_unix.yield
-    )
+  Eliom_common.Persistent_cookies.Cookies.iter
+    (fun k v -> f (k, v) >>= Lwt_unix.yield)
 
 
     (** Iterator on service cookies *)
@@ -94,14 +90,12 @@ let fold_data_cookies f beg =
 
     (** Iterator on persistent cookies *)
 let fold_persistent_cookies f beg =
-  Lazy.force Eliommod_persess.persistent_cookies_table >>= fun table ->
-  Ocsipersist.fold_table
+  Eliom_common.Persistent_cookies.Cookies.fold
     (fun k v beg ->
       f (k, v) beg >>= fun res ->
       Lwt_unix.yield () >>= fun () ->
       return res
     )
-    table
     beg
 
 (*****************************************************************************)
@@ -122,4 +116,4 @@ let number_of_table_elements () =
   List.map (fun f -> f ()) !Eliommod_datasess.counttableelements
 
 let number_of_persistent_cookies () =
-  Lazy.force Eliommod_persess.persistent_cookies_table >>= Ocsipersist.length
+  Eliom_common.Persistent_cookies.Cookies.length ()

--- a/src/lib/server/eliommod_sessiongroups.ml
+++ b/src/lib/server/eliommod_sessiongroups.ml
@@ -504,8 +504,7 @@ module Pers = struct
                                       belonging to the group grp *)
             (* group_name is the cookie value *)
             remove sitedata group_name grp >>= fun () ->
-            !!Eliom_common.persistent_cookies_table >>= fun table ->
-            Ocsipersist.remove table group_name
+            Eliom_common.Persistent_cookies.Cookies.remove group_name
           | _ -> Lwt.return_unit)
         >>= fun () ->
 
@@ -529,9 +528,7 @@ module Pers = struct
         match cookie_level with
           | `Client_process -> begin
             (* We remove cookie info from the table *)
-            !!Eliom_common.persistent_cookies_table >>= fun table ->
-            Ocsipersist.remove table cookie
-            >>= fun () ->
+            Eliom_common.Persistent_cookies.Cookies.remove cookie >>= fun () ->
 
             (* We remove the session from its group: *)
             remove sitedata cookie fullsessgrp >>= fun () ->


### PR DESCRIPTION
Depends on https://github.com/ocsigen/ocsigenserver/pull/187.

The current implementation suffers from performance issues as checking
for expired cookies requires cycling through the entire set of
persistent cookies.
This commit adds a new Ocsipersist table that maps cookie expiry dates
to cookie names, allowing for an efficient scan for potentially expired
cookies.