### PR TITLE
Distillery template: make sqlite the default backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* Basic client-server distillery template: sqlite is now the default backend
+
 ===== 10.3.1 (2024-02-21) =====
 * Fixing Problem with browser navigation https://github.com/ocsigen/eliom/issues/781
 

--- a/pkg/distillery/templates/client-server.basic/PROJECT_NAME.conf.in
+++ b/pkg/distillery/templates/client-server.basic/PROJECT_NAME.conf.in
@@ -18,16 +18,16 @@
     <extension findlib-package="ocsigenserver.ext.cors"/>
     <commandpipe>%%CMDPIPE%%</commandpipe>
     <extension findlib-package="ocsigenserver.ext.staticmod"/>
+    <!--
     <extension findlib-package="ocsipersist.dbm">
       <!-- delayloading val="true"/ -->
       <store dir="%%DATADIR%%"/>
       <ocsidbm name="ocsidbm"/>
     </extension>
-    <!--
+    -->
     <extension findlib-package="ocsipersist.sqlite">
       <database file="%%DATADIR%%/ocsidb"/>
     </extension>
-    -->
     <!--
     <extension findlib-package="ocsipersist.pgsql">
       <database


### PR DESCRIPTION
as dbm is not available by default on MacOS