### PR TITLE
Remove `lwt_ppx` dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,6 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   (js_of_ocaml-ppx_deriving_json (>= 5.5.0))
   (js_of_ocaml-tyxml (>= 5.5.0))
   lwt_log
-  (lwt_ppx (>= 1.2.3))
   (tyxml (and (>= 4.6.0) (< 4.7.0)))
   (ocsigenserver (and (>= 6.0.0) (< 7.0.0)))
   (ipaddr (>= 2.1))

--- a/eliom.opam
+++ b/eliom.opam
@@ -30,7 +30,6 @@ depends: [
   "js_of_ocaml-ppx_deriving_json" {>= "5.5.0"}
   "js_of_ocaml-tyxml" {>= "5.5.0"}
   "lwt_log"
-  "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.6.0" & < "4.7.0"}
   "ocsigenserver" {>= "6.0.0" & < "7.0.0"}
   "ipaddr" {>= "2.1"}

--- a/pkg/distillery/templates/app.exe/dune
+++ b/pkg/distillery/templates/app.exe/dune
@@ -10,7 +10,6 @@
  (wrapped false)
  (preprocess
   (pps
-   lwt_ppx
    ;   pgocaml_ppx
    js_of_ocaml-ppx_deriving_json
    ;   ocsigen-i18n
@@ -40,7 +39,6 @@
  (modules %%%MODULE_NAME%%%_main)
  (preprocess
   (pps
-   lwt_ppx
    ;   pgocaml_ppx
    js_of_ocaml-ppx_deriving_json
    ;   ocsigen-i18n
@@ -92,7 +90,6 @@
   (preprocess
    (pps
     js_of_ocaml-ppx
-    lwt_ppx
     ;    ocsigen-i18n
     ;    --
     ;    --prefix

--- a/pkg/distillery/templates/app.exe/tools!dune
+++ b/pkg/distillery/templates/app.exe/tools!dune
@@ -2,7 +2,6 @@
     (name eliom_ppx_client)
     (modes native)
     (modules eliom_ppx_client)
-    (preprocess (pps lwt_ppx))
     (libraries ocsigen-ppx-rpc eliom.ppx.client))
 
 (rule

--- a/pkg/distillery/templates/app.lib/dune
+++ b/pkg/distillery/templates/app.lib/dune
@@ -9,7 +9,6 @@
  (wrapped false)
  (preprocess
   (pps
-   lwt_ppx
    ;   pgocaml_ppx
    js_of_ocaml-ppx_deriving_json
    ;   ocsigen-i18n
@@ -62,7 +61,6 @@
   (preprocess
    (pps
     js_of_ocaml-ppx
-    lwt_ppx
     ;    ocsigen-i18n
     ;    --
     ;    --prefix

--- a/pkg/distillery/templates/app.lib/tools!dune
+++ b/pkg/distillery/templates/app.lib/tools!dune
@@ -2,7 +2,6 @@
     (name eliom_ppx_client)
     (modes native)
     (modules eliom_ppx_client)
-    (preprocess (pps lwt_ppx))
     (libraries ocsigen-ppx-rpc eliom.ppx.client))
 
 (rule

--- a/pkg/distillery/templates/basic.ppx/Makefile.options
+++ b/pkg/distillery/templates/basic.ppx/Makefile.options
@@ -11,9 +11,9 @@ SERVER_FILES := $(wildcard *.eliomi *.eliom)
 CLIENT_FILES := $(wildcard *.eliomi *.eliom)
 
 # OCamlfind packages for the server
-SERVER_PACKAGES := lwt_ppx js_of_ocaml-ppx_deriving_json
+SERVER_PACKAGES := js_of_ocaml-ppx_deriving_json
 # OCamlfind packages for the client
-CLIENT_PACKAGES := lwt_ppx js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json
+CLIENT_PACKAGES := js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json
 
 # Directory with files to be statically served
 LOCAL_STATIC = static

--- a/src/_tags
+++ b/src/_tags
@@ -6,11 +6,11 @@ true:keep_locs
 <lib/client/client.cma>:eliomstubs
 
 <lib/type_dir/*.ml{,i}>:eliom_ppx,thread
-<lib/type_dir/*.ml>:package(js_of_ocaml-ppx_deriving_json,lwt_ppx)
+<lib/type_dir/*.ml>:package(js_of_ocaml-ppx_deriving_json)
 <lib/type_dir/*.ml>:package(js_of_ocaml-ppx)
 
 <lib/server/*.ml{,i}>:eliom_ppx
-<lib/server/*.ml>:package(js_of_ocaml-ppx_deriving_json,lwt_ppx)
+<lib/server/*.ml>:package(js_of_ocaml-ppx_deriving_json)
 <lib/server/*.ml>:package(js_of_ocaml-ppx)
 
 <lib/server/*.ml{,i}>:thread
@@ -22,7 +22,7 @@ true:keep_locs
 <lib/*.eliom{,i}>:eliom_ppx
 
 <lib/*.ml{,i}>:eliom_ppx
-<lib/client/*.ml>:package(js_of_ocaml-ppx_deriving_json,lwt_ppx,js_of_ocaml-lwt.logger)
+<lib/client/*.ml>:package(js_of_ocaml-ppx_deriving_json,js_of_ocaml-lwt.logger)
 <lib/client/*.ml>:package(js_of_ocaml-ppx)
 
 <lib/client/*.ml{,i}>: eliom_ppx
@@ -33,7 +33,6 @@ true:keep_locs
 
 <lib/client/*.ml{,i}>:package(js_of_ocaml-ppx_deriving_json)
 
-<lib/server/monitor/*.ml>:package(lwt_ppx)
 <lib/server/monitor/*.ml{,i}>:thread
 <lib/server/monitor/*.ml{,i}>:package(lwt,ocsigenserver,ocsipersist,tyxml)
 <lib/server/monitor/*.ml{,i}>:I(src/lib/server)

--- a/src/lib/client/dune
+++ b/src/lib/client/dune
@@ -13,7 +13,7 @@
   eliom_shared_sigs
   eliom_wrap)
  (preprocess
-  (pps lwt_ppx js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json))
+  (pps js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json))
  (library_flags
   (:standard -linkall))
  (libraries

--- a/src/lib/eliom_bus.server.ml
+++ b/src/lib/eliom_bus.server.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2010
@@ -92,7 +94,7 @@ let create_filtered ?scope ?name ?size ~filter typ =
   (*The stream*)
   let stream, push = Lwt_stream.create () in
   let push x =
-    let%lwt y = filter x in
+    let* y = filter x in
     push (Some y); Lwt.return_unit
   in
   let scope =

--- a/src/lib/eliom_client_core.client.ml
+++ b/src/lib/eliom_client_core.client.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2010 Vincent Balat
@@ -330,7 +332,7 @@ let raw_form_handler form kind cookies_info tmpl ev client_form_handler =
   in
   let f () =
     Lwt.async @@ fun () ->
-    let%lwt b = client_form_handler ev in
+    let* b = client_form_handler ev in
     if not b then change_page_form ?cookies_info ?tmpl form action;
     Lwt.return_unit
   in

--- a/src/lib/eliom_common.server.ml
+++ b/src/lib/eliom_common.server.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2007 Vincent Balat
@@ -929,7 +931,7 @@ let get_session_info ~sitedata ~req previous_extension_err =
     | None -> true, Lwt.return []
     | Some v -> false, v
   in
-  let%lwt post_params = p in
+  let* post_params = p in
   let previous_tab_cookies_info, tab_cookies, post_params =
     try
       let tci, utc, tc =
@@ -1005,7 +1007,7 @@ let get_session_info ~sitedata ~req previous_extension_err =
   *)
   let get_params0 = get_params in
   let post_params0 = post_params in
-  let%lwt file_params0 = file_params in
+  let* file_params0 = file_params in
   let ( get_params
       , post_params
       , file_params

--- a/src/lib/eliom_cscache.eliom
+++ b/src/lib/eliom_cscache.eliom
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Copyright Vincent Balat *)
 
 [%%shared.start]
@@ -34,7 +36,8 @@ let%server find cache get_data id =
   try Hashtbl.find ((Eliom_shared.Value.local cache) ()) id
   with Not_found ->
     let th =
-      let%lwt v = get_data id in
+      let* v = get_data id in
+
       ignore [%client.unsafe (do_cache ~%cache ~%id ~%v : unit)];
       Lwt.return v
     in

--- a/src/lib/eliom_form.eliom
+++ b/src/lib/eliom_form.eliom
@@ -20,6 +20,7 @@
 
 open%shared Js_of_ocaml
 [%%client.start]
+open Lwt.Syntax
 
 let read_params form y =
   Eliom_parameter.reconstruct_params_form (Form.form_elements form) y
@@ -35,7 +36,7 @@ let iter_contents y ev f =
   Js.Opt.case (Dom_html.CoerceTo.form target) fls @@ fun target ->
   match read_params target y with
   | Some v ->
-      let%lwt () = f v in
+      let* () = f v in
       Lwt.return_true
   | None -> !error_handler ()
 

--- a/src/lib/eliom_mkreg.server.ml
+++ b/src/lib/eliom_mkreg.server.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Module Eliom_mkreg
@@ -119,11 +121,11 @@ let check_process_redir sp f param =
 let send_with_cookies sp pages ?options ?charset ?code ?content_type ?headers
     content
   =
-  let%lwt result =
+  let* result =
     pages.send ?options ?charset ?code ?content_type ?headers content
   in
-  let%lwt () = check_process_redir sp check_after result in
-  let%lwt tab_cookies =
+  let* () = check_process_redir sp check_after result in
+  let* tab_cookies =
     Eliommod_cookies.compute_cookies_to_send sp.Eliom_common.sp_sitedata
       sp.Eliom_common.sp_tab_cookie_info sp.Eliom_common.sp_user_tab_cookies
   in
@@ -434,7 +436,7 @@ let register_aux pages ?options ?charset ?code ?content_type ?headers table
           f tablereg na_name)
 
 let send pages ?options ?charset ?code ?content_type ?headers content =
-  let%lwt result =
+  let* result =
     pages.send ?options ?charset ?code ?content_type ?headers content
   in
   Lwt.return (pages.result_of_http_result result)

--- a/src/lib/eliom_parameter_base.shared.ml
+++ b/src/lib/eliom_parameter_base.shared.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2007 Vincent Balat
@@ -868,10 +870,10 @@ let reconstruct_params ~sp (type a c) (typ : (a, 'b, c) params_type) params
     try Lwt.return (reconstruct_params_ typ [] [] nosuffixversion urlsuffix)
     with e -> Lwt.fail e)
   | typ, _, _ -> (
-      let%lwt params =
+      let* params =
         match params with Some params -> params | None -> Lwt.return_nil
       in
-      let%lwt files =
+      let* files =
         match files with Some files -> files | None -> Lwt.return_nil
       in
       try

--- a/src/lib/eliom_react.client.ml
+++ b/src/lib/eliom_react.client.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2010-2011
@@ -48,7 +50,7 @@ module Down = struct
       Lwt_stream.iter_s
         (function
            | Error exn ->
-               let%lwt () = handle_react_exn ~exn () in
+               let* () = handle_react_exn ~exn () in
                Lwt.fail exn
            | Ok () -> Lwt.return_unit)
         stream);

--- a/src/lib/eliom_react.server.ml
+++ b/src/lib/eliom_react.server.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2010
@@ -178,7 +180,7 @@ module S = struct
       let rec aux () =
         if store.read
         then
-          let%lwt () = Lwt_condition.wait store.condition in
+          let* () = Lwt_condition.wait store.condition in
           aux ()
         else (
           store.read <- true;

--- a/src/lib/eliom_request.client.ml
+++ b/src/lib/eliom_request.client.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2010 Vincent Balat
@@ -258,100 +260,109 @@ let send ?with_credentials ?(expecting_process_page = false) ?cookies_info
           = Some (Eliom_process.get_application_name ())
       else true
     in
-    try%lwt
-      let%lwt r =
-        let contents =
-          match post_args with
-          | Some post_args -> Some (`POST_form post_args)
-          | None -> None
-        in
-        XmlHttpRequest.perform_raw_url ?with_credentials ?headers:(Some headers)
-          ?content_type:None ?contents ~get_args ~check_headers ?progress
-          ?upload_progress ?override_mime_type url
-      in
-      let wait_for_unlock, unlock = Lwt.wait () in
-      (if not @@ React.S.value locked
-       then Lwt.wakeup unlock ()
-       else
-         let unlock_event = React.E.once @@ React.S.changes locked in
-         Dom_reference.retain_generic wait_for_unlock
-           ~keep:(React.E.map (fun _ -> Lwt.wakeup unlock ()) unlock_event));
-      let%lwt () = wait_for_unlock in
-      (if Js.Optdef.test Js.Unsafe.global##.___eliom_use_cookie_substitutes_
-       then
-         match
-           (* Cookie substitutes are for iOS WKWebView *)
-           r.XmlHttpRequest.headers
-             Eliom_common.set_cookie_substitutes_header_name
-         with
-         | None | Some "" -> ()
-         | Some cookie_substitutes ->
-             Eliommod_cookies.update_cookie_table ~in_local_storage:true host
-               (Eliommod_cookies.cookieset_of_json cookie_substitutes));
-      (match
-         r.XmlHttpRequest.headers Eliom_common.set_tab_cookies_header_name
-       with
-      | None | Some "" -> () (* Empty tab_cookies for IE compat *)
-      | Some tab_cookies ->
-          let tab_cookies = Eliommod_cookies.cookieset_of_json tab_cookies in
-          Eliommod_cookies.update_cookie_table host tab_cookies);
-      if r.XmlHttpRequest.code = 204
-      then
-        match r.XmlHttpRequest.headers Eliom_common.full_xhr_redir_header with
-        | None | Some "" -> (
-          match r.XmlHttpRequest.headers Eliom_common.half_xhr_redir_header with
-          | None | Some "" -> Lwt.return (r.XmlHttpRequest.url, None)
-          | Some _uri ->
-              redirect_post url
-                (match post_args with
-                | Some post_args -> post_args
-                | None -> []);
-              Lwt.fail Program_terminated)
-        | Some uri ->
-            if i < max_redirection_level
-            then aux (i + 1) (Url.resolve uri)
-            else Lwt.fail Looping_redirection
-      else if expecting_process_page
-      then
-        let url =
-          match r.XmlHttpRequest.headers Eliom_common.response_url_header with
-          | None | Some "" -> Url.add_get_args url (List.tl get_args)
-          | Some url -> Url.resolve url
-        in
-        Lwt.return (url, Some (result r))
-      else if r.XmlHttpRequest.code = 200
-              || XmlHttpRequest.(r.code = 0 && r.content <> "")
-              (* HACK for file access within Cordova which yields code 0 *)
-              (* Code 0 might mean a network error, but then we have no
-                   content. *)
-      then Lwt.return (r.XmlHttpRequest.url, Some (result r))
-      else Lwt.fail (Failed_request r.XmlHttpRequest.code)
-    with XmlHttpRequest.Wrong_headers (code, headers) -> (
-      (* We are requesting application content and the headers tels
-           us that the answer is not application content *)
-      match headers Eliom_common.appl_name_header_name with
-      | None | Some "" ->
-          (* Empty appl_name for IE compat. *)
-          (match post_args with
-          | None -> redirect_get url
-          | _ ->
-              Lwt_log.raise_error ~section
-                "can't silently redirect a Post request to non application content");
-          Lwt.fail Program_terminated
-      | Some appl_name ->
-          let current_appl_name = Eliom_process.get_application_name () in
-          if appl_name = current_appl_name
+    Lwt.catch
+      (fun () ->
+         let* r =
+           let contents =
+             match post_args with
+             | Some post_args -> Some (`POST_form post_args)
+             | None -> None
+           in
+           XmlHttpRequest.perform_raw_url ?with_credentials
+             ?headers:(Some headers) ?content_type:None ?contents ~get_args
+             ~check_headers ?progress ?upload_progress ?override_mime_type url
+         in
+         let wait_for_unlock, unlock = Lwt.wait () in
+         (if not @@ React.S.value locked
+          then Lwt.wakeup unlock ()
+          else
+            let unlock_event = React.E.once @@ React.S.changes locked in
+            Dom_reference.retain_generic wait_for_unlock
+              ~keep:(React.E.map (fun _ -> Lwt.wakeup unlock ()) unlock_event));
+         let* () = wait_for_unlock in
+         (if Js.Optdef.test Js.Unsafe.global##.___eliom_use_cookie_substitutes_
           then
-            assert false
-            (* we can't go here:
+            match
+              (* Cookie substitutes are for iOS WKWebView *)
+              r.XmlHttpRequest.headers
+                Eliom_common.set_cookie_substitutes_header_name
+            with
+            | None | Some "" -> ()
+            | Some cookie_substitutes ->
+                Eliommod_cookies.update_cookie_table ~in_local_storage:true host
+                  (Eliommod_cookies.cookieset_of_json cookie_substitutes));
+         (match
+            r.XmlHttpRequest.headers Eliom_common.set_tab_cookies_header_name
+          with
+         | None | Some "" -> () (* Empty tab_cookies for IE compat *)
+         | Some tab_cookies ->
+             let tab_cookies = Eliommod_cookies.cookieset_of_json tab_cookies in
+             Eliommod_cookies.update_cookie_table host tab_cookies);
+         if r.XmlHttpRequest.code = 204
+         then
+           match
+             r.XmlHttpRequest.headers Eliom_common.full_xhr_redir_header
+           with
+           | None | Some "" -> (
+             match
+               r.XmlHttpRequest.headers Eliom_common.half_xhr_redir_header
+             with
+             | None | Some "" -> Lwt.return (r.XmlHttpRequest.url, None)
+             | Some _uri ->
+                 redirect_post url
+                   (match post_args with
+                   | Some post_args -> post_args
+                   | None -> []);
+                 Lwt.fail Program_terminated)
+           | Some uri ->
+               if i < max_redirection_level
+               then aux (i + 1) (Url.resolve uri)
+               else Lwt.fail Looping_redirection
+         else if expecting_process_page
+         then
+           let url =
+             match
+               r.XmlHttpRequest.headers Eliom_common.response_url_header
+             with
+             | None | Some "" -> Url.add_get_args url (List.tl get_args)
+             | Some url -> Url.resolve url
+           in
+           Lwt.return (url, Some (result r))
+         else if r.XmlHttpRequest.code = 200
+                 || XmlHttpRequest.(r.code = 0 && r.content <> "")
+                 (* HACK for file access within Cordova which yields code 0 *)
+                 (* Code 0 might mean a network error, but then we have no
+                   content. *)
+         then Lwt.return (r.XmlHttpRequest.url, Some (result r))
+         else Lwt.fail (Failed_request r.XmlHttpRequest.code))
+      (function
+         | XmlHttpRequest.Wrong_headers (code, headers) -> (
+           (* We are requesting application content and the headers tels
+           us that the answer is not application content *)
+           match headers Eliom_common.appl_name_header_name with
+           | None | Some "" ->
+               (* Empty appl_name for IE compat. *)
+               (match post_args with
+               | None -> redirect_get url
+               | _ ->
+                   Lwt_log.raise_error ~section
+                     "can't silently redirect a Post request to non application content");
+               Lwt.fail Program_terminated
+           | Some appl_name ->
+               let current_appl_name = Eliom_process.get_application_name () in
+               if appl_name = current_appl_name
+               then
+                 assert false
+                 (* we can't go here:
                                      this case is already handled before *)
-          else (
-            Lwt_log.ign_warning_f ~section
-              "received content for application %S when running application %s"
-              appl_name current_appl_name;
-            Lwt.fail (Failed_request code)))
+               else (
+                 Lwt_log.ign_warning_f ~section
+                   "received content for application %S when running application %s"
+                   appl_name current_appl_name;
+                 Lwt.fail (Failed_request code)))
+         | exc -> Lwt.reraise exc)
   in
-  let%lwt url, content = aux 0 ?cookies_info ?get_args ?post_args url in
+  let* url, content = aux 0 ?cookies_info ?get_args ?post_args url in
   let filter_url url =
     { url with
       Url.hu_arguments =

--- a/src/lib/eliom_tools.eliom
+++ b/src/lib/eliom_tools.eliom
@@ -521,6 +521,6 @@ module F = Make (Html.F)
 module D = Make (Html.D)
 
 let wrap_handler information none some get post =
-  match%lwt information () with
-  | None -> none get post
-  | Some value -> some value get post
+  Lwt.bind (information ()) (function
+    | None -> none get post
+    | Some value -> some value get post)

--- a/src/lib/server/dune
+++ b/src/lib/server/dune
@@ -11,7 +11,7 @@
   eliom_service_sigs
   eliom_shared_sigs)
  (preprocess
-  (pps lwt_ppx js_of_ocaml-ppx_deriving_json))
+  (pps js_of_ocaml-ppx_deriving_json))
  (flags
   (:standard
    (:include type_includes)))

--- a/src/lib/server/eliommod_gc.ml
+++ b/src/lib/server/eliommod_gc.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Module eliommod_gc.ml
@@ -59,7 +61,7 @@ let gc_timeouted_services now tables =
         Eliom_common.Serv_Table.fold
           (*VVV not tail recursive: may be a problem if lots of coservices *)
              (fun ptk (`Ptc (nodeopt, l)) thr ->
-             let%lwt _ = thr in
+             let* _ = thr in
              (* we wait for the previous one to be completed *)
              (match nodeopt, l with
              | Some node, {Eliom_common.s_expire = Some (_, e); _} :: _

--- a/src/lib/server/eliommod_persess.ml
+++ b/src/lib/server/eliommod_persess.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Module eliommod_persess.ml
@@ -94,13 +96,13 @@ let rec find_or_create_persistent_cookie_ ?set_max_in_group ?set_session_group
   (* if it exists, do not create it, but returns its value *)
   let cookie_level = Eliom_common.cookie_level_of_user_scope cookie_scope in
   let new_persistent_cookie sitedata full_state_name =
-    let%lwt set_session_group =
+    let* set_session_group =
       match cookie_scope with
       | `Client_process n ->
           (* We create a group whose name is the
                    browser session cookie
                    and put the tab session into it. *)
-          let%lwt r =
+          let* r =
             find_or_create_persistent_cookie_
               ~set_max_in_group:
                 (fst
@@ -118,7 +120,7 @@ let rec find_or_create_persistent_cookie_ ?set_max_in_group ?set_session_group
     (* We do not need to verify if it already exists.
      make_new_session_id does never generate twice the same cookie. *)
     let usertimeout = ref Eliom_common.TGlobal (* See global table *) in
-    let%lwt () =
+    let* () =
       Eliommod_cookies.Persistent_cookies.add hc_string
         { Eliommod_cookies.full_state_name
         ; expiry = None

--- a/src/lib/server/eliommod_sessadmin.ml
+++ b/src/lib/server/eliommod_sessadmin.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Module eliommod_sessadmin.ml
@@ -46,7 +48,7 @@ let close_all_service_states2 full_st_name sitedata =
       ; session_group_node
       ; _ }
       thr ->
-       let%lwt () = thr in
+       let* () = thr in
        if full_st_name = full_state_name && !timeout = Eliom_common.TGlobal
        then Eliommod_sessiongroups.Serv.remove session_group_node;
        Lwt.pause ())
@@ -146,7 +148,7 @@ let update_serv_exp full_st_name sitedata old_glob_timeout new_glob_timeout =
           ; session_group_node
           ; _ }
           thr ->
-           let%lwt () = thr in
+           let* () = thr in
            (if full_st_name = full_state_name && !timeout = Eliom_common.TGlobal
             then
               let newexp =
@@ -227,7 +229,7 @@ let update_pers_exp full_st_name sitedata old_glob_timeout new_glob_timeout =
                  Eliommod_persess.close_persistent_state2 ~scope sitedata
                    session_group k
              | _ ->
-                 let%lwt () =
+                 let* () =
                    Eliommod_cookies.Persistent_cookies.add k
                      { Eliommod_cookies.full_state_name
                      ; expiry = newexp

--- a/src/lib/server/monitor/dune
+++ b/src/lib/server/monitor/dune
@@ -3,8 +3,6 @@
  (public_name eliom.server.monitor)
  (wrapped false)
  (modules eliom_monitor)
- (preprocess
-  (pps lwt_ppx))
  (libraries eliom.server))
 
 (library
@@ -12,6 +10,4 @@
  (public_name eliom.server.monitor.start)
  (wrapped false)
  (modules eliom_monitor_main)
- (preprocess
-  (pps lwt_ppx))
  (libraries monitor eliom.server))

--- a/src/lib/server/monitor/eliom_monitor.ml
+++ b/src/lib/server/monitor/eliom_monitor.ml
@@ -1,3 +1,5 @@
+open Lwt.Syntax
+
 (* Ocsigen
  * http://www.ocsigen.org
  * Copyright (C) 2014 Hugo Heuzard
@@ -131,8 +133,8 @@ let http_stats () =
            hosts) ]
 
 let eliom_stats () =
-  let%lwt persist_nb_of_groups = Eliommod_sessiongroups.Pers.nb_of_groups () in
-  let%lwt number_of_persistent_data_cookies =
+  let* persist_nb_of_groups = Eliommod_sessiongroups.Pers.nb_of_groups () in
+  let* number_of_persistent_data_cookies =
     Eliom_state.number_of_persistent_data_cookies ()
   in
   Lwt.return
@@ -171,7 +173,7 @@ let eliom_stats () =
                       (Eliom_state.Ext.get_session_group_list ())) ] ] ])
 
 let content_div () =
-  let%lwt eliom_stats = eliom_stats () in
+  let* eliom_stats = eliom_stats () in
   Lwt.return
     (div
        [ h1 [ppf "Ocsigen server monitoring"]
@@ -188,7 +190,7 @@ let content_div () =
        ; preemptive_thread_stats () ])
 
 let content_html () =
-  let%lwt content_div = content_div () in
+  let* content_div = content_div () in
   Lwt.return
     (html
        (head


### PR DESCRIPTION

This PR proposes to get rid of the `%lwt` syntax from `lwt_ppx` in favor of the
`Lwt_syntax`.

It is based on #814, please consider only the last commit.

This is join work with @Julow (who wrote the tool making the automatic changes)

Most of the changes has been done automatically using the prototype tool
[here](https://github.com/Julow/lwt_ppx_to_let_syntax). This is the reason why
the PR is one big commit.

This is a first step toward moving from Lwt to effect-based concurrency. The
idea is to homogenize the syntax in order to have less cases to handle (again
by an automatic tool).

This is also an independent contribution, as it removes one dependency and one
preprocessor. Which can be considered a win by itself.