### PR TITLE
doc: format doc/dune (dune build @fmt)

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -1,5 +1,6 @@
 ; Eliom manual pages (odoc .mld), compiled in place with the API by
 ; odoc-driver and installed with the package, so they appear on ocaml.org
 ; and resolve {{!page-X}} / {!Module} references against the API.
+
 (documentation
  (package eliom))


### PR DESCRIPTION
`dune build @fmt` (lint-fmt CI step) requires a blank line between the leading comment block and the `(documentation ...)` stanza in `doc/dune`.

This is the fix for failure #1 of the lint-fmt job (see e.g. PR #875 CI). No code or behaviour change — formatting only.

The other two CI failures on #875 (js_of_ocaml not yet supporting OCaml 5.5; `ppx_optcomp` × `ppxlib >= 0.37` being unsatisfiable on OCaml 4.14) are tracked separately.