### PR TITLE
Add missing dependency on lwt_log

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,6 +34,7 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   lwt_log
   (tyxml (and (>= 4.6.0) (< 4.7.0)))
   (ocsigenserver (and (>= 6.0.0) (< 7.0.0)))
+  lwt_log
   (ipaddr (>= 2.1))
   (reactiveData (>= 0.2.1))
   base-bytes

--- a/eliom.opam
+++ b/eliom.opam
@@ -32,6 +32,7 @@ depends: [
   "lwt_log"
   "tyxml" {>= "4.6.0" & < "4.7.0"}
   "ocsigenserver" {>= "6.0.0" & < "7.0.0"}
+  "lwt_log"
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"

--- a/src/lib/client/dune
+++ b/src/lib/client/dune
@@ -25,6 +25,7 @@
   js_of_ocaml-lwt.logger
   lwt_react
   ocsigenserver.baselib.base
+  lwt_log
   cohttp
   tyxml
   reactiveData)

--- a/src/lib/server/dune
+++ b/src/lib/server/dune
@@ -17,7 +17,7 @@
    (:include type_includes)))
  (library_flags
   (:standard -linkall))
- (libraries lwt_react ocsigenserver ocsipersist tyxml))
+ (libraries lwt_react ocsigenserver lwt_log ocsipersist tyxml))
 
 (include dune.server)
 


### PR DESCRIPTION
This is a transitive dependency through ocsigenserver but is used directly.