### PR TITLE
CI: Pin latest version of ocsigenserver

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,9 +33,10 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-pin: false
 
-      - run: opam install . --deps-only
+      - run: opam pin -y git+https://github.com/ocsigen/ocsigenserver#master
+      - run: opam install . --deps-only -y
 
-      - run: opam exec -- make all
+      - run: opam exec -- dune build -p eliom
 
   lint-fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CI is otherwise broken when Eliom uses a newer or changed API in ocsigenserver. This also makes sure that Eliom doesn't use removed APIs.