### PR TITLE
Lower ppxlib lower bound to 0.35 to keep OCaml 4.14 support

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   (ocaml (>= 4.12))
   ocamlfind
   ppx_deriving
-  (ppxlib (>= 0.37))
+  (ppxlib (>= 0.35))
   (js_of_ocaml-compiler (>= 6.3.2))
   (wasm_of_ocaml-compiler (>= 6.3.2))
   (js_of_ocaml (>= 6.3.2))

--- a/eliom.opam
+++ b/eliom.opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.12"}
   "ocamlfind"
   "ppx_deriving"
-  "ppxlib" {>= "0.37"}
+  "ppxlib" {>= "0.35"}
   "js_of_ocaml-compiler" {>= "6.3.2"}
   "wasm_of_ocaml-compiler" {>= "6.3.2"}
   "js_of_ocaml" {>= "6.3.2"}


### PR DESCRIPTION
## Problem

Since the `ppxlib >= 0.15` → `>= 0.37` bump (commit cfd9af4c0, "Fix some dependencies"), the **OCaml 4.14** build is unsatisfiable:

```
eliom → ppxlib >= 0.37  ⇒  only ppx_optcomp v0.17.1 fits  ⇒  ocaml >= 5.1  ⇒  4.14 excluded
```

| ppx_optcomp | ocaml | ppxlib |
|---|---|---|
| v0.16.0 | >= 4.14 | >= 0.28 & < 0.36 |
| v0.17.1 | >= 5.1 | >= 0.36 |

`ppx_optcomp` cannot be dropped: it powers the version-conditional compilation (`[@if ocaml_version]`).

## Findings

- The `>= 0.37` bound came from eliom alone: that commit touched **no ppx source**, it was a metadata bump "to the current version".
- The js_of_ocaml 6.3.2 stack only requires `ppxlib >= 0.35` and supports `ocaml >= 4.13`.

## Fix

Lower the bound to `ppxlib >= 0.35`. The solver then automatically picks:

| compiler | ppxlib | ppx_optcomp |
|---|---|---|
| 4.14 | 0.35 | v0.16.0 |
| 5.x | 0.37 | v0.17.1 |

## Validation

Local OCaml **4.14.2** switch, `ocsigenserver` pinned to master (as in CI): `opam install . --deps-only` resolves, then **`dune build -p eliom` passes (exit 0)**. No code change.

See the CI diagnosis of #875.