### PR TITLE
Switch to ocamlformat 0.29.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.28.1
+version=0.29.0
 parse-docstrings = false
 wrap-comments = false
 break-cases = fit

--- a/doc/dune
+++ b/doc/dune
@@ -1,5 +1,6 @@
 ; Eliom manual pages (odoc .mld), compiled in place with the API by
 ; `dune build @doc` and installed with the package, so they appear on ocaml.org
 ; and resolve {{!page-X}} / {!Module} references against the API.
+
 (documentation
  (package eliom))

--- a/pkg/distillery/dune
+++ b/pkg/distillery/dune
@@ -2,6 +2,7 @@
 
 ; Install the distillery templates into lib/eliom/templates/<name>/
 ; so that eliom-distillery picks them up at the standard location.
+
 (install
  (package eliom)
  (section lib_root)

--- a/src/lib/common.server.ml
+++ b/src/lib/common.server.ml
@@ -30,12 +30,10 @@ exception
 
 exception Cannot_call_this_function_before_app_is_linked_to_a_site
 exception Eliom_error_while_loading_site of string
-
 exception Do_redirection of string
 
 (* Backwards-compatible alias; new code should use Do_redirection. *)
 exception Eliom_do_redirection = Do_redirection
-
 exception Do_half_xhr_redirection of string
 
 (* Backwards-compatible alias; new code should use Do_half_xhr_redirection. *)
@@ -159,9 +157,7 @@ type perssessgrp = string (* same triple, JSON-encoded *) [@@deriving json]
    {!sessgrp} but always with [Left g] for persistent groups, hence the
    simpler representation here. *)
 type perssessgrp_payload =
-  { p_site_dir_str : string
-  ; p_cookie_level : cookie_level
-  ; p_group : string }
+  {p_site_dir_str : string; p_cookie_level : cookie_level; p_group : string}
 [@@deriving json]
 
 [@@@warning "+39"]
@@ -171,7 +167,9 @@ let make_persistent_full_group_name ~cookie_level site_dir_string = function
   | Some g ->
       Some
         (Deriving_Json.to_string [%json: perssessgrp_payload]
-           {p_site_dir_str = site_dir_string; p_cookie_level = cookie_level; p_group = g})
+           { p_site_dir_str = site_dir_string
+           ; p_cookie_level = cookie_level
+           ; p_group = g })
 
 let getperssessgrp a : 'a sessgrp =
   let {p_site_dir_str; p_cookie_level; p_group} =
@@ -379,7 +377,8 @@ type node_info = {ni_id : node_ref; mutable ni_sent : bool}
 
 module Hier_set = String.Set
 
-type omitpersistentstorage_rule = HeaderRule of Ocsigen_http.Header.Name.t * Re.re
+type omitpersistentstorage_rule =
+  | HeaderRule of Ocsigen_http.Header.Name.t * Re.re
 
 type server_params =
   { sp_request : Ocsigen.Extensions.request
@@ -535,7 +534,8 @@ and sitedata =
   ; mutable omitpersistentstorage : omitpersistentstorage_rule list option }
 
 and dlist_ip_table =
-  (page_table ref * page_table_key, na_key_serv) leftright Ocsigen_base.Cache.Dlist.t
+  (page_table ref * page_table_key, na_key_serv) leftright
+    Ocsigen_base.Cache.Dlist.t
     Net_addr_Hashtbl.t
 
 let check_initialised field =
@@ -706,14 +706,17 @@ let list_scope_hierarchies () =
 
 (*****************************************************************************)
 (* The current registration directory *)
-let absolute_change_sitedata, get_current_sitedata, end_current_sitedata, has_current_sitedata =
+let ( absolute_change_sitedata
+    , get_current_sitedata
+    , end_current_sitedata
+    , has_current_sitedata )
+  =
   let f2 : sitedata list ref = ref [] in
   let popf2 () = match !f2 with _ :: t -> f2 := t | [] -> f2 := [] in
   ( (fun sitedata -> f2 := sitedata :: !f2) (* absolute_change_sitedata *)
   , (fun () ->
       match !f2 with
-      | [] ->
-          raise (Site_information_not_available "get_current_sitedata")
+      | [] -> raise (Site_information_not_available "get_current_sitedata")
       | sd :: _ -> sd)
     (* get_current_sitedata *)
   , (fun () -> popf2 ()) (* end_current_sitedata *)
@@ -775,8 +778,7 @@ let force_lazy_site_value v =
     | None -> (
       match global_register_allowed () with
       | Some f -> f ()
-      | None ->
-          raise (Site_information_not_available "force_lazy_site_value"))
+      | None -> raise (Site_information_not_available "force_lazy_site_value"))
   in
   try Polytables.get ~table:sitedata.site_value_table ~key:v.lazy_sv_key
   with Not_found ->
