### PR TITLE
Fix eliom client with jsoo 5.9.0

### DIFF
--- a/src/lib/client/eliom_client.js
+++ b/src/lib/client/eliom_client.js
@@ -2,7 +2,7 @@
 
 //Provides: caml_unwrap_value_from_string
 //Requires: caml_failwith, caml_marshal_constants
-//Requires: caml_int64_float_of_bits, caml_int64_of_bytes, caml_new_string
+//Requires: caml_int64_float_of_bits, caml_int64_of_bytes, caml_string_of_jsbytes
 //Requires: caml_jsbytes_of_string, caml_callback
 var caml_unwrap_value_from_string = function (){
   function StringReader (s, i) { this.s = caml_jsbytes_of_string(s); this.i = i; }
@@ -34,7 +34,7 @@ var caml_unwrap_value_from_string = function (){
     readstr:function (len) {
       var i = this.i;
       this.i = i + len;
-      return caml_new_string(this.s.substring(i, i + len));
+      return caml_string_of_jsbytes(this.s.substring(i, i + len));
     }
   }
   function caml_float_of_bytes (a) {


### PR DESCRIPTION
It would be nice to add a simple test in the codebase that checks that generating a js file including eliom.client works.
This test could be run by opam when releasing new packages and would allow us to spot such breakage before releasing into opam.

I did a spring cleaning in jsoo runtime functions and drop caml_new_string. I will try to reintroduce it temporarily with a deprecated warning instead.
 