### PR TITLE
ci: cancel superseded runs + fix eliom CI (Binaryen, doc/dune fmt)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,6 +26,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-deploy:
     # push, or a manual run with no version (just rebuild dev). NOT a release run.

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Three CI changes, all aimed at the org's shared runner pool / eliom's red CI:

**1. Cancel superseded runs.** Adds a `concurrency` group so a new push to a PR cancels the still-running superseded run for that ref (scoped to `pull_request` events, so master pushes/deploys are never cancelled):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**2. Install Binaryen in the build job.** Builds were failing at `opam install . --deps-only` because the transitively pulled `wasm_of_ocaml-compiler` needs `wasm-merge` (Binaryen) at build time, and Ubuntu's `binaryen` package is too old. Install a recent Binaryen via `Aandreba/setup-binaryen`, the same way js_of_ocaml's CI does.

**3. Format `doc/dune`.** `lint-fmt` failed on a missing blank line after the header comment (introduced by the recent doc migration). One-line fmt fix.

(2) and (3) fix failures that are already red on `master`, independent of (1).
