### PR TITLE
[cookies] fix: no longer log cookie IDs but only hashes

### DIFF
--- a/src/lib/eliom_common.server.ml
+++ b/src/lib/eliom_common.server.ml
@@ -105,19 +105,21 @@ module SessionCookies =
 (* keys in tables are hashes of cookie values *)
 module Hashed_cookies : sig
     type t
+    val sha256 : string -> string
     val hash : string -> t
     val to_string : t -> string
 end = struct
   type t = string
+
+  let sha256 c =
+    let to_b64 = Cryptokit.Base64.encode_compact () in
+    Cryptokit.transform_string to_b64 @@
+      Cryptokit.(hash_string (Hash.sha256 ()) c)
+
   let hash c =
     (* To preserve compatibility, we only hash cookies that ends with an
        'H'.  This is the case for all new cookies (see Eliommod_cookies). *)
-    if c <> "" &&  c.[String.length c - 1] = 'H' then
-      let to_b64 = Cryptokit.Base64.encode_compact () in
-      Cryptokit.transform_string to_b64
-        (Cryptokit.(hash_string (Hash.sha256 ()) c))
-    else
-      c
+    if c <> "" &&  c.[String.length c - 1] = 'H' then sha256 c else c
 
   let to_string x = x
 end

--- a/src/lib/eliom_common.server.mli
+++ b/src/lib/eliom_common.server.mli
@@ -327,7 +327,12 @@ val default_client_cookie_exp : unit -> cookie_exp
 
 module Hashed_cookies : sig
   type t
+
+  val sha256 : string -> string
+
+  (** NOTE: this function is the identity function for strings that do not with an 'H' *)
   val hash : string -> t
+
   val to_string : t -> string
 end
 

--- a/src/lib/server/eliommod_cookies.ml
+++ b/src/lib/server/eliommod_cookies.ml
@@ -104,10 +104,12 @@ module Persistent_cookies = struct
 
   let garbage_collect ~section gc_cookie =
     let now = Unix.time () in
-    Expiry_dates.iter ~lt:now @@ fun date cookies ->
+    Expiry_dates.iter ~lt:now @@ fun date cookies_str ->
+      let cookies = String.split_on_char ',' cookies_str in
+      let cookies_log = String.concat "," @@ List.map Eliom_common.Hashed_cookies.sha256 cookies in
       Lwt_log.ign_info_f ~section "potentially expired cookies %.0f: %s"
-                                    date cookies;
-      Lwt_list.iter_s gc_cookie (String.split_on_char ',' cookies) >>= fun _ ->
+                                  date cookies_log;
+      Lwt_list.iter_s gc_cookie cookies >>= fun _ ->
       Expiry_dates.remove date
 end
 

--- a/src/lib/server/eliommod_gc.ml
+++ b/src/lib/server/eliommod_gc.ml
@@ -303,18 +303,18 @@ let data_session_gc sitedata =
 let persistent_session_gc sitedata =
   let gc () =
     let now = Unix.time () in
-    let hash c = Eliom_common.Hashed_cookies.(to_string @@ hash c) in
+    let log_hash c = Eliom_common.Hashed_cookies.(sha256 c) in
     let do_gc_cookie cookie ((scope, _, _), exp, _, session_group) =
       match exp with
       | Some exp when exp <= now ->
-        Lwt_log.ign_info_f ~section "remove expired cookie %s" (hash cookie);
+        Lwt_log.ign_info_f ~section "remove expired cookie %s" (log_hash cookie);
         Eliommod_persess.close_persistent_state2
           ~scope
           sitedata
           session_group cookie
       (*WAS: remove_from_all_persistent_tables k *)
       | _ ->
-          Lwt_log.ign_info_f ~section "cookie not expired: %s" (hash cookie);
+          Lwt_log.ign_info_f ~section "cookie not expired: %s" (log_hash cookie);
           return_unit
     in
     let gc_cookie c =
@@ -323,7 +323,7 @@ let persistent_session_gc sitedata =
         (do_gc_cookie c)
         (function
          | Not_found ->
-             Lwt_log.ign_info_f ~section "cookie does not exist: %s" (hash c);
+             Lwt_log.ign_info_f ~section "cookie does not exist: %s" (log_hash c);
              Lwt.return_unit
          | exn -> Lwt.fail exn)
     in


### PR DESCRIPTION
The original solution still printed cookie strings for old cookies
(which do not end on 'H').

Fixes 1206469b8001170587b21c1db483a5b75a10c440.