### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -12,8 +12,8 @@
 ;; ocaml.org to relative links by (hosted ...); other deps stay on ocaml.org.
 (project eliom)
 (title Eliom)
-(pub /eliom)
-(odoc-driver eliom)        ; build the API with `odoc_driver eliom --remap`
+(url-prefix /eliom)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (landing overview.html)
 
 ;; The shared manual nav (the manual .mld are built with the package by


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps eliom's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.
- drop the now-redundant `(odoc-driver …)` — it is implied by `(client-server …)` in wodoc 1.0.

The doc CI tracks wodoc master, so no CI change is needed.