### PR TITLE
UNFINISHED! Hash session cookie value in si to avoid session id leaks

### DIFF
--- a/src/lib/eliom_common.server.ml
+++ b/src/lib/eliom_common.server.ml
@@ -136,7 +136,8 @@ let string_of_perssessgrp = id
 
 type 'a one_service_cookie_info =
   (* service sessions: *)
-  {sc_value:string             (* current value *);
+  {sc_hvalue:string            (* hash of current value *);
+   sc_set_value:string option  (* new value to set *);
    sc_table:'a ref             (* service session table
                                   ref towards cookie table
                                *);
@@ -157,7 +158,8 @@ type 'a one_service_cookie_info =
 
 type one_data_cookie_info =
   (* in memory data sessions: *)
-  {dc_value:string                    (* current value *);
+  {dc_hvalue:string                   (* hash of current value *);
+   dc_set_value:string option         (* new value to set *);
    dc_timeout:timeout ref             (* user timeout -
                                          ref towards cookie table
                                       *);
@@ -171,7 +173,8 @@ type one_data_cookie_info =
   }
 
 type one_persistent_cookie_info =
-  {pc_value:string                    (* current value *);
+  {pc_hvalue:string                   (* hash of current value *);
+   pc_set_value:string option         (* new value to set *);
    pc_timeout:timeout ref             (* user timeout *);
    pc_cookie_exp:cookie_exp ref       (* cookie expiration date to set *);
    pc_session_group:perssessgrp option ref (* session group *)
@@ -181,11 +184,8 @@ type one_persistent_cookie_info =
 (*VVV heavy *)
 type 'a cookie_info1 =
   (* service sessions: *)
-  (string option            (* value sent by the browser *)
-   (* None = new cookie
-      (not sent by the browser) *)
+  (bool            (* there was a value sent by the browser *)
    *
-
    'a one_service_cookie_info session_cookie ref
    (* SCNo_data = the session has been closed
       SCData_session_expired = the cookie has not been found in the table.
@@ -197,11 +197,8 @@ type 'a cookie_info1 =
     Full_state_name_table.t ref (* The key is the full session name *) *
 
   (* in memory data sessions: *)
-  (string option            (* value sent by the browser *)
-   (* None = new cookie
-      (not sent by the browser) *)
+  (bool            (* there was a value sent by the browser *)
    *
-
    one_data_cookie_info session_cookie ref
    (* SCNo_data = the session has been closed
       SCData_session_expired = the cookie has not been found in the table.
@@ -214,17 +211,14 @@ type 'a cookie_info1 =
     Full_state_name_table.t ref (* The key is the full session name *) *
 
   (* persistent sessions: *)
-  ((string                  (* value sent by the browser *) *
-    timeout                 (* timeout at the beginning of the request *) *
+  ((timeout                 (* timeout at the beginning of the request *) *
     float option            (* (server side) expdate
                                at the beginning of the request
                                None = no exp *) *
     perssessgrp option      (* session group at beginning of request *))
      option
-   (* None = new cookie
-      (not sent by the browser) *)
+   (* None = no cookie sent by the browser *)
    *
-
    one_persistent_cookie_info session_cookie ref
    (* SCNo_data = the session has been closed
       SCData_session_expired = the cookie has not been found in the table.
@@ -862,6 +856,9 @@ let full_state_name_of_cookie_name cookie_level cookiename =
     | `Session -> (`Session sc_hier, secure, sitedirstring)
     | `Client_process -> (`Client_process sc_hier, secure, sitedirstring)
 
+let hash_cookie c = "H"^c
+(*!!! trouver une meilleure fonction de hashage ;-) !!!*)
+
 let getcookies secure cookie_level cookienamepref cookies =
   let length = String.length cookienamepref in
   let last = length - 1 in
@@ -873,7 +870,7 @@ let getcookies secure cookie_level cookienamepref cookies =
           let (_, sec, _) as expcn =
             full_state_name_of_cookie_name cookie_level name in
           if sec = secure
-          then Full_state_name_table.add expcn value beg
+          then Full_state_name_table.add expcn (hash_cookie value) beg
           else beg
         with Not_found -> beg
       else beg

--- a/src/lib/eliom_common.server.mli
+++ b/src/lib/eliom_common.server.mli
@@ -326,7 +326,8 @@ val default_client_cookie_exp : unit -> cookie_exp
 
 type timeout = TGlobal | TNone | TSome of float
 type 'a one_service_cookie_info = {
-  sc_value : string;
+  sc_hvalue : string;
+  sc_set_value : string option;
   sc_table : 'a ref;
   sc_timeout : timeout ref;
   sc_exp : float option ref;
@@ -335,7 +336,8 @@ type 'a one_service_cookie_info = {
   mutable sc_session_group_node:string Ocsigen_cache.Dlist.node;
 }
 type one_data_cookie_info = {
-  dc_value : string;
+  dc_hvalue : string;
+  dc_set_value : string option;
   dc_timeout : timeout ref;
   dc_exp : float option ref;
   dc_cookie_exp : cookie_exp ref;
@@ -343,20 +345,20 @@ type one_data_cookie_info = {
   mutable dc_session_group_node:string Ocsigen_cache.Dlist.node;
 }
 type one_persistent_cookie_info = {
-  pc_value : string;
+  pc_hvalue : string;
+  pc_set_value : string option;
   pc_timeout : timeout ref;
   pc_cookie_exp : cookie_exp ref;
   pc_session_group : perssessgrp option ref;
 }
 
 type 'a cookie_info1 =
-    (string option * 'a one_service_cookie_info session_cookie ref)
+    (bool * 'a one_service_cookie_info session_cookie ref)
     Full_state_name_table.t ref *
-    (string option * one_data_cookie_info session_cookie ref) Lazy.t
+    (bool * one_data_cookie_info session_cookie ref) Lazy.t
     Full_state_name_table.t ref *
-    ((string * timeout * float option *
-      perssessgrp option)
-     option * one_persistent_cookie_info session_cookie ref)
+      ((timeout * float option * perssessgrp option) option *
+         one_persistent_cookie_info session_cookie ref)
     Lwt.t Lazy.t Full_state_name_table.t ref
 
 type 'a cookie_info =
@@ -754,3 +756,5 @@ end
 
 (** Raises exception on server, only relevant for client apps *)
 val client_html_file : unit -> string
+
+val hash_cookie : string -> string

--- a/src/lib/eliom_state.server.ml
+++ b/src/lib/eliom_state.server.ml
@@ -328,7 +328,7 @@ let rec close_service_state_if_empty ~scope ?secure () =
         if
           (Eliommod_sessiongroups.Data.group_size
              (sitedata.Eliom_common.site_dir_string, `Client_process,
-              Left c.Eliom_common.sc_value)
+              Left c.Eliom_common.sc_hvalue)
            = 0) (* no tab sessions *)
           &&
             (Eliom_common.service_tables_are_empty !(c.Eliom_common.sc_table))
@@ -367,11 +367,11 @@ let rec close_volatile_state_if_empty ~scope ?secure () =
               when
                 (Eliommod_sessiongroups.Data.group_size
                    (sitedata.Eliom_common.site_dir_string, `Client_process,
-                    Left c.Eliom_common.dc_value)
+                    Left c.Eliom_common.dc_hvalue)
                  = 0) (* no tab sessions *)
                 &&
                   (sitedata.Eliom_common.not_bound_in_data_tables
-                     c.Eliom_common.dc_value)
+                     c.Eliom_common.dc_hvalue)
                 ->
             Eliommod_sessiongroups.Data.remove
               c.Eliom_common.dc_session_group_node
@@ -380,7 +380,7 @@ let rec close_volatile_state_if_empty ~scope ?secure () =
 (* This should never occur, because we always have tab session data
    when we have a tab session (at least the change_page_event).
         if (sitedata.Eliom_common.not_bound_in_data_tables
-              c.Eliom_common.dc_value)
+              c.Eliom_common.dc_hvalue)
         then Eliommod_sessiongroups.Data.remove
           c.Eliom_common.dc_session_group_node *)
       | `Session_group scope_hierarchy ->
@@ -587,7 +587,7 @@ let set_persistent_data_session_group ?set_max
     sitedata
     ?set_max
     (fst sitedata.Eliom_common.max_persistent_data_sessions_per_group)
-    c.Eliom_common.pc_value !grp n in
+    c.Eliom_common.pc_hvalue !grp n in
   let%lwt () = Lwt_list.iter_p
     (Eliommod_persess.close_persistent_state2
        ~scope:(scope:>Eliom_common.user_scope) sitedata None) l in
@@ -604,7 +604,7 @@ let unset_persistent_data_session_group
       ~secure_o:secure ~sp () in
     let grp = c.Eliom_common.pc_session_group in
     let%lwt () = Eliommod_sessiongroups.Pers.remove
-      sitedata c.Eliom_common.pc_value !grp in
+      sitedata c.Eliom_common.pc_hvalue !grp in
     grp := None;
 
     close_persistent_state_if_empty
@@ -904,7 +904,7 @@ let get_p_table_key_
   let get_cookie () =
     let cookie_scope = Eliom_common.cookie_scope_of_user_scope scope in
     let%lwt c = find_cookie ~cookie_scope ~secure_o:(Some secure) () in
-    Lwt.return c.Eliom_common.pc_value
+    Lwt.return c.Eliom_common.pc_hvalue
   in
   let%lwt key = match scope with
     | `Session_group state_name ->
@@ -992,7 +992,7 @@ let get_table_key_ ~table:(scope, secure, table)
   let get_cookie () =
     let cookie_scope = Eliom_common.cookie_scope_of_user_scope scope in
       let c = find_cookie ~cookie_scope ~secure_o:(Some secure) () in
-      c.Eliom_common.dc_value
+      c.Eliom_common.dc_hvalue
   in
   (table, match scope with
     | `Session_group state_name ->
@@ -1232,7 +1232,7 @@ module Ext = struct
       let cookie = Eliommod_datasess.find_or_create_data_cookie
           ~secure_o:secure ~cookie_scope ()
       in
-      ((scope, `Data, cookie.Eliom_common.dc_value) : ('a, 'b) state)
+      ((scope, `Data, cookie.Eliom_common.dc_hvalue) : ('a, 'b) state)
 
   let current_persistent_data_state
       ?secure ?(scope = (Eliom_common.default_session_scope
@@ -1248,7 +1248,7 @@ module Ext = struct
     | #Eliom_common.cookie_scope as cookie_scope ->
       Eliommod_persess.find_or_create_persistent_cookie
         ~secure_o:secure ~cookie_scope () >>= fun cookie ->
-      Lwt.return (scope, `Pers, cookie.Eliom_common.pc_value)
+      Lwt.return (scope, `Pers, cookie.Eliom_common.pc_hvalue)
 
   let current_service_state
       ?secure ?(scope = (Eliom_common.default_session_scope
@@ -1262,7 +1262,7 @@ module Ext = struct
     | #Eliom_common.cookie_scope as cookie_scope ->
       let cookie = Eliommod_sersess.find_or_create_service_cookie
           ~secure_o:secure ~cookie_scope () in
-      (scope, `Service, cookie.Eliom_common.sc_value)
+      (scope, `Service, cookie.Eliom_common.sc_hvalue)
 
   let get_service_cookie_info
       ((_, _, cookie) : ([< Eliom_common.cookie_level ], [ `Service ]) state) =
@@ -1565,7 +1565,7 @@ let get_service_cookie ~cookie_scope ?secure () =
   try
     let c = Eliommod_sersess.find_service_cookie_only
       ~cookie_scope ~secure_o:secure () in
-    Some c.Eliom_common.sc_value
+    Some c.Eliom_common.sc_hvalue
   with Not_found | Eliom_common.Eliom_Session_expired -> None
 
 let get_volatile_data_cookie ~cookie_scope ?secure () =
@@ -1573,14 +1573,14 @@ let get_volatile_data_cookie ~cookie_scope ?secure () =
     let c = Eliommod_datasess.find_data_cookie_only
         ~cookie_scope ~secure_o:secure ()
     in
-    Some c.Eliom_common.dc_value
+    Some c.Eliom_common.dc_hvalue
   with Not_found | Eliom_common.Eliom_Session_expired -> None
 
 let get_persistent_data_cookie ~cookie_scope ?secure () =
   try%lwt
     let%lwt c = Eliommod_persess.find_persistent_cookie_only
       ~cookie_scope ~secure_o:secure () in
-    return_some c.Eliom_common.pc_value
+    return_some c.Eliom_common.pc_hvalue
   with
     | Not_found
     | Eliom_common.Eliom_Session_expired -> return_none

--- a/src/lib/server/eliommod_datasess.ml
+++ b/src/lib/server/eliommod_datasess.ml
@@ -114,7 +114,7 @@ let rec find_or_create_data_cookie ?set_session_group
               ~sp
               ()
             in
-            Some v.Eliom_common.dc_value
+            Some v.Eliom_common.dc_hvalue
           end
         | _ -> set_session_group
     in
@@ -142,7 +142,8 @@ let rec find_or_create_data_cookie ?set_session_group
        usertimeout,
        fullsessgrpref,
        node);
-    {Eliom_common.dc_value= c;
+    {Eliom_common.dc_hvalue= Eliom_common.hash_cookie c;
+     Eliom_common.dc_set_value= Some c;
      Eliom_common.dc_timeout= usertimeout;
      Eliom_common.dc_exp= serverexp;
      Eliom_common.dc_cookie_exp=
@@ -202,7 +203,7 @@ let rec find_or_create_data_cookie ?set_session_group
     cookie_info :=
       Eliom_common.Full_state_name_table.add
         full_st_name
-        (Lazy.from_val (None, ref (Eliom_common.SC v)))
+        (Lazy.from_val (false, ref (Eliom_common.SC v)))
         !cookie_info;
     v
 

--- a/src/lib/server/eliommod_pagegen.ml
+++ b/src/lib/server/eliommod_pagegen.ml
@@ -150,18 +150,18 @@ let update_cookie_table ?now sitedata (ci, sci) =
                     | Eliom_common.TSome t -> Some (t +. now)
                 in
                 match oldvalue with
-                  | Some (oldv, oldti, oldexp, oldgrp) when
+                  | Some (oldti, oldexp, oldgrp) when
                       (oldexp = newexp &&
                           oldti = !(newc.Eliom_common.pc_timeout) &&
                           oldgrp = !(newc.Eliom_common.pc_session_group) &&
-                       oldv = newc.Eliom_common.pc_value) -> Lwt.return ()
+                       newc.Eliom_common.pc_set_value = None) -> Lwt.return ()
                 (* nothing to do *)
-                  | Some (oldv, oldti, oldexp, oldgrp) when
-                      oldv = newc.Eliom_common.pc_value ->
+                  | Some (oldti, oldexp, oldgrp) when
+                      newc.Eliom_common.pc_set_value = None ->
                     Lwt.catch
                       (fun () ->
                         Eliom_common.Persistent_cookies.replace_if_exists
-                          newc.Eliom_common.pc_value
+                          newc.Eliom_common.pc_hvalue
                           (name,
                            newexp,
                            !(newc.Eliom_common.pc_timeout),
@@ -172,7 +172,7 @@ let update_cookie_table ?now sitedata (ci, sci) =
                         | e -> Lwt.fail e)
                   | _ ->
                     Eliom_common.Persistent_cookies.add
-                      newc.Eliom_common.pc_value
+                      newc.Eliom_common.pc_hvalue
                       (name,
                        newexp,
                        !(newc.Eliom_common.pc_timeout),

--- a/src/lib/server/eliommod_persess.ml
+++ b/src/lib/server/eliommod_persess.ml
@@ -93,7 +93,7 @@ let close_persistent_state ~scope ~secure_o ?sp () =
            ~scope:(scope :> Eliom_common.user_scope)
            sp.Eliom_common.sp_sitedata
            !(c.Eliom_common.pc_session_group)
-           c.Eliom_common.pc_value)
+           c.Eliom_common.pc_hvalue)
         >>= fun () ->
         ior := Eliom_common.SCNo_data;
         return_unit
@@ -131,7 +131,7 @@ let rec find_or_create_persistent_cookie_
               ~secure_o
               ~sp
               () in
-            Lwt.return_some r.Eliom_common.pc_value
+            Lwt.return_some r.Eliom_common.pc_hvalue
           end
         | _  -> Lwt.return set_session_group in
 
@@ -156,7 +156,8 @@ let rec find_or_create_persistent_cookie_
                      sitedata None) l
     >>= fun () ->
     Lwt.return
-      { Eliom_common.pc_value= c;
+      { Eliom_common.pc_hvalue= Eliom_common.hash_cookie c;
+        Eliom_common.pc_set_value= Some c;
         Eliom_common.pc_timeout= usertimeout;
         Eliom_common.pc_cookie_exp =
           ref (Eliom_common.default_client_cookie_exp ()) (* exp on client *);

--- a/src/lib/server/eliommod_sersess.ml
+++ b/src/lib/server/eliommod_sersess.ml
@@ -110,7 +110,7 @@ let rec find_or_create_service_cookie_ ?set_session_group
               ~sp
               ()
             in
-            Some v.Eliom_common.sc_value
+            Some v.Eliom_common.sc_hvalue
           end
         |  _ -> set_session_group
     in
@@ -140,7 +140,8 @@ let rec find_or_create_service_cookie_ ?set_session_group
        usertimeout,
        fullsessgrpref,
        node);
-    {Eliom_common.sc_value= c;
+    {Eliom_common.sc_hvalue= Eliom_common.hash_cookie c;
+     Eliom_common.sc_set_value= Some c;
      Eliom_common.sc_table= str;
      Eliom_common.sc_timeout= usertimeout;
      Eliom_common.sc_exp= serverexp;
@@ -201,7 +202,7 @@ let rec find_or_create_service_cookie_ ?set_session_group
     cookie_info :=
       Eliom_common.Full_state_name_table.add
         full_st_name
-        (None, ref (Eliom_common.SC v))
+        (false, ref (Eliom_common.SC v))
         !cookie_info;
     v
 


### PR DESCRIPTION
We now use hash as key in session tables
Warning: will close all existing sessions!!!

Remains to be done:
 - find good hash function
 - do we want to keep the initial value to keep functions Eliom_state.set_*_cookie_exp_date?
 in that case I think there is no other way than keeping the old value somewhere (instead of a_cookie_was_sent_by_browser)
 (in that case we'll need to adapt compute_new_ri_cookies too? (exp in the past?))
 - use an abstract type for hashed values (?)
 - transition period to avoid closing all sessions?