### PR TITLE
Make wasm_of_ocaml-compiler an optional dependency

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,11 +73,16 @@ jobs:
         with:
           token: ${{ github.token }}
 
-      - run: opam pin -y git+https://github.com/ocsigen/ocsigenserver#master
-      - run: opam pin -y git+https://github.com/ocsigen/js_of_ocaml#master
+      # Pin with -n (no install): pinning the js_of_ocaml repo otherwise
+      # installs every package in it, including wasm_of_ocaml-compiler, which
+      # would make the JS-only phase below build wasm anyway. With -n, only
+      # eliom's actual dependencies get installed by `opam install .` (wasm is
+      # an optional dep, so it stays out).
+      - run: opam pin -n -y git+https://github.com/ocsigen/ocsigenserver#master
+      - run: opam pin -n -y git+https://github.com/ocsigen/js_of_ocaml#master
       # Install eliom itself: it provides eliom-distillery and the project
       # templates. wasm_of_ocaml-compiler is optional and left uninstalled for
-      # now, so the first build below is JS-only.
+      # now, so the first build below is genuinely JS-only.
       - run: opam install . -y
 
       # Generate a project from each template, install its dependencies and
@@ -91,6 +96,8 @@ jobs:
             opam exec -- eliom-distillery -y -name testapp -template "$tmpl" -target-directory "/tmp/$tmpl"
             opam install "/tmp/$tmpl" --deps-only -y
             opam exec -- make -C "/tmp/$tmpl"
+            test ! -f "/tmp/$tmpl/_build/default/client/testapp.bc.wasm.js" \
+              || { echo "wasm unexpectedly built for $tmpl without wasm_of_ocaml"; exit 1; }
           done
 
       # Install the wasm toolchain and rebuild: the templates auto-detect

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,6 +47,9 @@ jobs:
       # 5.5 support (also pulls wasm_of_ocaml, hence the binaryen set-up).
       - run: opam pin -y git+https://github.com/ocsigen/js_of_ocaml#master
       - run: opam install . --deps-only -y
+      # wasm_of_ocaml-compiler is now an optional dependency; install it
+      # explicitly so the WebAssembly client target stays covered by CI.
+      - run: opam install -y wasm_of_ocaml-compiler
 
       - run: opam exec -- dune build -p eliom
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -53,6 +53,41 @@ jobs:
 
       - run: opam exec -- dune build -p eliom
 
+  distillery:
+    # Builds projects generated from the distillery templates. Runs on OCaml 4
+    # because the templates' ocsipersist-sqlite backend pulls lwt_log, which
+    # requires OCaml < 5.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v6
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 4
+          opam-pin: false
+
+      - run: opam pin -y git+https://github.com/ocsigen/ocsigenserver#master
+      - run: opam pin -y git+https://github.com/ocsigen/js_of_ocaml#master
+      # Install eliom itself: it provides eliom-distillery and the project
+      # templates. wasm_of_ocaml-compiler is optional and left uninstalled, so
+      # the generated projects are built JS-only (their WASM build auto-disables
+      # because wasm_of_ocaml is not on PATH).
+      - run: opam install . -y
+
+      # Generate a project from each template, install its dependencies and
+      # build it (default target, which exercises the project alias). This
+      # checks the templates build out-of-the-box on a JS-only install.
+      - name: Generate and build templates
+        run: |
+          for tmpl in app.exe app.lib; do
+            rm -rf "/tmp/$tmpl"
+            opam exec -- eliom-distillery -y -name testapp -template "$tmpl" -target-directory "/tmp/$tmpl"
+            opam install "/tmp/$tmpl" --deps-only -y
+            opam exec -- make -C "/tmp/$tmpl"
+          done
+
   lint-fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,24 +68,44 @@ jobs:
           ocaml-compiler: 4
           opam-pin: false
 
