### PR TITLE
doc: add the home page to the manual navigation

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -22,6 +22,7 @@
 ;; versions keep the nav they were frozen with.
 (nav
  (section "Eliom's Reference manual"
+  (link "Overview" index.html index)
   (link "Introduction" intro.html intro)
   (group "Server-side programming"
    (group "Services"


### PR DESCRIPTION
Follow-up to #866. The package home page (`index.mld`, the unified overview) is the ocsigen.org landing but was not reachable from the left navigation menu (which started at "Introduction"). Add an "Overview" entry pointing at the home page, before the Introduction, so users can navigate back to it.

On ocaml.org the home page is already reachable (it is the doc root); this only affects the ocsigen.org left navigation.