### PR TITLE
Fix typos in messages, comments, and a local binding

### DIFF
--- a/src/lib/eliom_comet.server.ml
+++ b/src/lib/eliom_comet.server.ml
@@ -423,7 +423,7 @@ end = struct
         Lwt.wakeup_exn wakener New_connection
 
   (** called when a new channel is made active. It restarts the thread
-      wainting for inputs ( wait_data ) such that it can receive the messages from
+      waiting for inputs ( wait_data ) such that it can receive the messages from
       the new channel *)
   let signal_update handler event =
     match handler.hd_update_streams_w with

--- a/src/lib/eliom_content_.client.ml
+++ b/src/lib/eliom_content_.client.ml
@@ -513,7 +513,7 @@ module Html = struct
         id
 
     let scrollIntoView ?(bottom = false) elt =
-      let elt = get_unique_elt "Css.background" elt in
+      let elt = get_unique_elt "scrollIntoView" elt in
       elt##(scrollIntoView (Js.bool (not bottom)))
 
     module Elt = struct

--- a/src/lib/eliom_form_sigs.shared.mli
+++ b/src/lib/eliom_form_sigs.shared.mli
@@ -197,7 +197,7 @@ module type LINKS = sig
       with {!make_uri}.
 
       By default, the link is implemented in a way that allows the
-      client-side Eliom application to keep running, irrespectable of
+      client-side Eliom application to keep running, irrespective of
       the usage of the link (cf. {!Eliom_client.change_page}).
 
       By contrast, if the optional parameter [~xhr:false] is given,
@@ -304,7 +304,7 @@ module type S = sig
       a relative URL recomputed at each request with {!make_uri}.
 
       By default, the form is realized such that the client-side Eliom
-      application keeps running irrespectable of the usage of the form
+      application keeps running irrespective of the usage of the form
       (cf. {!Eliom_client.change_page}).
 
       By contrast, if the optional parameter [~xhr:false] is given,

--- a/src/lib/eliom_service.server.ml
+++ b/src/lib/eliom_service.server.ml
@@ -233,7 +233,7 @@ let attach :
   let fallbackkind = attached_info fallback in
   let open Eliom_common in
   let error_msg =
-    "attach' is not implemented for this kind ofservice. Please report a bug if you need this."
+    "attach is not implemented for this kind of service. Please report a bug if you need this."
   in
   let get_name =
     match na_name with

--- a/src/lib/eliom_shared.eliom
+++ b/src/lib/eliom_shared.eliom
@@ -182,14 +182,14 @@ module ReactiveData = struct
           when the initial list has been computed on server side.  *)
       let map_p_init ~init (f : 'a -> 'b Lwt.t) (l : 'a t) : 'b t =
         let ((rr, _) as r) = ReactiveData.RList.create init in
-        let effectul_event = map_p_aux (Lwt.return r) f l in
-        (* We keep a reference to the effectul_event in the resulting
-           reactive list in order that the effectul_event is garbage
+        let effectful_event = map_p_aux (Lwt.return r) f l in
+        (* We keep a reference to the effectful_event in the resulting
+           reactive list in order that the effectful_event is garbage
            collected only if the resulting list is garbage
            collected. *)
         ignore
           (React.E.retain (ReactiveData.RList.event rr) (fun () ->
-             ignore effectul_event));
+             ignore effectful_event));
         rr
 
       (** [map_p f l] is the equivalent of [ReactiveData.Rlist.map]
@@ -203,15 +203,15 @@ module ReactiveData = struct
           let* r = Lwt_list.map_p f (ReactiveData.RList.value l) in
           Lwt.return (ReactiveData.RList.create r)
         in
-        let effectul_event = map_p_aux r_th f l in
+        let effectful_event = map_p_aux r_th f l in
         let* rr, _ = r_th in
-        (* We keep a reference to the effectul_event in the resulting
-           reactive list in order that the effectul_event is garbage
+        (* We keep a reference to the effectful_event in the resulting
+           reactive list in order that the effectful_event is garbage
            collected only if the resulting list is garbage
            collected. *)
         ignore
           (React.E.retain (ReactiveData.RList.event rr) (fun () ->
-             ignore effectul_event));
+             ignore effectful_event));
         Lwt.return rr
     end
 