+      - name: Set-up Binaryen
+        uses: Aandreba/setup-binaryen@v1.0.0
+        with:
+          token: ${{ github.token }}
+
       - run: opam pin -y git+https://github.com/ocsigen/ocsigenserver#master
       - run: opam pin -y git+https://github.com/ocsigen/js_of_ocaml#master
       # Install eliom itself: it provides eliom-distillery and the project
-      # templates. wasm_of_ocaml-compiler is optional and left uninstalled, so
-      # the generated projects are built JS-only (their WASM build auto-disables
-      # because wasm_of_ocaml is not on PATH).
+      # templates. wasm_of_ocaml-compiler is optional and left uninstalled for
+      # now, so the first build below is JS-only.
       - run: opam install . -y
 
       # Generate a project from each template, install its dependencies and
-      # build it (default target, which exercises the project alias). This
+      # build it (default target, which exercises the project alias). With
+      # wasm_of_ocaml absent the project's WASM build auto-disables, so this
       # checks the templates build out-of-the-box on a JS-only install.
-      - name: Generate and build templates
+      - name: Generate and build templates (JS only)
         run: |
           for tmpl in app.exe app.lib; do
             rm -rf "/tmp/$tmpl"
             opam exec -- eliom-distillery -y -name testapp -template "$tmpl" -target-directory "/tmp/$tmpl"
             opam install "/tmp/$tmpl" --deps-only -y
             opam exec -- make -C "/tmp/$tmpl"
+          done
+
+      # Install the wasm toolchain and rebuild: the templates auto-detect
+      # wasm_of_ocaml and compile the client to WebAssembly. This is the only
+      # job that actually exercises wasm_of_ocaml compilation end to end.
+      - name: Generate and build templates (wasm enabled)
+        run: |
+          opam install -y wasm_of_ocaml-compiler
+          for tmpl in app.exe app.lib; do
+            rm -rf "/tmp/$tmpl-wasm"
+            opam exec -- eliom-distillery -y -name testapp -template "$tmpl" -target-directory "/tmp/$tmpl-wasm"
+            opam install "/tmp/$tmpl-wasm" --deps-only -y
+            opam exec -- make -C "/tmp/$tmpl-wasm"
+            test -f "/tmp/$tmpl-wasm/_build/default/client/testapp.bc.wasm.js" \
+              || { echo "wasm artifact not built for $tmpl"; exit 1; }
           done
 
   lint-fmt:

--- a/dune-project
+++ b/dune-project
@@ -44,9 +44,7 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   (reactiveData (>= 0.2.1))
   base-bytes
   (ocsipersist (and (>= 2.0) (< 3.0)))
-  (xml-light (>= "2.5")))
- ; Only needed to compile the client side to WebAssembly. Eliom itself
- ; builds without it (the client lib is byte-mode; eliom_client.wat is
- ; installed as a runtime asset, not compiled), so keep it optional.
- (depopts
-  (wasm_of_ocaml-compiler (>= 6.3.2))))
+  ; wasm_of_ocaml-compiler is intentionally not listed: eliom does not build
+  ; against it (eliom_client.wat is shipped as a runtime asset, not compiled).
+  ; It is only needed downstream to compile a client to WebAssembly.
+  (xml-light (>= "2.5"))))

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,6 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   ; resolves a more recent ppxlib. The ppx builds against the whole range.
   (ppxlib (>= 0.35.0))
   (js_of_ocaml-compiler (>= 6.3.2))
-  (wasm_of_ocaml-compiler (>= 6.3.2))
   (js_of_ocaml (>= 6.3.2))
   (js_of_ocaml-lwt (>= 6.3.2))
   (js_of_ocaml-ocamlbuild :build)
@@ -45,4 +44,9 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   (reactiveData (>= 0.2.1))
   base-bytes
   (ocsipersist (and (>= 2.0) (< 3.0)))
-  (xml-light (>= "2.5"))))
+  (xml-light (>= "2.5")))
+ ; Only needed to compile the client side to WebAssembly. Eliom itself
+ ; builds without it (the client lib is byte-mode; eliom_client.wat is
+ ; installed as a runtime asset, not compiled), so keep it optional.
+ (depopts
+  (wasm_of_ocaml-compiler (>= 6.3.2))))