@@ -847,7 +849,8 @@ let empty_tables max forsession =
       (if forsession
        then (
          let dlist = Ocsigen_base.Cache.Dlist.create max in
-         Ocsigen_base.Cache.Dlist.set_finaliser_before (dlist_finaliser t2) dlist;
+         Ocsigen_base.Cache.Dlist.set_finaliser_before (dlist_finaliser t2)
+           dlist;
          fun ?sp:_ v -> add_dlist_ dlist v)
        else
          fun ?sp v ->
@@ -1387,7 +1390,6 @@ end
 (* keeping track of all the persistent tables *)
 module Persistent_tables = struct
   let functorial_tables = ref []
-
   let add_functorial_table t = functorial_tables := t :: !functorial_tables
 
   let create_json (type a) ~name (json : a Deriving_Json.t) :

--- a/src/lib/common.server.mli
+++ b/src/lib/common.server.mli
@@ -416,7 +416,8 @@ type node_info = {ni_id : node_ref; mutable ni_sent : bool}
 
 module Hier_set : Set.S
 
-type omitpersistentstorage_rule = HeaderRule of Ocsigen_http.Header.Name.t * Re.re
+type omitpersistentstorage_rule =
+  | HeaderRule of Ocsigen_http.Header.Name.t * Re.re
 
 type 'a dircontent = Vide | Table of 'a direlt ref String.Table.t
 and 'a direlt = Dir of 'a dircontent ref | File of 'a ref
@@ -644,9 +645,7 @@ module Persistent_tables : sig
   val create_json :
      name:string
     -> 'a Deriving_Json.t
-    -> (module Ocsipersist.TABLE
-          with type key = string
-           and type value = 'a)
+    -> (module Ocsipersist.TABLE with type key = string and type value = 'a)
 
   val add_functorial_table :
      (module Ocsipersist.TABLE with type key = string)

--- a/src/lib/config.server.ml
+++ b/src/lib/config.server.ml
@@ -137,8 +137,7 @@ let get_config () =
     match !Mod_main.config with
     | Some c -> c
     | None -> failwith "No config file. Is it a statically linked executable?")
-  | None ->
-      raise (Common.Site_information_not_available "Config.get_config")
+  | None -> raise (Common.Site_information_not_available "Config.get_config")
 
 let parse_config ?pcdata ?other_elements elements =
   Ocsigen.Extensions.Configuration.process_elements

--- a/src/lib/lib.server.ml
+++ b/src/lib/lib.server.ml
@@ -62,4 +62,5 @@ let jsmarshal v = string_escape (Marshal.to_string v [])
 let make_cryptographic_safe_string ?len () =
   match len with
   | None -> Ocsigen_base.Lib.make_cryptographic_safe_string ()
-  | Some l -> String.sub (Ocsigen_base.Lib.make_cryptographic_safe_string ()) 0 l
+  | Some l ->
+      String.sub (Ocsigen_base.Lib.make_cryptographic_safe_string ()) 0 l

--- a/src/lib/mkreg.server.ml
+++ b/src/lib/mkreg.server.ml
@@ -485,8 +485,8 @@ let register
             (* I suppose that it's a statically linked module
                that is not associated with a site yet.
                I will defer the registration until app is initialised. *)
-            Ocsigen_base.Loader.add_module_init_function (Common.get_app_name ())
-              (fun () -> aux sitedata)
+            Ocsigen_base.Loader.add_module_init_function
+              (Common.get_app_name ()) (fun () -> aux sitedata)
       | _ -> raise (Common.Site_information_not_available "register"))
   | None, Some _ | Some `Site, Some _ ->
       register_aux pages ?options ?charset ?code ?content_type ?headers

--- a/src/lib/parameter_sigs.shared.mli
+++ b/src/lib/parameter_sigs.shared.mli
@@ -407,4 +407,3 @@ module type S = sig
   val is_unit : ('a, _, _) params_type -> 'a is_unit
   val anonymise_params_type : ('a, 'b, 'c) params_type -> int
 end
-

--- a/src/lib/reference.server.ml
+++ b/src/lib/reference.server.ml
@@ -22,7 +22,6 @@
 
 open State
 open Lwt.Infix
-
 module Store_json = Common.Ocsipersist.Store_json
 
 let pers_ref_store = Store_json.open_store "eliom__persistent_refs"
@@ -38,9 +37,7 @@ let json_option (type x) (j : x Deriving_Json.t) : x option Deriving_Json.t =
   O.t
 
 type 'a typed_table =
-  (module Common.Ocsipersist.TABLE
-     with type key = string
-      and type value = 'a)
+  (module Common.Ocsipersist.TABLE with type key = string and type value = 'a)
 
 type 'a eref_kind =
   | Req of 'a Polytables.key
@@ -209,11 +206,10 @@ let get_site_id () =
   ^ Common.get_site_dir_string sd
 
 let typed_table_call (type a) (t : a typed_table) =
-  (module (val t)
-    : Common.Ocsipersist.TABLE
+  (module (val t) : Common.Ocsipersist.TABLE
      with type key = string
       and type value = a)
-  [@@warning "-32"]
+[@@warning "-32"]
 (* helper signature used inside [let module] below *)
 
 let get (type a) ((f, _, table) as eref) : a Lwt.t =
@@ -235,9 +231,7 @@ let get (type a) ((f, _, table) as eref) : a Lwt.t =
   | Ocsiper_sit t ->
       let module T =
         (val t
-            : Common.Ocsipersist.TABLE
-             with type key = string
-              and type value = a)
+          : Common.Ocsipersist.TABLE with type key = string and type value = a)
       in
       let site_id = get_site_id () in
       Lwt.catch
@@ -256,9 +250,7 @@ let set (type a) ((_, _, table) as eref) (value : a) =
   | Ocsiper_sit t ->
       let module T =
         (val t
-            : Common.Ocsipersist.TABLE
-             with type key = string
-              and type value = a)
+          : Common.Ocsipersist.TABLE with type key = string and type value = a)
       in
       T.add (get_site_id ()) value
   | _ -> Lwt.return (Volatile.set eref value)
@@ -272,9 +264,7 @@ let unset (type a) ((_, _, table) as eref) =
   | Ocsiper_sit t ->
       let module T =
         (val t
-            : Common.Ocsipersist.TABLE
-             with type key = string
-              and type value = a)
+          : Common.Ocsipersist.TABLE with type key = string and type value = a)
       in
       T.remove (get_site_id ())
   | _ -> Lwt.return (Volatile.unset eref)

--- a/src/lib/registration.server.ml
+++ b/src/lib/registration.server.ml
@@ -107,7 +107,8 @@ let content_type_html content_type =
           Ocsigen_http.Header.Name.accept
       in
       let accept = Ocsigen_http.Header.Accept.parse accept in
-      Ocsigen_http.Header.Content_type.choose accept Content.Html.D.Info.content_type
+      Ocsigen_http.Header.Content_type.choose accept
+        Content.Html.D.Info.content_type
         Content.Html.D.Info.alternative_content_types
 
 module Html_base = struct
@@ -179,7 +180,9 @@ module String_base = struct
   let send ?options ?charset ?code ?content_type:_ ?headers (c, content_type) =
     let status = Lib.Option.map Cohttp.Code.status_of_code code
     and body = Ocsigen.Response.Body.of_string c
-    and headers = add_cache_header options (Ocsigen_http.Header.of_option headers) in
+    and headers =
+      add_cache_header options (Ocsigen_http.Header.of_option headers)
+    in
     result_of_content ?charset ?status ~content_type ~headers body
 end
 

--- a/src/lib/server/Eliom/mod_cookies.ml
+++ b/src/lib/server/Eliom/mod_cookies.ml
@@ -25,7 +25,8 @@ open Lwt
 include Cookies_base
 
 (*****************************************************************************)
-let make_new_session_id () = Ocsigen_base.Lib.make_cryptographic_safe_string () ^ "H"
+let make_new_session_id () =
+  Ocsigen_base.Lib.make_cryptographic_safe_string () ^ "H"
 
 [@@@warning "-39"]
 

--- a/src/lib/server/Eliom/mod_main.ml
+++ b/src/lib/server/Eliom/mod_main.ml
@@ -842,7 +842,10 @@ let parse_config _ hostpattern conf_info site_dir =
     | ("findlib-package", s) :: suite -> (
       match file with
       | None -> (
-        try parse_module_attrs (Some (Files (Ocsigen_base.Loader.findfiles s))) suite
+        try
+          parse_module_attrs
+            (Some (Files (Ocsigen_base.Loader.findfiles s)))
+            suite
         with Ocsigen_base.Loader.Findlib_error _ as e ->
           raise
             (Error_in_config_file

--- a/src/lib/server/Eliom/mod_pagegen.ml
+++ b/src/lib/server/Eliom/mod_pagegen.ml
@@ -107,8 +107,7 @@ let update_cookie_table ?now sitedata (ci, sci) =
 
       let within_tolerance_opt x y =
         match x, y with Some x, Some y -> within_tolerance x y | _ -> x = y
-    end
-    in
+    end in
     (* Update persistent expiration date, user timeout and value *)
     (* 2018-07-17 We do this for all persistent sessions
        only if one persistent session has been used:
@@ -228,7 +227,9 @@ let do_redirection header_id status uri =
     (fun () ->
       let response =
         let headers =
-          Cohttp.Header.init_with Ocsigen_http.Header.Name.(to_string header_id) uri
+          Cohttp.Header.init_with
+            Ocsigen_http.Header.Name.(to_string header_id)
+            uri
         in
         Cohttp.Response.make ~status ~headers ()
       in
@@ -359,12 +360,13 @@ let gen_req_not_found ~is_eliom_extension ~sitedata ~previous_extension_err ~req
         | Common.Eliom_retry_with a -> gen_aux a
         | Common.Do_redirection uri ->
             Lwt.return
-            @@ do_redirection Ocsigen_http.Header.Name.location `Temporary_redirect
-                 uri
+            @@ do_redirection Ocsigen_http.Header.Name.location
+                 `Temporary_redirect uri
         | Common.Do_half_xhr_redirection uri ->
             Lwt.return
             @@ do_redirection
-                 (Ocsigen_http.Header.Name.of_string Common.half_xhr_redir_header)
+                 (Ocsigen_http.Header.Name.of_string
+                    Common.half_xhr_redir_header)
                  `No_content uri
         | e -> Lwt.fail e)
   in

