### PR TITLE
doc: reference Eliom's own config page with a relative odoc reference

### DIFF
--- a/src/lib/eliom_config.server.mli
+++ b/src/lib/eliom_config.server.mli
@@ -148,7 +148,7 @@ val set_default_links_xhr : ?override_configfile:bool -> bool -> unit
     [~xhr] in the functions [Eliom_registration.*.{a, get_form, post_form,
     lwt_get_form, lwt_post_form}] (cf. {!Eliom_registration.Html.a} et al.).
     This value can also be set in the
-    {{:http://ocsigen.org/eliom/dev/manual/config#h5o-25}config file}.  *)
+    {{!page-config}config file}.  *)
 
 (**/**)
 


### PR DESCRIPTION
While verifying the cross-project links work (eliom#868), found an **intra-project** link that was hardcoded and absolute: `Eliom_config` (`eliom_config.server.mli`) linked to Eliom's own config manual page via `http://ocsigen.org/eliom/dev/manual/config#h5o-25` — an old wikidoc path that (a) 404s today and (b) pins `dev`, so from a stable version it would jump to dev.

Intra-project links must be **relative** so they stay on the version the reader is browsing. Replace it with the odoc page reference `{{!page-config}config file}`, which odoc resolves within the package (to `doc/config.mld`).

(Two more stale `ocsigen.org/eliom/manual/…` links exist only in `pkg/distillery/templates/` user-template comments — separate, they need the template regeneration workflow.)