### PR TITLE
doc: client API symmetry (surface Registration, Parameter, Request_info, Tools)

### DIFF
--- a/doc/client.indexdoc
+++ b/doc/client.indexdoc
@@ -4,6 +4,7 @@
 Eliom_lib
 Eliom_client
 Eliom_client_value
+Eliom_request_info
 }
 
 {2 Content and form creation}
@@ -13,6 +14,14 @@ Eliom_content.Html
 Eliom_content.Html.Manip
 Eliom_content.Svg
 Eliom_content.Xml
+Eliom_tools
+}
+
+{2 Service creation}
+
+{!modules:
+Eliom_parameter
+Eliom_registration
 }
 
 {2 Client/server communication}


### PR DESCRIPTION
`Eliom_registration`, `Eliom_parameter`, `Eliom_request_info` and `Eliom_tools` exist in `eliom.client` and are documented on the server side, but were missing from `doc/client.indexdoc`, leaving the client API navigation asymmetric with the server.

This adds them to the client index (with a new **Service creation** section), so the client API page lists the same user-facing modules as the server where they exist. Doc-only change; all four already have generated client pages.