### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,6 +3,8 @@ name: Main workflow
 on:
   pull_request:
   push:
+    branches:
+      - master
   schedule:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
@@ -15,7 +17,6 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
         ocaml-compiler:
           - "4.14"
           - "5.2"


### PR DESCRIPTION
- Only run the CI for PRs and master 
- The windows build is currently failing because of ocsigenserver, there is no point keeping CI noise here. One should fix ocsigenserver first.

```
#=== ERROR while installing ocsigenserver.6.0.0 ===============================#
# context     2.3.0 | win32/x86_64 | ocaml-base-compiler.5.2.1 | git+https://github.com/ocaml/opam-repository.git
# path        D:\a\eliom\eliom\_opam\.opam-switch\build\ocsigenserver.6.0.0
# command     D:\cygwin\bin\make.exe install.files
# exit-code   2
# env-file    D:\.opam\log\ocsigenserver-1452-b73f7d.env
# output-file D:\.opam\log\ocsigenserver-1452-b73f7d.out
### output ###
# 
# ## Run "make doc" and "make install.doc" to build and install the ocamldoc.
# INSTALL_CAN_PUT_PERMISSIONS: no
# ## Configuration files
# install -m 777 -d "D:\a\eliom\eliom\_opam\lib/ocsigenserver/etc/ocsigenserver/conf.d
# /bin/sh: -c: line 1: unexpected EOF while looking for matching `"'
# make: *** [Makefile:78: install.files] Error 2
```