### PR TITLE
client: Direct-style API for `Eliom_comet` and `Eliom_bus`

### DIFF
--- a/src/lib/eliom_bus.client.ml
+++ b/src/lib/eliom_bus.client.ml
@@ -65,9 +65,11 @@ let comet_register chan =
     t.consumers <- [];
     Lwt.return_unit
   in
-  Eliom_comet.register chan (function
-    | Some data -> notify (Some data)
-    | None -> teardown ());
+  let _chan =
+    Eliom_comet.register_wrapped chan (function
+      | Some data -> notify (Some data)
+      | None -> teardown ())
+  in
   t
 
 let create service channel waiter =

--- a/src/lib/eliom_bus.client.mli
+++ b/src/lib/eliom_bus.client.mli
@@ -25,19 +25,16 @@
 
 type ('a, 'b) t
 
+val register : ('a, 'b) t -> ('b -> unit Lwt.t) -> unit
+(** Register a callback that will get called on every messages from the server.
+    Messages received before the call to [register] are lost. *)
+
 val stream : ('a, 'b) t -> 'b Lwt_stream.t
-(** [stream b] returns the stream of data sent to bus [b]. A new
-    stream is created each time this function is called. Some messages
-    from the bus can be lost if they were sent before the call to
-    [stream]. If you need to receive every message, use original stream
-    instead. *)
+(** Create a new stream from the messages from the server. This has the same
+    behavior as {!register}. *)
 
 val original_stream : ('a, 'b) t -> 'b Lwt_stream.t
-(** [stream b] returns the stream of data sent to bus [b]. A new
-    stream is created each time this function is called. Every
-    messages sent to the bus after the generation of the page are
-    received. This function can be called only in the onload event
-    handler, if called outside, it will raise a Failure. *)
+(** @deprecated Deprecated alias to [stream]. *)
 
 val write : ('a, 'b) t -> 'a -> unit Lwt.t
 (** [write b v] send [v] to the bus [b]. Every participant of the bus

--- a/src/lib/eliom_bus.client.mli
+++ b/src/lib/eliom_bus.client.mli
@@ -25,9 +25,11 @@
 
 type ('a, 'b) t
 
-val register : ('a, 'b) t -> ('b -> unit Lwt.t) -> unit
+val register : ('a, 'b) t -> ('b option -> unit Lwt.t) -> unit
 (** Register a callback that will get called on every messages from the server.
-    Messages received before the call to [register] are lost. *)
+    Messages received before the call to [register] are lost. The callback is
+    called with [Some data] when receiving a message from the server or with
+    [None] when no more data will be received. *)
 
 val stream : ('a, 'b) t -> 'b Lwt_stream.t
 (** Create a new stream from the messages from the server. This has the same

--- a/src/lib/eliom_comet.client.mli
+++ b/src/lib/eliom_comet.client.mli
@@ -110,22 +110,26 @@ module Configuration : sig
 end
 
 module Channel : sig
-  type 'a t = 'a Lwt_stream.t
+  type 'a t
+
+  val register : 'a t -> ('a option -> unit Lwt.t) -> unit
+  (** [register chan callback] registers a callback to be called for new messages
+    from the server. The callback receives [Some data] for each new messages
+    from the server and [None] when the server closes the channel or an error
+    occurs. Not thread-safe. *)
 end
 
 (**/**)
 
-val register :
+val register_wrapped :
    ?wake:bool
   -> 'a Eliom_comet_base.wrapped_channel
   -> ('a option -> unit Lwt.t)
-  -> unit
-(** [register ~wake chan callback] registers a callback to be called for new
-    messages from the server. If wake is false, the registration of the channel
-    won't activate the handling loop ( no request will be sent ). Default is
-    true. The callback receives [Some data] for each new messages from the
-    server and [None] when the server closes the channel or an error occurs. Not
-    thread-safe. *)
+  -> 'a Channel.t
+(** [register_wrapped ~wake chan callback] registers a callback to a wrapped
+    channel and return a [Channel.t]. If wake is false, the registration of the
+    channel won't activate the handling loop ( no request will be sent ),
+    default is true. *)
 
 val restart : unit -> unit
 (** [restart ()] Restarts the loop waiting for server messages. It is

--- a/src/lib/eliom_comet.client.mli
+++ b/src/lib/eliom_comet.client.mli
@@ -123,9 +123,13 @@ end
 val register :
    ?wake:bool
   -> 'a Eliom_comet_base.wrapped_channel
-  -> 'a Lwt_stream.t
-(** if wake is false, the registration of the channel won't
-    activate the handling loop ( no request will be sent ). Default is true *)
+  -> ('a -> unit Lwt.t)
+  -> unit
+(** [register ~wake chan callback] registers a callback to be called for new
+    messages from the server. If wake is false, the registration of the channel
+    won't activate the handling loop ( no request will be sent ). Default is
+    true.
+    Not thread-safe. *)
 
 val restart : unit -> unit
 (** [restart ()] Restarts the loop waiting for server messages. It is

--- a/src/lib/eliom_comet.client.mli
+++ b/src/lib/eliom_comet.client.mli
@@ -35,15 +35,10 @@
     will close the channel. *)
 
 exception Channel_full
-(** [Channel_full] is raised when trying to read on a channel marked
-    full by the server. It is not possible to read anything else from a
-    full channel. *)
+(** @deprecated Not raised anymore. *)
 
 exception Channel_closed
-(** [Channel_closed] is raised when reading on a channel and the
-    server side of the application closed channel ( the server was restarted,
-    a session was closed, or a stateless channel was garbage collected).
-     *)
+(** @deprecated Not raised anymore. *)
 
 val is_active : unit -> [`Active | `Idle | `Inactive]
 (** [is_active ()] returns the current activity state *)
@@ -123,13 +118,14 @@ end
 val register :
    ?wake:bool
   -> 'a Eliom_comet_base.wrapped_channel
-  -> ('a -> unit Lwt.t)
+  -> ('a option -> unit Lwt.t)
   -> unit
 (** [register ~wake chan callback] registers a callback to be called for new
     messages from the server. If wake is false, the registration of the channel
     won't activate the handling loop ( no request will be sent ). Default is
-    true.
-    Not thread-safe. *)
+    true. The callback receives [Some data] for each new messages from the
+    server and [None] when the server closes the channel or an error occurs. Not
+    thread-safe. *)
 
 val restart : unit -> unit
 (** [restart ()] Restarts the loop waiting for server messages. It is


### PR DESCRIPTION
This changes the client-side API of `Eliom_comet` and `Eliom_bus` to be more compatible with direct-style programming:

- Add a new callback-based API, `Eliom_bus.register`, which avoids using `Lwt_stream` internally.
  `Eliom_bus.stream` is re-implemented against the register API.
  `Eliom_bus.original_stream` is not re-implemented yet.

- `Eliom_comet.Channel` is an abstract type instead of a `Lwt_stream`.
  `Lwt_stream` is difficult to migrate to other concurrency libraries because of its vast API and its many usecases.
  It's also callback-based but it's made to be easy to construct a `Lwt_stream` on top of it.

This might increase performances as well.

This was successfully tested against a small application that uses these APIs: https://github.com/Julow/ocsigen-tictactoe/pull/1

Some work remains to be done:

- [ ] API to unregister callbacks. It was common to cancel a listening loop on a channel using `Lwt.cancel` or `Lwt.pick`.
- [ ] Simplify the implementation of `Eliom_bus`. For example, the callback list could possibly be removed and implemented directly against `Eliom_comet.register`. This change also opens the door for performance improvements and code simplifications in `Eliom_comet`.
