### PR TITLE
client: make of_json/to_json work under wasm_of_ocaml (fix #880)

### DIFF
--- a/src/lib/eliom_lib.client.ml
+++ b/src/lib/eliom_lib.client.ml
@@ -131,21 +131,28 @@ end
 (* We do not use the deriving (un)marshaling even if typ is available
    because direct jsn (un)marshaling is very fast client side
 *)
-let to_json ?typ s =
+(* [Json.output]/[Json.unsafe_input] are provided by both the js_of_ocaml and
+   wasm_of_ocaml runtimes, so use the fast path on either web backend. *)
+let is_web_client =
   match Sys.backend_type with
-  | Other "js_of_ocaml" -> Js.to_string (Json.output s)
-  | _ -> (
+  | Other ("js_of_ocaml" | "wasm_of_ocaml") -> true
+  | Native | Bytecode | Other _ -> false
+
+let to_json ?typ s =
+  if is_web_client
+  then Js.to_string (Json.output s)
+  else
     match typ with
     | Some typ -> Deriving_Json.to_string typ s
-    | None -> Js.to_string (Json.output s))
+    | None -> Js.to_string (Json.output s)
 
 let of_json ?typ v =
-  match Sys.backend_type with
-  | Other "js_of_ocaml" -> Json.unsafe_input (Js.string v)
-  | _ -> (
+  if is_web_client
+  then Json.unsafe_input (Js.string v)
+  else
     match typ with
     | Some typ -> Deriving_Json.from_string typ v
-    | None -> assert false)
+    | None -> assert false
 
 (* Url.urlencode ~with_plus:true (Marshal.to_string x [])
     (* I encode the data because it seems that multipart does not


### PR DESCRIPTION
Fixes the H2 finding reported in #880.

`to_json` and `of_json` selected their fast `Json.output` / `Json.unsafe_input` path only when `Sys.backend_type` is `Other "js_of_ocaml"`. Under `wasm_of_ocaml` the backend type is `Other "wasm_of_ocaml"`, so the branch was not taken. Two consequences on the Wasm target:

1. `of_json` called without `~typ` — which the `.mli` advertises as a valid client-side call — fell through to `None -> assert false` and crashed, whereas it works under js_of_ocaml.
2. The documented fast (un)marshaling path (see the comment above `to_json`) was silently disabled, forcing the slower `Deriving_Json` path.

### Fix

Introduce an `is_web_client` predicate matching both web backends (`js_of_ocaml | wasm_of_ocaml`). `Json.output` / `Json.unsafe_input` are provided by both runtimes, so the fast path is valid on either. The `Native | Bytecode | Other _` arm is enumerated explicitly so a future backend rename is a compile-time signal rather than a silent regression.

Built against `master` with `dune build src/lib` (OCaml 5.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