--- a/src/lib/server/Eliom/mod_sessiongroups.ml
+++ b/src/lib/server/Eliom/mod_sessiongroups.ml
@@ -85,7 +85,8 @@ module Make (A : sig
     type group_of_group_data
 
     val table :
-      (group_of_group_data option * string Ocsigen_base.Cache.Dlist.t) GroupTable.t
+      (group_of_group_data option * string Ocsigen_base.Cache.Dlist.t)
+        GroupTable.t
 
     val close_session : Common.sitedata -> string -> unit
     val max_tab_per_session : Common.sitedata -> int
@@ -188,7 +189,8 @@ module Make (A : sig
         match cookie_level with
         | `Session ->
             ignore
-              (Ocsigen_base.Cache.Dlist.add sess_grp sitedata.Common.group_of_groups);
+              (Ocsigen_base.Cache.Dlist.add sess_grp
+                 sitedata.Common.group_of_groups);
             Ocsigen_base.Cache.Dlist.newest sitedata.Common.group_of_groups
         | _ -> None
       in
@@ -238,7 +240,8 @@ module Data = Make (struct
       [`Session] Common.sessgrp Ocsigen_base.Cache.Dlist.node
 
     let table :
-      (group_of_group_data option * string Ocsigen_base.Cache.Dlist.t) GroupTable.t
+      (group_of_group_data option * string Ocsigen_base.Cache.Dlist.t)
+        GroupTable.t
       =
       (* The table associates the dlist for a group
          to a full session group name.
@@ -321,10 +324,12 @@ Besides, volatile sessions are (hopefully) going to disappear soon.
 
 module Serv = Make (struct
     type group_of_group_data =
-      Common.tables ref * [`Session] Common.sessgrp Ocsigen_base.Cache.Dlist.node
+      Common.tables ref
+      * [`Session] Common.sessgrp Ocsigen_base.Cache.Dlist.node
 
     let table :
-      (group_of_group_data option * string Ocsigen_base.Cache.Dlist.t) GroupTable.t
+      (group_of_group_data option * string Ocsigen_base.Cache.Dlist.t)
+        GroupTable.t
       =
       GroupTable.create 100
 
@@ -435,8 +440,8 @@ module Pers = struct
     | Some g ->
         Lwt.catch
           (fun () ->
-             Grouptable.find (Common.string_of_perssessgrp g)
-             >>= fun (_, a) -> Lwt.return a)
+             Grouptable.find (Common.string_of_perssessgrp g) >>= fun (_, a) ->
+             Lwt.return a)
           (function Not_found -> Lwt.return_nil | e -> Lwt.fail e)
 
   let add ?set_max defaultmax sess_id sess_grp =
@@ -468,8 +473,7 @@ module Pers = struct
                   | Some None -> Nolimit
                   | Some (Some v) -> Val v
                 in
-                Grouptable.add sg (max, [sess_id]) >>= fun () ->
-                Lwt.return_nil
+                Grouptable.add sg (max, [sess_id]) >>= fun () -> Lwt.return_nil
             | e -> Lwt.fail e)
     | None -> Lwt.return_nil
 

--- a/src/lib/service.server.ml
+++ b/src/lib/service.server.ml
@@ -358,8 +358,7 @@ let unregister
           | Some get_current_sitedata ->
               let sitedata = get_current_sitedata () in
               sitedata.Common.global_services
-          | _ ->
-              raise (Common.Site_information_not_available "unregister"))
+          | _ -> raise (Common.Site_information_not_available "unregister"))
         | Some _ -> State.get_global_table ()
       in
       remove_service table service

