### PR TITLE
ppx: Remove sensitivity to paths passed on the command line

### DIFF
--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -50,7 +50,7 @@ let pat_args = function [] -> punit () | [p] -> p | l -> Pat.tuple l
    These bits are encoded using an OCaml-compatible variant of Base
    64, as the hash is used to generate OCaml identifiers. *)
 let file_hash loc =
-  let s = Digest.string loc.Location.loc_start.pos_fname in
+  let s = Filename.basename loc.Location.loc_start.pos_fname in
   let e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_'" in
   let o = Bytes.create 6 in
   let g p = Char.code s.[p] in
@@ -283,7 +283,7 @@ module Cmo = struct
            ; ev_kind = Event_after ty
            ; _ } ->
              if pos_cnum' = pos_cnum + 1
-             then Hashtbl.add events (pos_fname, pos_cnum) ty
+             then Hashtbl.add events (Filename.basename pos_fname, pos_cnum) ty
          | _ -> ())
       evl
 
@@ -459,7 +459,7 @@ module Cmo = struct
 
   let find err loc =
     let {Lexing.pos_fname; pos_cnum; _} = loc.Location.loc_start in
-    try typ (Hashtbl.find (Lazy.force events) (pos_fname, pos_cnum))
+    try typ (Hashtbl.find (Lazy.force events) (Filename.basename pos_fname, pos_cnum))
     with Not_found ->
       Typ.extension ~loc @@ Location.Error.to_extension
       @@ Location.Error.make ~loc ~sub:[]


### PR DESCRIPTION
eliom_ppx_client and eliom_ppx_server could be passed different paths to the same files, as Dune execute commands from different current directories.

However, this might create collisions if two file have the same name.

This was suggested by @vouillon in https://github.com/ocsigen/eliom/pull/803