### PR TITLE
Compatibility with js_of_ocaml 6.4

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+===== dev =====
+* Compatibility with js_of_ocaml 6.4
+  (getElementsByTagName now returns a Dom.collection, and Dom_html gained a
+  `listener` value that shadowed a local binding)
+
 ===== 12.0 =====
 * Eliom_lib
 ** Deprecated logging functions were removed (#821)

--- a/src/lib/client/eliommod_dom.ml
+++ b/src/lib/client/eliommod_dom.ml
@@ -290,18 +290,16 @@ let createEvent =
 
 (* DOM traversal *)
 
-class type ['element] get_tag = object
-  method getElementsByTagName :
-    Js.js_string Js.t -> 'element Dom.nodeList Js.t Js.meth
-end
-
-(* We can't use Dom_html.document##head: it is not defined in ff3.6... *)
-let get_head (page : 'element #get_tag Js.t) : 'element Js.t =
+(* We can't use Dom_html.document##head: it is not defined in ff3.6...
+   [getElementsByTagName] returns a [Dom.nodeList] on js_of_ocaml < 6.4 and a
+   [Dom.collection] since 6.4; both provide [item], so we just require a
+   [#Dom.element]. *)
+let get_head (page : #Dom.element Js.t) : Dom.element Js.t =
   Js.Opt.get
     page##(getElementsByTagName (Js.string "head"))##(item 0)
     (fun () -> raise_error ~section "get_head")
 
-let get_body (page : 'element #get_tag Js.t) : 'element Js.t =
+let get_body (page : #Dom.element Js.t) : Dom.element Js.t =
   Js.Opt.get
     page##(getElementsByTagName (Js.string "body"))##(item 0)
     (fun () -> raise_error ~section "get_body")

--- a/src/lib/client/eliommod_dom.mli
+++ b/src/lib/client/eliommod_dom.mli
@@ -21,13 +21,8 @@
 
 open Js_of_ocaml
 
-class type ['element] get_tag = object
-  method getElementsByTagName :
-    Js.js_string Js.t -> 'element Dom.nodeList Js.t Js.meth
-end
-
-val get_body : 'element #get_tag Js.t -> 'element Js.t
-val get_head : 'element #get_tag Js.t -> 'element Js.t
+val get_body : #Dom.element Js.t -> Dom.element Js.t
+val get_head : #Dom.element Js.t -> Dom.element Js.t
 
 (** [select_nodes root] finds the nodes below [root]
     in the page annotated to be:

--- a/src/lib/eliom_comet.client.ml
+++ b/src/lib/eliom_comet.client.ml
@@ -270,7 +270,10 @@ end = struct
 
   let add_listener target event f =
     let listener = Dom_html.handler (fun _ -> f (); Js._true) in
-    ignore @@ Dom_html.(addEventListener target event listener Js._false)
+    (* Note: no [Dom_html.(...)] local open here: since js_of_ocaml 6.4 it
+       would resolve [listener] to [Dom_html.listener] instead of the local
+       binding. *)
+    ignore (Dom_html.addEventListener target event listener Js._false)
 
   let add_visibility_change_listener f =
     Dom_html.(add_listener document (Event.make "visibilitychange") f)


### PR DESCRIPTION
js_of_ocaml 6.4 makes two source-incompatible changes to its DOM bindings that break the eliom client (caught by the opam-repository revdeps CI for the 6.4.0 release):

1. **`getElementsByTagName` now returns a `Dom.collection`** (which adds `namedItem`) instead of a plain `Dom.nodeList` ([ocsigen/js_of_ocaml#2221](https://github.com/ocsigen/js_of_ocaml/pull/2221) area). Eliom's arity-1 `get_tag` class type pinned the result to `nodeList`, so `Dom_html.element` no longer unified with it (`The second object type has no method namedItem`). That class type can't be made version-agnostic (an open-row return type makes the method polymorphic), so it's dropped; `get_head`/`get_body` are now typed on `#Dom.element` — both `nodeList` (≤ 6.3) and `collection` (6.4) provide `item`, which is all these functions use.

2. **`Dom_html` gained a `listener` value** (ocsigen/js_of_ocaml#1436). Inside the `Dom_html.(...)` local open in `Eliom_comet.add_listener`, it shadowed the local `let listener`, so a function was passed where an `event_listener` was expected. Fixed by dropping the local open and qualifying `addEventListener`.

### Errors fixed
```
eliom_comet.client.ml:273  Error: The value listener has type ... event_listener
eliommod_dom.ml:672        Error: ... The second object type has no method namedItem
eliom_client.client.ml:1665 Error: ... The second object type has no method namedItem
```

### Verification
Built against the 6.4.0 bindings: with the pre-fix files the **exact three CI errors reproduce** at the same lines; with the fix `dune build` is clean (no ripples). Backward compatible — the `#Dom.element`/`item` typing also compiles against js_of_ocaml ≤ 6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)