--- a/src/lib/state.server.ml
+++ b/src/lib/state.server.ml
@@ -852,11 +852,11 @@ let get_session_service_table_if_exists ~sp ~scope ?secure () =
 type 'a persistent_table =
   Common.user_scope
   * bool
-  * (module Common.Ocsipersist.TABLE
-       with type key = string
-        and type value = 'a)
+  * (module Common.Ocsipersist.TABLE with type key = string and type value = 'a)
 
-let create_persistent_table ~scope ?secure ~json name : 'a persistent_table Lwt.t =
+let create_persistent_table ~scope ?secure ~json name :
+  'a persistent_table Lwt.t
+  =
   let sitedata = Request_info.find_sitedata "create_persistent_table" in
   let secure = Common.get_secure ~secure_o:secure ~sitedata () in
   let t = Common.Persistent_tables.create_json ~name json in
@@ -898,9 +898,7 @@ let get_persistent_data (type a) ~(table : a persistent_table) () =
        >>= fun (table, key) ->
        let module T =
          (val table
-             : Common.Ocsipersist.TABLE
-              with type key = string
-               and type value = a)
+           : Common.Ocsipersist.TABLE with type key = string and type value = a)
        in
        T.find key >>= fun v -> Lwt.return (Data v))
     (function
@@ -925,9 +923,7 @@ let remove_persistent_data (type a) ~(table : a persistent_table) () =
        in
        let module T =
          (val table
-             : Common.Ocsipersist.TABLE
-              with type key = string
-               and type value = a)
+           : Common.Ocsipersist.TABLE with type key = string and type value = a)
        in
        let* () = T.remove key in
        close_persistent_state_if_empty ~scope ~secure ())