--- a/src/lib/eliom_tools.eliom
+++ b/src/lib/eliom_tools.eliom
@@ -124,7 +124,7 @@ module type HTML5_TOOLS = sig
     -> unit
     -> [> `Ul] Html.elt list
   (** The function [hierarchical_menu_depth_first site ()] constructs
-      a hieranrchical menu by exploring the hierarchical [site]
+      a hierarchical menu by exploring the hierarchical [site]
       description using a depth-first algorithm: the first menu item
       will be displayed, followed by the whole sub-menu for this item,
       then the second menu item with its sub-menu, and so on.

--- a/src/lib/eliom_tools.eliomi
+++ b/src/lib/eliom_tools.eliomi
@@ -138,7 +138,7 @@ module type HTML5_TOOLS = sig
     -> unit
     -> [> `Ul] Html.elt list
   (** The function [hierarchical_menu_depth_first site ()] constructs
-      a hieranrchical menu by exploring the hierarchical [site]
+      a hierarchical menu by exploring the hierarchical [site]
       description using a depth-first algorithm: the first menu item
       will be displayed, followed by the whole sub-menu for this item,
       then the second menu item with its sub-menu, and so on.

--- a/src/lib/server/eliommod.ml
+++ b/src/lib/server/eliommod.ml
@@ -275,23 +275,26 @@ let parse_eliom_option
     in
     a, Eliom_lib.Option.map parse_scope_hierarchy sn, ct
   in
-  let convert_attr tag f v =
+  let convert_attr ~element tag f v =
     try f v
     with Invalid_argument _ ->
       raise
         (Error_in_config_file
            (Printf.sprintf
-              "Eliom: Wrong attribute value for tag %s in element cacheglobaldata"
-              tag))
+              "Eliom: Wrong attribute value for tag %s in element %s" tag element))
   in
   let parse_application_script_attrs attrs =
     let rec aux defer async attrs =
       match attrs with
       | [] -> defer, async
       | ("defer", v) :: rem ->
-          aux (convert_attr "defer" bool_of_string v) async rem
+          aux
+            (convert_attr ~element:"applicationscript" "defer" bool_of_string v)
+            async rem
       | ("async", v) :: rem ->
-          aux defer (convert_attr "async" bool_of_string v) rem
+          aux defer
+            (convert_attr ~element:"applicationscript" "async" bool_of_string v)
+            rem
       | (tag, _) :: _ ->
           raise
             (Error_in_config_file
@@ -307,7 +310,9 @@ let parse_eliom_option
       | [] -> Some (path, max_age)
       | ("path", p) :: rem -> aux (Eliom_lib.Url.split_path p) max_age rem
       | ("cache", v) :: rem ->
-          aux path (convert_attr "cache" int_of_string v) rem
+          aux path
+            (convert_attr ~element:"cacheglobaldata" "cache" int_of_string v)
+            rem
       | (tag, _) :: _ ->
           raise
             (Error_in_config_file


### PR DESCRIPTION
Fixes the typo-class findings from the audit in #880, plus a few additional misspellings found while sweeping `src/lib`.

### User-facing / message typos
- **`eliom_service.server.ml`** — the `failwith` message read `"attach' is not implemented for this kind ofservice. Please report a bug if you need this."` — a stale function name (`attach'` → `attach`) and a missing space (`ofservice` → `of service`).
- **`server/eliommod.ml`** — `convert_attr` is shared between the `applicationscript` and `cacheglobaldata` config parsers, but its error message hardcoded `"... in element cacheglobaldata"`. A bad value on `<applicationscript defer="…">` therefore pointed the operator at the wrong tag. Parameterized the element name so each parser reports its own tag.
- **`eliom_content_.client.ml`** — `scrollIntoView` passed the copy/paste-leftover context string `"Css.background"` to `get_unique_elt`, so its error read "Cannot call Css.background…". Changed to `"scrollIntoView"`.

### Comment / identifier typos
- `hieranrchical` → `hierarchical` (`eliom_tools.eliom` and `.eliomi`)
- `wainting` → `waiting` (`eliom_comet.server.ml`)
- `irrespectable` → `irrespective` (`eliom_form_sigs.shared.mli`, ×2)
- local binding `effectul_event` → `effectful_event` and its comments (`eliom_shared.eliom`)

### Deliberately left alone
- **`classe`** (`eliom_tools`) — an intentional API parameter name (`class` is reserved in OCaml), not a typo.
- **`ancessor`** (`Eliommod_dom.ancessor`, + `fast_/slow_ancessor` and call sites) — also a misspelling, but it's an exported symbol, so renaming it is an API change rather than a comment/message fix. Left out of this PR; happy to do it separately if you'd like.

No behavioural change. Built with `dune build src/lib` (OCaml 5.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
