### PR TITLE
[cookies] use timestamp with less precision

### DIFF
--- a/src/lib/server/eliommod_pagegen.ml
+++ b/src/lib/server/eliommod_pagegen.ml
@@ -54,7 +54,7 @@ let handle_site_exn exn info sitedata =
 let update_cookie_table ?now sitedata (ci, sci) =
   let now = match now with
     | Some n -> n
-    | None -> Unix.gettimeofday ()
+    | None -> Unix.time ()
   in
 
   let update_exp


### PR DESCRIPTION
Too much precision will lead to entries in
Persistent_cookies.Expiry_dates not being deleted because of rounding
problems in the ocsipersist-pgsql backend.