### PR TITLE
Set an upper bound version to ocsigenserver

### DIFF
--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "3.0.0"}
+  "ocsigenserver" {< "4.0.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "dbm" | "sqlite3"


### PR DESCRIPTION
Because the versions above that introduces breaking changes (that are
resolved by https://github.com/ocsigen/eliom/pull/685)