### PR TITLE
Remove `Eliom_lib.lwt_ignore` and Lwt stats

### DIFF
--- a/src/lib/eliom_lib.client.ml
+++ b/src/lib/eliom_lib.client.ml
@@ -102,11 +102,6 @@ let trace fmts =
   then Printf.ksprintf (fun msg -> Logs.info (fun fmt -> fmt ">> %s" msg)) fmts
   else Printf.ksprintf ignore fmts
 
-let lwt_ignore ?(message = "") t =
-  Lwt.on_failure t (fun exn ->
-    Logs.info (fun fmt ->
-      fmt ("%s" ^^ "@\n%s") message (Printexc.to_string exn)))
-
 (* Debbuging *)
 let jsalert a = Dom_html.window##(alert a)
 let alert fmt = Printf.ksprintf (fun s -> jsalert (Js.string s)) fmt

--- a/src/lib/eliom_lib.client.mli
+++ b/src/lib/eliom_lib.client.mli
@@ -91,7 +91,6 @@ val jsalert : Js.js_string Js.t -> unit
 val confirm : ('a, unit, string, bool) format4 -> 'a
 val debug_var : string -> 'a -> unit
 val trace : ('a, unit, string, unit) format4 -> 'a
-val lwt_ignore : ?message:string -> unit Lwt.t -> unit
 val unmarshal_js : Js.js_string Js.t -> 'a
 val encode_header_value : typ:'a Deriving_Json.t -> 'a -> string
 

--- a/src/lib/server/monitor/eliom_monitor.ml
+++ b/src/lib/server/monitor/eliom_monitor.ml
@@ -77,17 +77,6 @@ let gc_stats () =
             [ ppf "%d words in the the major heap (max %d)." stat.Gc.heap_words
                 stat.Gc.top_heap_words ] ] ]
 
-let lwt_stats () =
-  div
-    [ ul
-        [ li
-            [ ppf "%d lwt threads waiting for inputs"
-                (Lwt_engine.readable_count ()) ]
-        ; li
-            [ ppf "%d lwt threads waiting for outputs"
-                (Lwt_engine.writable_count ()) ]
-        ; li [ppf "%d sleeping lwt threads" (Lwt_engine.timer_count ())] ] ]
-
 let http_stats () =
   let hosts = Ocsigen_extensions.get_hosts () in
   div
@@ -169,9 +158,7 @@ let content_div () =
        ; h2 [ppf "Eliom sessions"]
        ; eliom_stats
        ; h2 [ppf "GC"]
-       ; gc_stats ()
-       ; h2 [ppf "Lwt threads"]
-       ; lwt_stats () ])
+       ; gc_stats () ])
 
 let content_html () =
   let* content_div = content_div () in


### PR DESCRIPTION
In the same vein as https://github.com/ocsigen/eliom/pull/841 but this time the API changes.