### PR TITLE
[cleanup] Dispose of references to deprecated `Js_of_ocaml.Js.to_float`

### DIFF
--- a/src/lib/client/eliommod_cookies.ml
+++ b/src/lib/client/eliommod_cookies.ml
@@ -66,7 +66,7 @@ let set_table ?(in_local_storage = false) host t =
 
 let now () =
   let date = new%js Js.date_now in
-  Js.to_float date##getTime /. 1000.
+  date##getTime /. 1000.
 
 (** [in_local_storage] implements cookie substitutes for iOS WKWebView *)
 let update_cookie_table ?(in_local_storage = false) host cookies =

--- a/src/lib/eliom_comet.client.ml
+++ b/src/lib/eliom_comet.client.ml
@@ -138,7 +138,7 @@ module Configuration = struct
       then
         match (get ()).time_between_request_unfocused, focused () with
         | Some ((a, b, c) :: l), Some start ->
-            let now = Js.to_float (new%js Js.date_now)##getTime in
+            let now = (new%js Js.date_now)##getTime in
             (* time from idle start *)
             let t =
               max 0. (((now -. start) *. 0.001) -. (get ()).time_after_unfocus)


### PR DESCRIPTION
`Js_of_ocaml.Js.to_float` is simply the identity function.