### PR TITLE
Avoid 'assert false' when looking up module .cmo

### DIFF
--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -88,9 +88,10 @@ module Pass = struct
   let find_fragment loc id =
     if Mli.exists ()
     then Mli.find_fragment id
-    else if Cmo.exists ()
-    then Cmo.find_fragment loc
-    else [%type: _]
+    else
+      match if Cmo.exists () then Cmo.find_fragment loc else None with
+      | Some typ -> typ
+      | None -> [%type: _]
 
   let register_client_closures client_value_datas =
     let registrations =

--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -471,9 +471,7 @@ module Cmo = struct
   let find_injected_ident = find "injected ident"
 
   let find_fragment loc =
-    match Mli.get_fragment_type (find "client value" loc) with
-    | Some ty -> ty
-    | None -> assert false
+    Mli.get_fragment_type (find "client value" loc)
 end
 
 (** Context convenience module. *)

--- a/src/ppx/ppx_eliom_utils.mli
+++ b/src/ppx/ppx_eliom_utils.mli
@@ -57,7 +57,7 @@ module Cmo : sig
   val exists : unit -> bool
   val find_escaped_ident : Location.t -> core_type
   val find_injected_ident : Location.t -> core_type
-  val find_fragment : Location.t -> core_type
+  val find_fragment : Location.t -> core_type option
 end
 
 (** Signature of specific code of a preprocessor. *)


### PR DESCRIPTION
This error was reachable when also hitting this error:

    Error: Error: Inferred type of injected ident not found. You need to
           regenerate services/.services.objs/byte/game.cmo.