### PR TITLE
doc: use a relative reference for Eliom's own config page (sync with master)

### DIFF
--- a/src/lib/config.server.mli
+++ b/src/lib/config.server.mli
@@ -148,7 +148,7 @@ val set_default_links_xhr : ?override_configfile:bool -> bool -> unit
     [~xhr] in the functions [Registration.*.{a, get_form, post_form,
     lwt_get_form, lwt_post_form}] (cf. {!Registration.Html.a} et al.).
     This value can also be set in the
-    {{:http://ocsigen.org/eliom/dev/manual/config#h5o-25}config file}.  *)
+    {{!page-config}config file}.  *)
 
 (**/**)
 


### PR DESCRIPTION
Audit before release found this branch still carries the stale intra-project link `{{:http://ocsigen.org/eliom/dev/manual/config#h5o-25}}` (old wikidoc path, 404, dev-pinned) in `config.server.mli`. Master fixed it in #870, but on the renamed file `eliom_config.server.mli`, so it did not reach this branch. Use `{{!page-config}}` (relative odoc reference) here too.