@@ -952,8 +948,7 @@ let create_volatile_table ~scope ?secure () =
         let secure = Common.get_secure ~secure_o:secure ~sitedata () in
         Mod_datasess.create_volatile_table ~scope ~secure
     | None ->
-        raise
-          (Common.Site_information_not_available "create_volatile_table"))
+        raise (Common.Site_information_not_available "create_volatile_table"))
   | Some sp ->
       let sitedata = Request_info.get_sitedata_sp ~sp in
       let secure = Common.get_secure ~secure_o:secure ~sitedata () in
@@ -1349,7 +1344,8 @@ module Ext = struct
     =
     let state' = (state :> ('aa, 'bb) state) in
     let a = fold_sub_states_aux_aux ?sitedata ~state:state' f in
-    fold_sub_states_aux Ocsigen_base.Cache.Dlist.fold Ocsigen_base.Lib.id a e state
+    fold_sub_states_aux Ocsigen_base.Cache.Dlist.fold Ocsigen_base.Lib.id a e
+      state
 
   (** Fold over the snapshot of a Dlist. *)
   let dlist_lwt_fold f acc dlist =
@@ -1406,9 +1402,7 @@ module Ext = struct
       lwt_check_scopes table_scope state_scope >>= fun () ->
       let module T =
         (val t
-            : Common.Ocsipersist.TABLE
-             with type key = string
-              and type value = a)
+          : Common.Ocsipersist.TABLE with type key = string and type value = a)
       in
       T.find cookie
 
@@ -1429,9 +1423,7 @@ module Ext = struct
       lwt_check_scopes table_scope state_scope >>= fun () ->
       let module T =
         (val t
-            : Common.Ocsipersist.TABLE
-             with type key = string
-              and type value = a)
+          : Common.Ocsipersist.TABLE with type key = string and type value = a)
       in
       T.add cookie value
 
@@ -1450,9 +1442,7 @@ module Ext = struct
       lwt_check_scopes table_scope state_scope >>= fun () ->
       let module T =
         (val t
-            : Common.Ocsipersist.TABLE
-             with type key = string
-              and type value = a)
+          : Common.Ocsipersist.TABLE with type key = string and type value = a)
       in
       T.remove cookie
   end

