### PR TITLE
[ppx] Make the PPX syntax extension more robust

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "eliom"
-version: "9.2.1"
+version: "9.2.2"
 maintainer: "dev@ocsigen.org"
 authors: "dev@ocsigen.org"
 synopsis: "Client/server Web framework"

--- a/src/ppx/ppx_eliom_type.ml
+++ b/src/ppx/ppx_eliom_type.ml
@@ -112,7 +112,7 @@ module Pass = struct
       [%e frag_eid] :=
         Some ( Eliom_syntax.client_value "" 0 :
                  [%t typ] Eliom_client_value.t);
-      (Option.get (! [%e frag_eid]) : _ Eliom_client_value.t)
+      (Stdlib.Option.get (! [%e frag_eid]) : _ Eliom_client_value.t)
     ]
 
   let escape_inject


### PR DESCRIPTION
Make the client fragments compatible with the opening of `Eliom_lib`.

Fixes #730.