--- a/eliom.opam
+++ b/eliom.opam
@@ -23,7 +23,6 @@ depends: [
   "ppx_deriving"
   "ppxlib" {>= "0.35.0"}
   "js_of_ocaml-compiler" {>= "6.3.2"}
-  "wasm_of_ocaml-compiler" {>= "6.3.2"}
   "js_of_ocaml" {>= "6.3.2"}
   "js_of_ocaml-lwt" {>= "6.3.2"}
   "js_of_ocaml-ocamlbuild" {build}
@@ -39,6 +38,9 @@ depends: [
   "ocsipersist" {>= "2.0" & < "3.0"}
   "xml-light" {>= "2.5"}
   "odoc" {with-doc}
+]
+depopts: [
+  "wasm_of_ocaml-compiler" {>= "6.3.2"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/eliom.opam
+++ b/eliom.opam
@@ -55,5 +55,3 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocsigen/eliom.git"
 x-maintenance-intent: ["(latest)"]
-# these distributions don't offer a recent enough binaryen for wasm_of_ocaml
-x-ci-accept-failures: ["centos-10" "opensuse-15.6" "opensuse-16.0"]

--- a/eliom.opam
+++ b/eliom.opam
@@ -39,9 +39,6 @@ depends: [
   "xml-light" {>= "2.5"}
   "odoc" {with-doc}
 ]
-depopts: [
-  "wasm_of_ocaml-compiler" {>= "6.3.2"}
-]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/eliom.opam.template
+++ b/eliom.opam.template
@@ -1,2 +1,0 @@
-# these distributions don't offer a recent enough binaryen for wasm_of_ocaml
-x-ci-accept-failures: ["centos-10" "opensuse-15.6" "opensuse-16.0"]

--- a/pkg/distillery/templates/app.exe/Makefile.app
+++ b/pkg/distillery/templates/app.exe/Makefile.app
@@ -116,6 +116,11 @@ all::
 js::
 	$(ENV_PSQL) dune build $(DUNE_OPTIONS) client/$(PROJECT_NAME).bc.js
 ifeq ($(ENABLE_WASM),yes)
+	@command -v wasm_of_ocaml > /dev/null 2>&1 || { \
+	  echo "Error: ENABLE_WASM=yes but the wasm_of_ocaml compiler is not installed."; \
+	  echo "Install it with: opam install wasm_of_ocaml-compiler"; \
+	  echo "or set ENABLE_WASM=no in Makefile.options to build JavaScript only."; \
+	  exit 1; }
 	$(ENV_PSQL) dune build $(DUNE_OPTIONS) client/$(PROJECT_NAME).bc.wasm.js
 endif
 

--- a/pkg/distillery/templates/app.exe/Makefile.options
+++ b/pkg/distillery/templates/app.exe/Makefile.options
@@ -73,8 +73,9 @@ CSS_PREFIX            := $(LOCAL_STATIC_CSS)/${PROJECT_NAME}
 # JavaScript, ocsigenserver
 DEBUG                 := yes
 
-# Enable WASM compilation (yes/no): Requires wasm_of_ocaml (enabled by default)
-ENABLE_WASM           := yes
+# Enable WASM compilation (yes/no): requires wasm_of_ocaml. Defaults to "yes"
+# when the wasm_of_ocaml compiler is available, "no" otherwise.
+ENABLE_WASM           := $(shell command -v wasm_of_ocaml > /dev/null 2>&1 && echo yes || echo no)
 
 ##----------------------------------------------------------------------
 

--- a/pkg/distillery/templates/app.exe/PROJECT_NAME.opam
+++ b/pkg/distillery/templates/app.exe/PROJECT_NAME.opam
@@ -4,6 +4,7 @@ version: "0.1"
 synopsis: "%%%PROJECT_NAME%%%"
 
 depends: [
-  "eliom" {>= "11.0.0" & < "12.0.0"}
+  "eliom" {>= "12.0.0" & < "13.0.0"}
+  "ocsigen-ppx-rpc"
   "ocsipersist-sqlite-config" {>= "2.0" & < "3.0"}
 ]

--- a/pkg/distillery/templates/app.exe/dune
+++ b/pkg/distillery/templates/app.exe/dune
@@ -122,7 +122,6 @@
   %%%PROJECT_NAME%%%_main.exe
   client/%%%PROJECT_NAME%%%.bc
   client/%%%PROJECT_NAME%%%.bc.js
-  client/%%%PROJECT_NAME%%%.bc.wasm.js
   tools/check_modules.ml)
  (action
   (run ocaml -I +unix -I +str tools/check_modules.ml %%%PROJECT_NAME%%%)))

--- a/pkg/distillery/templates/app.lib/Makefile.app
+++ b/pkg/distillery/templates/app.lib/Makefile.app
@@ -187,6 +187,11 @@ all::
 js::
 	$(ENV_PSQL) dune build $(DUNE_OPTIONS) client/$(PROJECT_NAME).bc.js
 ifeq ($(ENABLE_WASM),yes)
+	@command -v wasm_of_ocaml > /dev/null 2>&1 || { \
+	  echo "Error: ENABLE_WASM=yes but the wasm_of_ocaml compiler is not installed."; \
+	  echo "Install it with: opam install wasm_of_ocaml-compiler"; \
+	  echo "or set ENABLE_WASM=no in Makefile.options to build JavaScript only."; \
+	  exit 1; }
 	$(ENV_PSQL) dune build $(DUNE_OPTIONS) client/$(PROJECT_NAME).bc.wasm.js
 endif
 

--- a/pkg/distillery/templates/app.lib/Makefile.app
+++ b/pkg/distillery/templates/app.lib/Makefile.app
@@ -190,11 +190,11 @@ ifeq ($(ENABLE_WASM),yes)
 	$(ENV_PSQL) dune build $(DUNE_OPTIONS) client/$(PROJECT_NAME).bc.wasm.js
 endif
 
-byte::
+byte:: js
 	$(ENV_PSQL) dune build $(DUNE_OPTIONS) @$(PROJECT_NAME)
 	make config-files PROJECT_NAME=$(PROJECT_NAME)
 
-opt::
+opt:: js
 	$(ENV_PSQL) dune build $(DUNE_OPTIONS) $(PROJECT_NAME).cmxs @$(PROJECT_NAME)
 	make config-files PROJECT_NAME=$(PROJECT_NAME)
 

--- a/pkg/distillery/templates/app.lib/Makefile.options
+++ b/pkg/distillery/templates/app.lib/Makefile.options
@@ -73,8 +73,9 @@ CSS_PREFIX            := $(LOCAL_STATIC_CSS)/${PROJECT_NAME}
 # JavaScript, ocsigenserver
 DEBUG                 := yes
 
-# Enable WASM compilation (yes/no): Requires wasm_of_ocaml (enabled by default)
-ENABLE_WASM           := yes
+# Enable WASM compilation (yes/no): requires wasm_of_ocaml. Defaults to "yes"
+# when the wasm_of_ocaml compiler is available, "no" otherwise.
+ENABLE_WASM           := $(shell command -v wasm_of_ocaml > /dev/null 2>&1 && echo yes || echo no)
 
 ##----------------------------------------------------------------------
 

--- a/pkg/distillery/templates/app.lib/PROJECT_NAME.opam
+++ b/pkg/distillery/templates/app.lib/PROJECT_NAME.opam
@@ -4,6 +4,7 @@ version: "0.1"
 synopsis: "%%%PROJECT_NAME%%%"
 
 depends: [
-  "eliom" {>= "11.0.0" & < "12.0.0"}
+  "eliom" {>= "12.0.0" & < "13.0.0"}
+  "ocsigen-ppx-rpc"
   "ocsipersist-sqlite-config" {>= "2.0" & < "3.0"}
 ]

--- a/pkg/distillery/templates/app.lib/dune
+++ b/pkg/distillery/templates/app.lib/dune
@@ -91,7 +91,6 @@
   %%%PROJECT_NAME%%%.cma
   client/%%%PROJECT_NAME%%%.bc
   client/%%%PROJECT_NAME%%%.bc.js
-  client/%%%PROJECT_NAME%%%.bc.wasm.js
   tools/check_modules.ml)
  (action
   (run ocaml -I +unix -I +str tools/check_modules.ml %%%PROJECT_NAME%%%)))


