### PR TITLE
doc: link js_of_ocaml, tyxml and reactiveData docs internally (ocsigen.org)

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -51,9 +51,14 @@
   (client (lib eliom.client) (indexdoc doc/client.indexdoc) (heading "Client API")))
 
 ;; Sibling Ocsigen projects whose ocaml.org xrefs are rewritten to relative
-;; links into their wodoc docs:  (pkg deploy-dir multi-library? wrapper-module)
+;; links into their wodoc docs:  (pkg deploy-dir layout wrapper-module)
+;; layout = true/multilib (<dir>.<side>/) | false/root (modules at version
+;; root) | subdir (each opam package under its own <pkg>/, whole family).
 (hosted
   (eliom           eliom           true  Eliom)
   (ocsigen-toolkit ocsigen-toolkit true  Ot)
   (ocsigen-start   ocsigen-start   true  Os)
-  (ocsigenserver   ocsigenserver   false Ocsigen))
+  (ocsigenserver   ocsigenserver   false Ocsigen)
+  (js_of_ocaml     js_of_ocaml     subdir)
+  (tyxml           tyxml           subdir)
+  (reactiveData    reactiveData    root))


### PR DESCRIPTION
## Why

References to other Ocsigen projects in this projectʼs docs were rewritten from `ocaml.org` to relative links only for a few core packages (`eliom`, `ocsigen-toolkit`, `ocsigen-start`, `ocsigenserver`). Links to **js_of_ocaml**, **tyxml** and **reactiveData** — also Ocsigen projects with docs on ocsigen.org — still pointed at ocaml.org.

## What

Add them to the `(hosted …)` table:
- `js_of_ocaml`, `tyxml` → `subdir` layout (each opam package under its own `<pkg>/`; one entry covers the family, e.g. `js_of_ocaml-lwt`).
- `reactiveData` → `root` layout (modules at the version root).

`lwt` is intentionally left out until its docs are rebuilt with wodoc (its current deploy is the legacy preview layout).

## Depends on

Requires wodoc with the `subdir` layout: **ocsigen/wodoc#4**. The doc CI pins wodoc from `master`, so this is picked up automatically once that PR is merged. Merge wodoc#4 first to avoid a window where `subdir`/`root` tokens are misparsed.