--- a/src/lib/syntax.server.ml
+++ b/src/lib/syntax.server.ml
@@ -43,7 +43,7 @@ let get_global_data, modify_global_data =
        push the default sitedata, and crash. *)
     Common.(
       get_sp_option () <> None
-      || Ocsigen.Extensions.during_initialisation () && has_current_sitedata ())
+      || (Ocsigen.Extensions.during_initialisation () && has_current_sitedata ()))
   in
   let get () =
     if is_site_available ()

--- a/src/ppx/ppx_eliom_client.ml
+++ b/src/ppx/ppx_eliom_client.ml
@@ -13,20 +13,20 @@ module Pass = struct
   (* Replace every escaped identifier [v] with
      [Client_core.Syntax_helpers.get_escaped_value v] *)
   let map_get_escaped_values expr =
-    (object
-       inherit Ppxlib.Ast_traverse.map as super
+    object
+      inherit Ppxlib.Ast_traverse.map as super
 
-       method! expression e =
-         match e.pexp_desc with
-         | Pexp_ident {txt; _}
-           when Mli.is_escaped_ident @@ Longident.last_exn txt ->
-             let loc = e.pexp_loc in
-             [%expr
-               [%e
-                 eliom_expr ~loc "Client_core.Syntax_helpers.get_escaped_value"]
-                 [%e e]]
-         | _ -> super#expression e
-    end)
+      method! expression e =
+        match e.pexp_desc with
+        | Pexp_ident {txt; _}
+          when Mli.is_escaped_ident @@ Longident.last_exn txt ->
+            let loc = e.pexp_loc in
+            [%expr
+              [%e
+                eliom_expr ~loc "Client_core.Syntax_helpers.get_escaped_value"]
+                [%e e]]
+        | _ -> super#expression e
+    end
       #expression
       expr
 
@@ -208,21 +208,21 @@ module Pass = struct
         Exp.let_ ~loc Nonrecursive bindings [%expr [%e frag_eid] [%e args]]
 
   let check_no_variable =
-    (object
-       inherit Ppxlib.Ast_traverse.map as super
+    object
+      inherit Ppxlib.Ast_traverse.map as super
 
-       method! core_type typ =
-         match typ with
-         | {ptyp_desc = Ptyp_var _; ptyp_loc = loc; _} ->
-             let attr =
-               attribute_of_warning loc
-                 "The type of this injected value contains a type variable that could be wrongly inferred."
-             in
-             { typ with
-               ptyp_attributes = attr :: typ.ptyp_attributes
-             ; ptyp_loc = loc }
-         | _ -> super#core_type typ
-    end)
+      method! core_type typ =
+        match typ with
+        | {ptyp_desc = Ptyp_var _; ptyp_loc = loc; _} ->
+            let attr =
+              attribute_of_warning loc
+                "The type of this injected value contains a type variable that could be wrongly inferred."
+            in
+            { typ with
+              ptyp_attributes = attr :: typ.ptyp_attributes
+            ; ptyp_loc = loc }
+        | _ -> super#core_type typ
+    end
       #core_type
 
   let escape_inject

--- a/src/ppx/ppx_eliom_utils.ml
+++ b/src/ppx/ppx_eliom_utils.ml
@@ -214,17 +214,17 @@ module Mli = struct
       fun s ->
         String.length s >= len && String.sub s 0 len = inferred_type_prefix
     in
-    (object
-       inherit Ppxlib.Ast_traverse.map as super
+    object
+      inherit Ppxlib.Ast_traverse.map as super
 
-       method! core_type ty =
-         match ty.ptyp_desc with
-         (* | Ptyp_constr  (_, Ast.TyAny _, ty) *)
-         (* | Ptyp_constr (_, ty, Ast.TyAny _) -> ty *)
-         | Ptyp_var var when has_pfix var ->
-             super#core_type {ty with ptyp_desc = Ptyp_var (rename var)}
-         | _ -> super#core_type ty
-    end)
+      method! core_type ty =
+        match ty.ptyp_desc with
+        (* | Ptyp_constr  (_, Ast.TyAny _, ty) *)
+        (* | Ptyp_constr (_, ty, Ast.TyAny _) -> ty *)
+        | Ptyp_var var when has_pfix var ->
+            super#core_type {ty with ptyp_desc = Ptyp_var (rename var)}
+        | _ -> super#core_type ty
+    end
       #core_type
 
   let is_injected_ident id =
@@ -777,32 +777,32 @@ end
 
 module Shared = struct
   let server =
