### PR TITLE
Wikidoc fix a api

### DIFF
--- a/doc/dev/api/client/Eliom_client_value.wiki
+++ b/doc/dev/api/client/Eliom_client_value.wiki
@@ -21,7 +21,6 @@
     <<span class="odocwiki_inlinecode"|~Printexc~.to~_string>>~.
 >>
 
-~Event handlers like <<a_api | Eliom_content.Html.F.a_onclick
-    >>  may raise <<span class="odocwiki_inlinecode"|~False>> to cancel the event ~(as if the ~Java~Script
+~Event handlers like <<a_api | val Html_sigs.T.a_onclick >> may raise <<span class="odocwiki_inlinecode"|~False>> to cancel the event ~(as if the ~Java~Script
     function returned <<span class="odocwiki_inlinecode"|false>>~)~.
 <<pre id="EXCEPTIONFalse" class="ocsforge_color odocwiki_code"|<<span class="ocsforge_color_keyword"|exception>> <<span class="odocwiki_name"|False>>>>

--- a/doc/dev/manual/eliom-language.wiki
+++ b/doc/dev/manual/eliom-language.wiki
@@ -267,7 +267,7 @@ content has changed//. That way they may refer to the new DOM.
 If a client value is created outside of the initialization of the
 server program and also outside of the processing of a request, the
 exception {% <<a_api subproject="server"|exception
-Eliom_client_value.t_creation_invalid_context>> %} is raised.
+Eliom_client_value.Client_value_creation_invalid_context>> %} is raised.
 
 ===@@id="sharedclientvalues"@@ In a shared section
 

--- a/doc/dev/manual/server-outputs.wiki
+++ b/doc/dev/manual/server-outputs.wiki
@@ -38,7 +38,7 @@ using polymorphic variant types. You may use constructor functions from <<a_api 
 | module Eliom_content.Html.D >> or a syntax extension close to the standard HTML syntax.
 ;<<a_api subproject="server"| module Eliom_registration.Flow5 >>
 : Registration of functions that generate a portion of page using <<a_api subproject="server" |
-module Eliom_content.Html.F >> or the syntax extension (useful for {{{XMLHttpRequest}}} requests for example). Do not use with Eliom applications: you can instead use <<a_api subproject="server" | Eliom_client.server_function>> (or the {{{let%rpc}}} syntax) to call server functions that produce HTML nodes.
+module Eliom_content.Html.F >> or the syntax extension (useful for {{{XMLHttpRequest}}} requests for example). Do not use with Eliom applications: you can instead use <<a_api subproject="server"| val Eliom_client.server_function >> (or the {{{let%rpc}}} syntax) to call server functions that produce HTML nodes.
 ;<<a_api subproject="server"| module Eliom_registration.Html_text >>
 : Registration of functions that generate text HTML pages, without any validation of the content. The content type sent by the server is "{{{text/html}}}".
 ;<<a_api subproject="server"| module Eliom_registration.CssText >>


### PR DESCRIPTION
Fix issues with certain `a_api` links in the Eliom project documentation

This pull request addresses the following documentation errors:

1. https://ocsigen.org/eliom/latest/api/client/Eliom_client_value
   Error: Dune__exe__Api.Error("invalid contents: Eliom_content.Html.F.a_onclick")

2. https://ocsigen.org/eliom/latest/manual/eliom-language
   Error: Error a_api: exception Dune__exe__Api.Error("invalid ocaml id \"Eliom_client_value.t_creation_invalid_context\"")

3. https://ocsigen.org/eliom/latest/manual/server-outputs
   Error: Dune__exe__Api.Error("invalid contents: Eliom_client.server_function")

All issues have been resolved except for the last one. An attempt was made to fix it by adding the missing "val" keyword in the final commit, but this solution was unsuccessful.

I only fix errors in dev folder.