### PR TITLE
configuration option for omitting cookie creation

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "eliom"
-version: "9.3.2"
+version: "9.4.0"
 maintainer: "dev@ocsigen.org"
 authors: "dev@ocsigen.org"
 synopsis: "Client/server Web framework"

--- a/src/lib/eliom_common.server.mli
+++ b/src/lib/eliom_common.server.mli
@@ -22,6 +22,8 @@
 
 open Eliom_lib
 
+module Ocsipersist : module type of Ocsipersist
+
 (** {2 Scopes} *)
 (* those types are not available to the user, a scope must be created using
    create_..._scope functions *)
@@ -428,6 +430,8 @@ type node_info = {
 
 module Hier_set : Set.S
 
+type omitpersistentstorage_rule = HeaderRule of Ocsigen_header.Name.t * Re.re
+
 type 'a dircontent = Vide | Table of 'a direlt ref String.Table.t
 and 'a direlt = Dir of 'a dircontent ref | File of 'a ref
 
@@ -580,6 +584,7 @@ and sitedata = {
   mutable html_content_type : string option;
   mutable ignored_get_params : (string * Re.re) list;
   mutable ignored_post_params : (string * Re.re) list;
+  mutable omitpersistentstorage : omitpersistentstorage_rule list option;
 }
 
 type 'a lazy_site_value (** lazy site values, are lazy values with

--- a/src/lib/eliom_reference.server.ml
+++ b/src/lib/eliom_reference.server.ml
@@ -25,8 +25,8 @@ open Eliom_state
 let (>>=) = Lwt.bind
 
 module Ocsipersist = struct
-  include Ocsipersist.Store
-  include Ocsipersist.Polymorphic
+  include Eliom_common.Ocsipersist.Store
+  include Eliom_common.Ocsipersist.Polymorphic
 end
 
 let pers_ref_store = Ocsipersist.open_store "eliom__persistent_refs"

--- a/src/lib/eliom_reference.server.mli
+++ b/src/lib/eliom_reference.server.mli
@@ -25,7 +25,6 @@
 
 *)
 
-
 (** Eliom references come in two flavors: they may be stored persistently or
     the may be volatile.  The module [Volatile] allows creation of
     references which can be, get, set, modify, and unset volatile references

--- a/src/lib/eliom_state.server.ml
+++ b/src/lib/eliom_state.server.ml
@@ -885,7 +885,7 @@ let get_session_service_table_if_exists ~sp
 (*****************************************************************************)
 (** {2 persistent sessions} *)
 
-module Ocsipersist = Ocsipersist.Polymorphic
+module Ocsipersist = Eliom_common.Ocsipersist.Polymorphic
 
 type 'a persistent_table =
     (Eliom_common.user_scope *

--- a/src/lib/server/eliommod_cookies.ml
+++ b/src/lib/server/eliommod_cookies.ml
@@ -50,7 +50,7 @@ module Persistent_cookies = struct
      the initialization of eliom in case we use static linking with
      sqlite backend ... *)
 
-  module Ocsipersist = Ocsipersist.Functorial
+  module Ocsipersist = Eliom_common.Ocsipersist.Functorial
 
   (* NOTE: Do not forget to change the version number when the internal format changes! *)
   let persistent_cookie_table_version = "_v5"

--- a/src/lib/server/eliommod_pagegen.mli
+++ b/src/lib/server/eliommod_pagegen.mli
@@ -18,10 +18,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 val def_handler : exn -> 'b Lwt.t
-val handle_site_exn :
-  exn ->
-  Eliom_common.info ->
-  Eliom_common.sitedata -> Ocsigen_response.t Lwt.t
 val execute :
   float ->
   (float ->

--- a/src/lib/server/eliommod_sessiongroups.ml
+++ b/src/lib/server/eliommod_sessiongroups.ml
@@ -415,7 +415,7 @@ module Pers = struct
 (*VVV Verify this carefully! *)
 (*VVV VERIFY concurrent access *)
 
-  module Ocsipersist = Ocsipersist.Polymorphic
+  module Ocsipersist = Eliom_common.Ocsipersist.Polymorphic
 
   let grouptable : (nbmax * string list) Ocsipersist.table Lwt.t Lazy.t =
     lazy (Ocsipersist.open_table "__eliom_session_group_table")


### PR DESCRIPTION
Adds a configuration option that allows for the omission of the storage
of any persistent information on the server for any requests that
satisfy all of the given conditions. Conditions can be expressed as
PCREs applied to any HTTP header of the request. This can be used to
prevent inundating the cookie table by cookies generated for crawlers
(that usually do not store cookies on their end anyway).

Documentation: https://github.com/ocsigen/eliom/pull/734