### PR TITLE
[ci] Use the latest version of `actions/checkout`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
To avoid the warning about deprecated Node.js 16 actions.  See https://github.com/ocsigen/eliom/actions/runs/8134813445.