### PR DESCRIPTION
## What

Stop requiring `wasm_of_ocaml-compiler` to use eliom, make the distillery templates' WebAssembly build opt-in on the toolchain, and add CI that actually builds generated projects (JS-only *and* wasm).

## 1. wasm_of_ocaml-compiler is not a dependency

eliom links no `wasm_of_ocaml` library and never invokes the compiler at build time — `eliom_client.wat` is shipped as a runtime asset, not compiled, so `dune build -p eliom` builds and installs identically with or without it. It is only a tool a *downstream* app uses to compile its client to WebAssembly. So it is removed from the opam metadata entirely (neither `depends` nor `depopts`, since a depopt would wrongly imply eliom's build varies with its presence).

Consequently the `x-ci-accept-failures` entry for `centos-10` / `opensuse-*` (added because those distros lacked a recent enough binaryen for wasm_of_ocaml) is now obsolete — the opam-repo CI no longer builds wasm_of_ocaml for eliom — and is removed (which empties and so deletes `eliom.opam.template`).

*Verified*: with `wasm_of_ocaml-compiler` removed from the switch, `dune build -p eliom` still succeeds.

## 2. Distillery templates: WASM opt-in on the toolchain

A generated project must not require the wasm toolchain unless wasm is actually wanted:
- `Makefile.options`: `ENABLE_WASM` auto-detects `wasm_of_ocaml` (`command -v`), defaulting to `yes` when present and `no` otherwise (was hardcoded `yes`).
- `app.{exe,lib}/dune`: drop `client/<project>.bc.wasm.js` from the `<project>` alias `deps`. That dep made `make all` compile wasm unconditionally regardless of `ENABLE_WASM`; the alias is now a plain module check, and the gated `js` target still builds wasm when enabled. `(modes js byte wasm)` is kept so the gated build works.
- `app.lib/Makefile.app`: route `byte`/`opt` through the gated `js` target (app.exe already did).
- `Makefile.app`: if `ENABLE_WASM=yes` is forced without `wasm_of_ocaml` installed, the build fails with an actionable hint instead of a cryptic dune "program not found" error.

Also fix two pre-existing staleness bugs in `PROJECT_NAME.opam` (both templates) that prevented a generated project from building against current eliom:
- eliom was capped at `< 12.0.0`, rejecting the current `12.0.1` -> bump to `>= 12.0.0 & < 13.0.0`.
- `ocsigen-ppx-rpc` is used by the generated dune files but was not declared -> add it.

## 3. CI

- The `build` matrix installs `wasm_of_ocaml-compiler` explicitly (it is no longer pulled as a dependency) so the eliom library still builds with it present.
- New `distillery` job: generates a project from each template and builds it. Runs on **OCaml 4** because the templates' `ocsipersist-sqlite` backend pulls `lwt_log`, which requires OCaml < 5. Two phases:
  - **JS only** - pins use `-n` so `wasm_of_ocaml-compiler` is not installed; asserts no `.bc.wasm.js` is produced (the opt-out path).
  - **wasm enabled** - installs binaryen + `wasm_of_ocaml-compiler`, rebuilds, and asserts `.bc.wasm.js` *is* produced. This is the only job that exercises `wasm_of_ocaml` compilation end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
