### PR TITLE
Require ocsigenserver >= 8.0 (and < 9.0)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -39,7 +39,7 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   (js_of_ocaml-tyxml (>= 6.3.2))
   logs
   (tyxml (and (>= 4.6) (< 4.7)))
-  (ocsigenserver (and (>= 7.0) (< 8.0)))
+  (ocsigenserver (and (>= 8.0) (< 9.0)))
   (ipaddr (>= 2.1))
   (reactiveData (>= 0.2.1))
   base-bytes

--- a/eliom.opam
+++ b/eliom.opam
@@ -31,7 +31,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "6.3.2"}
   "logs"
   "tyxml" {>= "4.6" & < "4.7"}
-  "ocsigenserver" {>= "7.0" & < "8.0"}
+  "ocsigenserver" {>= "8.0" & < "9.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"


### PR DESCRIPTION
Eliom on `deriving` targets the Ocsigen Server 8.x API, but the dependency bound still allowed only 7.x (`>= 7.0 & < 8.0`). That made eliom uninstallable against `ocsigenserver.8.0.0~dev` (`eliom → ocsigenserver < 8.0` conflict).

Bump the bound in `dune-project` to `(>= 8.0) (< 9.0)` and regenerate `eliom.opam`.