### PR TITLE
Eliom_lib: Remove deprecated logging functions

### DIFF
--- a/src/lib/eliom_lib.client.ml
+++ b/src/lib/eliom_lib.client.ml
@@ -101,14 +101,6 @@ let _ =
         (Js.string (Printexc.to_string exn))
         exn
 
-(* Deprecated ON *)
-let debug_exn fmt exn = Lwt_log.ign_info_f ~exn fmt
-let debug fmt = Lwt_log.ign_info_f fmt
-let error fmt = Lwt_log.raise_error_f fmt
-let error_any any fmt = Lwt_log.raise_error_f ~inspect:any fmt
-let jsdebug a = Lwt_log.ign_info ~inspect:a "Jsdebug"
-(* Deprecated OFF *)
-
 let trace fmt =
   if Eliom_config.get_tracing ()
   then Lwt_log.ign_info_f (">> " ^^ fmt)

--- a/src/lib/eliom_lib.client.mli
+++ b/src/lib/eliom_lib.client.mli
@@ -105,21 +105,6 @@ module Lwt_log : sig
   val eliom : section
 end
 
-val error : ('a, unit, string, 'b) format4 -> 'a
-(** Deprecated. Use Lwt_log.ign_raise_error_f instead *)
-
-val error_any : _ -> ('a, unit, string, 'b) format4 -> 'a
-(** Deprecated. Use Lwt_log.ign_raise_error_f (with ~inspect argument) instead *)
-
-val debug : ('a, unit, string, unit) format4 -> 'a
-(** Deprecated. Use Lwt_log.ign_info_f instead *)
-
-val debug_exn : ('a, unit, string, unit) format4 -> exn -> 'a
-(** Deprecated. Use Lwt_log.ign_info_f instead *)
-
-val jsdebug : 'a -> unit
-(** Deprecated. Use Lwt_log.ign_info (with ~inspect argument) instead *)
-
 val alert : ('a, unit, string, unit) format4 -> 'a
 val jsalert : Js.js_string Js.t -> unit
 val confirm : ('a, unit, string, bool) format4 -> 'a


### PR DESCRIPTION
These functions were deprecated for more than 10 years, since the introduction of `Lwt_log`: https://github.com/ocsigen/eliom/pull/117