-    (object
-       inherit Ppxlib.Ast_traverse.map as super
+    object
+      inherit Ppxlib.Ast_traverse.map as super
 
-       method! expression expr =
-         match expr with
-         | [%expr [%client [%e? _]]] -> expr
-         | [%expr [%client.unsafe [%e? _]]] -> expr
-         | [%expr ~%[%e? injection_expr]] -> injection_expr
-         | _ -> super#expression expr
-    end)
+      method! expression expr =
+        match expr with
+        | [%expr [%client [%e? _]]] -> expr
+        | [%expr [%client.unsafe [%e? _]]] -> expr
+        | [%expr ~%[%e? injection_expr]] -> injection_expr
+        | _ -> super#expression expr
+    end
       #expression
 
   let client expr =
     let context = ref `Top in
-    (object (self)
-       inherit Ppxlib.Ast_traverse.map as super
+    object (self)
+      inherit Ppxlib.Ast_traverse.map as super
 
-       method! expression expr =
-         match expr with
-         | [%expr [%client [%e? fragment_expr]]]
-         | [%expr [%client.unsafe [%e? fragment_expr]]] ->
-             in_context context `Fragment self#expression fragment_expr
-         | [%expr ~%[%e? injection_expr]] -> (
-           match !context with `Top -> expr | `Fragment -> injection_expr)
-         | _ -> super#expression expr
-    end)
+      method! expression expr =
+        match expr with
+        | [%expr [%client [%e? fragment_expr]]]
+        | [%expr [%client.unsafe [%e? fragment_expr]]] ->
+            in_context context `Fragment self#expression fragment_expr
+        | [%expr ~%[%e? injection_expr]] -> (
+          match !context with `Top -> expr | `Fragment -> injection_expr)
+        | _ -> super#expression expr
+    end
       #expression
       expr
 

--- a/src/tools/gen_dune.ml
+++ b/src/tools/gen_dune.ml
@@ -1,7 +1,8 @@
 let pf = Printf.printf
 
 let module_name nm =
-  try let nm = Filename.chop_extension nm in
+  try
+    let nm = Filename.chop_extension nm in
     try Filename.chop_extension nm with Invalid_argument _ -> nm
   with Invalid_argument _ -> nm
 
@@ -20,13 +21,15 @@ let scan_mli_only dir =
   List.iter
     (fun f ->
        let modname = module_name f in
-       if Filename.check_suffix f ".server.mli"
-          || Filename.check_suffix f ".shared.mli"
+       if
+         Filename.check_suffix f ".server.mli"
+         || Filename.check_suffix f ".shared.mli"
        then
          if not (has_impl_for modname [".server.ml"; ".shared.ml"; ".eliom"])
          then Hashtbl.replace mli_only_server modname true;
-       if Filename.check_suffix f ".client.mli"
-          || Filename.check_suffix f ".shared.mli"
+       if
+         Filename.check_suffix f ".client.mli"
+         || Filename.check_suffix f ".shared.mli"
        then
          if not (has_impl_for modname [".client.ml"; ".shared.ml"; ".eliom"])
          then Hashtbl.replace mli_only_client modname true)
@@ -47,41 +50,27 @@ let handle_file_client nm =
   then (
     copy_file ".client.mli";
     let modname = module_name nm in
-    if Hashtbl.mem mli_only_client modname then
-      subdir_copy nm (modname ^ ".ml"))
+    if Hashtbl.mem mli_only_client modname then subdir_copy nm (modname ^ ".ml"))
   else if Filename.check_suffix nm ".shared.mli"
   then (
     copy_file ".shared.mli";
     let modname = module_name nm in
-    if Hashtbl.mem mli_only_client modname then
-      subdir_copy nm (modname ^ ".ml"))
+    if Hashtbl.mem mli_only_client modname then subdir_copy nm (modname ^ ".ml"))
   else if Filename.check_suffix nm ".eliom"
-  then (
+  then
     let nm = Filename.chop_suffix nm ".eliom" in
     pf
-      "(subdir Eliom\n\
-      \ (rule (target %s.ml)\n\
-      \  (deps ../../%s.eliom (file \
-       ../../server/.eliom_server.objs/byte/eliom__%s.cmo))\n\
-      \  (action\n\
-      \    (with-stdout-to %%{target}\n\
-      \      (chdir ../.. (run ppx_eliom_client --as-pp -internal -server-cmo \
-       server/.eliom_server.objs/byte/eliom__%s.cmo --impl %s.eliom))))))\n"
+      "(subdir Eliom\n\ (rule (target %s.ml)\n\  (deps ../../%s.eliom (file ../../server/.eliom_server.objs/byte/eliom__%s.cmo))\n\  (action\n\    (with-stdout-to %%{target}\n\      (chdir ../.. (run ppx_eliom_client --as-pp -internal -server-cmo server/.eliom_server.objs/byte/eliom__%s.cmo --impl %s.eliom))))))\n"
       nm nm
       (String.capitalize_ascii nm)
       (String.capitalize_ascii nm)
-      nm)
+      nm
   else if Filename.check_suffix nm ".eliomi"
-  then (
+  then
     let nm = Filename.chop_suffix nm ".eliomi" in
     pf
-      "(subdir Eliom\n\
-      \ (rule (target %s.mli) (deps ../../%s.eliomi)\n\
-      \  (action\n\
-      \    (with-stdout-to %%{target}\n\
-      \      (chdir ../.. (run ppx_eliom_client --as-pp -internal --intf \
-       %s.eliomi))))))\n"
-      nm nm nm)
+      "(subdir Eliom\n\ (rule (target %s.mli) (deps ../../%s.eliomi)\n\  (action\n\    (with-stdout-to %%{target}\n\      (chdir ../.. (run ppx_eliom_client --as-pp -internal --intf %s.eliomi))))))\n"
+      nm nm nm
 
 let handle_file_server nm =
   let subdir_copy src dst =
@@ -98,36 +87,24 @@ let handle_file_server nm =
   then (
     copy_file ".server.mli";
     let modname = module_name nm in
-    if Hashtbl.mem mli_only_server modname then
-      subdir_copy nm (modname ^ ".ml"))
+    if Hashtbl.mem mli_only_server modname then subdir_copy nm (modname ^ ".ml"))
   else if Filename.check_suffix nm ".shared.mli"
   then (
     copy_file ".shared.mli";
     let modname = module_name nm in
-    if Hashtbl.mem mli_only_server modname then
-      subdir_copy nm (modname ^ ".ml"))
+    if Hashtbl.mem mli_only_server modname then subdir_copy nm (modname ^ ".ml"))
   else if Filename.check_suffix nm ".eliom"
-  then (
+  then
     let nm = Filename.chop_suffix nm ".eliom" in
     pf
-      "(subdir Eliom\n\
-      \ (rule (target %s.ml) (deps ../../%s.eliom)\n\
-      \  (action\n\
-      \    (with-stdout-to %%{target}\n\
-      \      (chdir ../.. (run ppx_eliom_server --as-pp -internal --impl \
-       %s.eliom))))))\n"
-      nm nm nm)
+      "(subdir Eliom\n\ (rule (target %s.ml) (deps ../../%s.eliom)\n\  (action\n\    (with-stdout-to %%{target}\n\      (chdir ../.. (run ppx_eliom_server --as-pp -internal --impl %s.eliom))))))\n"
+      nm nm nm
   else if Filename.check_suffix nm ".eliomi"
-  then (
+  then
     let nm = Filename.chop_suffix nm ".eliomi" in
     pf
-      "(subdir Eliom\n\
-      \ (rule (target %s.mli) (deps ../../%s.eliomi)\n\
-      \  (action\n\
-      \    (with-stdout-to %%{target}\n\
-      \      (chdir ../.. (run ppx_eliom_server --as-pp -internal --intf \
-       %s.eliomi))))))\n"
-      nm nm nm)
+      "(subdir Eliom\n\ (rule (target %s.mli) (deps ../../%s.eliomi)\n\  (action\n\    (with-stdout-to %%{target}\n\      (chdir ../.. (run ppx_eliom_server --as-pp -internal --intf %s.eliomi))))))\n"
+      nm nm nm
 
 let () =
   let dir = Sys.argv.(2) in


### PR DESCRIPTION
## Problem
`deriving` is already formatted with ocamlformat **0.29.0** in practice (editor format-on-save), but `.ocamlformat` still pins **0.28.1**. The `lint-fmt` CI job installs the pinned version, so it fails on the 0.29.0-formatted code — `deriving`'s `lint-fmt` has been red independently of any feature work.

## Fix
- Bump the pinned version in `.ocamlformat` to `0.29.0`.
- Reformat the remaining stragglers via `dune fmt`.

**21 files only**, pure formatting (`.ocamlformat` + 20 reformatted files). No semantic edits, no generated artifacts. `dune build @fmt` is clean under 0.29.0.

## CI note
`build` jobs stay red here: `deriving` does not yet compile against Ocsigen Server 8 (opam dependency conflict, fixed separately). Only `lint-fmt` is in scope and is green.