### PR TITLE
Remove redefinitions of Lwt infix operators

### DIFF
--- a/src/lib/eliom_lib_base.shared.ml
+++ b/src/lib/eliom_lib_base.shared.ml
@@ -21,13 +21,6 @@ open Ocsigen_lib_base
 
 exception Eliom_Internal_Error of string
 
-module Lwt_ops = struct
-  let ( >>= ) = Lwt.( >>= )
-  let ( =<< ) = Lwt.( =<< )
-  let ( >|= ) = Lwt.( >|= )
-  let ( =|< ) = Lwt.( =|< )
-end
-
 type pos = Lexing.position * Lexing.position
 
 let pos_to_string ((start, stop) : pos) =

--- a/src/lib/eliom_lib_base.shared.mli
+++ b/src/lib/eliom_lib_base.shared.mli
@@ -19,14 +19,6 @@
 
 exception Eliom_Internal_Error of string
 
-(** Module with Lwt operators: Open to use them without polluting your scope. *)
-module Lwt_ops : sig
-  val ( >>= ) : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
-  val ( =<< ) : ('a -> 'b Lwt.t) -> 'a Lwt.t -> 'b Lwt.t
-  val ( >|= ) : 'a Lwt.t -> ('a -> 'b) -> 'b Lwt.t
-  val ( =|< ) : ('a -> 'b) -> 'a Lwt.t -> 'b Lwt.t
-end
-
 module type Map_S = sig
   include Map.S
 

--- a/src/lib/eliom_mkreg.server.ml
+++ b/src/lib/eliom_mkreg.server.ml
@@ -21,8 +21,8 @@ open Lwt.Syntax
 *)
 
 module S = Eliom_service
+open Lwt.Infix
 
-let ( >>= ) = Lwt.( >>= )
 let suffix_redir_uri_key = Polytables.make_key ()
 
 type ('options, 'page, 'result) param =

--- a/src/lib/eliom_react.client.ml
+++ b/src/lib/eliom_react.client.ml
@@ -22,9 +22,8 @@ open Lwt.Syntax
 *)
 
 (* Module for event unwrapping *)
-let ( >|= ) = Lwt.( >|= )
-
 open Lwt_react
+open Lwt.Infix
 
 let section = Logs.Src.create "eliom:comet"
 

--- a/src/lib/eliom_reference.server.ml
+++ b/src/lib/eliom_reference.server.ml
@@ -21,8 +21,7 @@
 (** {2 Eliom references} *)
 
 open Eliom_state
-
-let ( >>= ) = Lwt.bind
+open Lwt.Infix
 
 module Ocsipersist = struct
   include Eliom_common.Ocsipersist.Store


### PR DESCRIPTION
Remove `Eliom_lib_base.Lwt_ops` and other local redefinitions of Lwt operators.

Using `open Lwt.Infix` instead makes the transition to direct-style easier.