### PR TITLE
client: unlock load_mutex on failure (fix #880 deadlock)

### DIFF
--- a/src/lib/eliom_client.client.ml
+++ b/src/lib/eliom_client.client.ml
@@ -1313,17 +1313,25 @@ let call_ocaml_service
       ?fragment ?keep_nl_params ?nl_params ?keep_get_na_params ?progress
       ?upload_progress ?override_mime_type get_params post_params
   in
-  let* () = Lwt_mutex.lock Eliom_client_core.load_mutex in
-  Eliom_client_core.set_loading_phase ();
-  let* content, request_data = unwrap_caml_content content in
-  do_request_data request_data;
-  Eliom_client_core.reset_request_nodes ();
-  let load_callbacks = [Eliom_client_core.broadcast_load_end] in
-  Lwt_mutex.unlock Eliom_client_core.load_mutex;
-  run_callbacks load_callbacks;
-  match content with
-  | `Success result -> Lwt.return result
-  | `Failure msg -> Lwt.fail (Eliom_client_value.Exception_on_server msg)
+  let locked = ref true in
+  let recover () =
+    if !locked then Lwt_mutex.unlock Eliom_client_core.load_mutex
+  in
+  Lwt.catch
+    (fun () ->
+       let* () = Lwt_mutex.lock Eliom_client_core.load_mutex in
+       Eliom_client_core.set_loading_phase ();
+       let* content, request_data = unwrap_caml_content content in
+       do_request_data request_data;
+       Eliom_client_core.reset_request_nodes ();
+       let load_callbacks = [Eliom_client_core.broadcast_load_end] in
+       locked := false;
+       Lwt_mutex.unlock Eliom_client_core.load_mutex;
+       run_callbacks load_callbacks;
+       match content with
+       | `Success result -> Lwt.return result
+       | `Failure msg -> Lwt.fail (Eliom_client_value.Exception_on_server msg))
+    (fun exn -> recover (); Lwt.fail exn)
 
 (* == Current uri.
 
@@ -1534,14 +1542,22 @@ let set_template_content ~replace ~uri ?fragment =
     (match fragment with
     | None -> change_url_string ~replace uri
     | Some fragment -> change_url_string ~replace (uri ^ "#" ^ fragment));
-    let* () = Lwt_mutex.lock Eliom_client_core.load_mutex in
-    let* (), request_data = unwrap_caml_content content in
-    do_request_data request_data;
-    Eliom_client_core.reset_request_nodes ();
-    let load_callbacks = flush_onload () in
-    Lwt_mutex.unlock Eliom_client_core.load_mutex;
-    run_callbacks load_callbacks;
-    Lwt.return_unit
+    let locked = ref true in
+    let recover () =
+      if !locked then Lwt_mutex.unlock Eliom_client_core.load_mutex
+    in
+    Lwt.catch
+      (fun () ->
+         let* () = Lwt_mutex.lock Eliom_client_core.load_mutex in
+         let* (), request_data = unwrap_caml_content content in
+         do_request_data request_data;
+         Eliom_client_core.reset_request_nodes ();
+         let load_callbacks = flush_onload () in
+         locked := false;
+         Lwt_mutex.unlock Eliom_client_core.load_mutex;
+         run_callbacks load_callbacks;
+         Lwt.return_unit)
+      (fun exn -> recover (); Lwt.fail exn)
   and cancel () = Lwt.return_unit in
   function
   | None -> Lwt.return_unit


### PR DESCRIPTION
Fixes the H1/M9 deadlock reported in #880.

`call_ocaml_service` and `set_template_content` acquire the global page-load mutex `Eliom_client_core.load_mutex` and only release it on the success path. Between lock and unlock they call:

- `unwrap_caml_content` — `Eliom_unwrap.unwrap (Url.decode content)`, which raises on malformed/truncated server content or from a registered unwrapper, and
- `do_request_data` — which initializes client values and can raise.

If either raises, the exception escapes with `load_mutex` still held. Because it is a single process-wide mutex, every subsequent `change_page` / `set_content` / `call_ocaml_service` then blocks forever — a permanent client-side deadlock. `call_ocaml_service` is on the path of **every** `server_function`/RPC call, so any malformed or raising RPC response triggers it.

### Fix

Wrap the locked region in `Lwt.catch` and unlock on failure before re-raising, mirroring the existing `locked` / `recover` / `Lwt.catch` idiom already used in the sibling `set_content` and `set_content_local` (which guard exactly this concern). No behavioural change on the success path.

I kept the change local to the two affected functions rather than introducing a shared `with_load_mutex` helper, to keep the diff minimal and avoid touching the already-correct functions; happy to refactor toward a shared helper if you'd prefer.

Built against `master` with `dune build src/lib` (OCaml 5.4.0). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
