### PR TITLE
Adapt Eliom to Ocsigen Server 8

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -39,7 +39,7 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   (js_of_ocaml-tyxml (>= 6.3.2))
   logs
   (tyxml (and (>= 4.6) (< 4.7)))
-  (ocsigenserver (and (>= 7.0) (< 8.0)))
+  (ocsigenserver (and (>= 8.0) (< 9.0)))
   (ipaddr (>= 2.1))
   (reactiveData (>= 0.2.1))
   base-bytes

--- a/eliom.opam
+++ b/eliom.opam
@@ -31,7 +31,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "6.3.2"}
   "logs"
   "tyxml" {>= "4.6" & < "4.7"}
-  "ocsigenserver" {>= "7.0" & < "8.0"}
+  "ocsigenserver" {>= "8.0" & < "9.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "base-bytes"

--- a/src/lib/client.client.ml
+++ b/src/lib/client.client.ml
@@ -25,7 +25,7 @@ let section = Client_core.section
 
 open Js_of_ocaml
 open Lib
-module Opt = Lib.Option
+module Opt = Option
 module Xml = Content_core.Xml
 
 (* == Callbacks for onload, onbeforeunload, and onunload *)
@@ -1893,7 +1893,7 @@ and change_page :
             (* The service has a client side implementation.
               We do not make the request *)
             (* I record the function to be used for void coservices: *)
-            Lib.Option.iter
+            Option.iter
               (fun rf -> reload_function := Some (fun () -> rf get_params))
               (Service.reload_fun service);
             let uri, l, l' =

--- a/src/lib/client/Eliom/mod_dom.ml
+++ b/src/lib/client/Eliom/mod_dom.ml
@@ -392,7 +392,7 @@ let copy_element
         in
         iter_dom_array add_attribute e##.attributes;
         let child_copies =
-          List.map_filter
+          List.filter_map
             (fun child ->
                match Dom.nodeType child with
                | Dom.Text t -> Some (copy_text t :> Dom.node Js.t)

--- a/src/lib/comet.server.ml
+++ b/src/lib/comet.server.ml
@@ -176,8 +176,8 @@ end = struct
 
   let get_channel (ch_id, position) =
     match find_channel ch_id with
-    | Some channel -> Lib.Left (channel, position)
-    | None -> Right ch_id
+    | Some channel -> Either.Left (channel, position)
+    | None -> Either.Right ch_id
 
   exception
     Finished of (channel_id * (string * int) Comet_base.channel_data) list
@@ -193,8 +193,8 @@ end = struct
     with Finished l -> l
 
   let get_available_data = function
-    | Lib.Right ch_id -> [ch_id, Comet_base.Closed]
-    | Lib.Left (channel, position) -> (
+    | Either.Right ch_id -> [ch_id, Comet_base.Closed]
+    | Either.Left (channel, position) -> (
       match position with
       (* the first request of the client should be with i = 1 *)
       (* when the client is requesting the newest data, only return
@@ -219,9 +219,9 @@ end = struct
           queue_take channel i)
 
   let has_data = function
-    | Lib.Right _ ->
+    | Either.Right _ ->
         true (* a channel was closed: need to tell it to the client *)
-    | Lib.Left (channel, position) -> (
+    | Either.Left (channel, position) -> (
       match position with
       | Comet_base.Newest i when i > channel.ch_index -> false
       | Comet_base.Newest _ -> true
@@ -233,9 +233,9 @@ end = struct
   let really_wait_data requests =
     let rec make_list = function
       | [] -> []
-      | Lib.Left (channel, _) :: q ->
+      | Either.Left (channel, _) :: q ->
           Lwt_condition.wait channel.ch_wakeup :: make_list q
-      | Lib.Right _ :: _ -> assert false
+      | Either.Right _ :: _ -> assert false
       (* closed channels are considered to have data *)
     in
     Lwt.pick (make_list requests)

--- a/src/lib/common.server.ml
+++ b/src/lib/common.server.ml
@@ -141,7 +141,7 @@ end = struct
 end
 
 (* session groups *)
-type 'a sessgrp = string * cookie_level * (string, Ipaddr.t) leftright
+type 'a sessgrp = string * cookie_level * (string, Ipaddr.t) Either.t
 
 (* The full session group is the triple
    (site_dir_string, scope, session group name).
@@ -154,7 +154,7 @@ type perssessgrp = string (* same triple, JSON-encoded *) [@@deriving json]
 
 (* Persistent representation of a session group. Stored on disk through
    {!perssessgrp}: a JSON-encoded value of this record. The triple form is
-   {!sessgrp} but always with [Left g] for persistent groups, hence the
+   {!sessgrp} but always with [Either.Left g] for persistent groups, hence the
    simpler representation here. *)
 type perssessgrp_payload =
   {p_site_dir_str : string; p_cookie_level : cookie_level; p_group : string}
@@ -175,9 +175,9 @@ let getperssessgrp a : 'a sessgrp =
   let {p_site_dir_str; p_cookie_level; p_group} =
     Deriving_Json.from_string [%json: perssessgrp_payload] a
   in
-  p_site_dir_str, p_cookie_level, Left p_group
+  p_site_dir_str, p_cookie_level, Either.Left p_group
 
-let string_of_perssessgrp = id
+let string_of_perssessgrp = Fun.id
 
 (* cookies information during page generation: *)
 
@@ -403,7 +403,7 @@ and page_table = page_table_content Serv_Table.t
 
 and page_table_content =
   [ `Ptc of
-      (page_table ref * page_table_key, na_key_serv) leftright
+      (page_table ref * page_table_key, na_key_serv) Either.t
         Ocsigen_base.Cache.Dlist.node
         option
       * (server_params, Ocsigen.Response.t) service list ]
@@ -417,7 +417,7 @@ and naservice_table_content =
   * (float * float ref) option
   (* timeout and expiration date *)
   * (server_params -> Ocsigen.Response.t Lwt.t)
-  * (page_table ref * page_table_key, na_key_serv) leftright
+  * (page_table ref * page_table_key, na_key_serv) Either.t
       Ocsigen_base.Cache.Dlist.node
       option
 (* for limitation of number of dynamic coservices *)
@@ -451,8 +451,8 @@ and tables =
     *)
     service_dlist_add :
       ?sp:server_params
-      -> (page_table ref * page_table_key, na_key_serv) leftright
-      -> (page_table ref * page_table_key, na_key_serv) leftright
+      -> (page_table ref * page_table_key, na_key_serv) Either.t
+      -> (page_table ref * page_table_key, na_key_serv) Either.t
            Ocsigen_base.Cache.Dlist.node
     (* We use a dlist for limiting the number of dynamic
             anonymous coservices in each table (and avoid DoS).  There
@@ -534,7 +534,7 @@ and sitedata =
   ; mutable omitpersistentstorage : omitpersistentstorage_rule list option }
 
 and dlist_ip_table =
-  (page_table ref * page_table_key, na_key_serv) leftright
+  (page_table ref * page_table_key, na_key_serv) Either.t
     Ocsigen_base.Cache.Dlist.t
     Net_addr_Hashtbl.t
 
@@ -553,7 +553,7 @@ let find_dlist_ip_table :
   -> int option * 'b
   -> dlist_ip_table
   -> Ipaddr.t
-  -> (page_table ref * page_table_key, na_key_serv) leftright
+  -> (page_table ref * page_table_key, na_key_serv) Either.t
        Ocsigen_base.Cache.Dlist.t
   =
   Net_addr_Hashtbl.find
@@ -811,9 +811,9 @@ let dlist_finaliser na_table_ref node =
   (* If the node disappears from the dlist,
      we remove the service from the service table *)
   match Ocsigen_base.Cache.Dlist.value node with
-  | Left (page_table_ref, page_table_key) ->
+  | Either.Left (page_table_ref, page_table_key) ->
       page_table_ref := Serv_Table.remove page_table_key !page_table_ref
-  | Right na_key_serv ->
+  | Either.Right na_key_serv ->
       na_table_ref := remove_naservice_table !na_table_ref na_key_serv
 
 let dlist_finaliser_ip sitedata ip na_table_ref node =

--- a/src/lib/common.server.mli
+++ b/src/lib/common.server.mli
@@ -295,7 +295,7 @@ type sess_info =
 module SessionCookies : Hashtbl.S with type key = string
 
 (* session groups *)
-type 'a sessgrp = string * cookie_level * (string, Ipaddr.t) leftright
+type 'a sessgrp = string * cookie_level * (string, Ipaddr.t) Either.t
 
 (* The full session group is the triple
        (site_dir_string, scope, session group name).
@@ -456,7 +456,7 @@ and page_table = page_table_content Serv_Table.t
 
 and page_table_content =
   [ `Ptc of
-      (page_table ref * page_table_key, na_key_serv) leftright
+      (page_table ref * page_table_key, na_key_serv) Either.t
         Ocsigen_base.Cache.Dlist.node
         option
       * (server_params, Ocsigen.Response.t) service list ]
@@ -470,7 +470,7 @@ and naservice_table_content =
   * (float * float ref) option
   (* timeout and expiration date *)
   * (server_params -> Ocsigen.Response.t Lwt.t)
-  * (page_table ref * page_table_key, na_key_serv) leftright
+  * (page_table ref * page_table_key, na_key_serv) Either.t
       Ocsigen_base.Cache.Dlist.node
       option
 (* for limitation of number of dynamic coservices *)
@@ -502,8 +502,8 @@ and tables =
     *)
     service_dlist_add :
       ?sp:server_params
-      -> (page_table ref * page_table_key, na_key_serv) leftright
-      -> (page_table ref * page_table_key, na_key_serv) leftright
+      -> (page_table ref * page_table_key, na_key_serv) Either.t
+      -> (page_table ref * page_table_key, na_key_serv) Either.t
            Ocsigen_base.Cache.Dlist.node
     (* Add in a dlist
           for limiting the number of dynamic anonymous coservices in each table
@@ -711,7 +711,7 @@ val find_dlist_ip_table :
   -> int option * 'a
   -> dlist_ip_table
   -> Ipaddr.t
-  -> (page_table ref * page_table_key, na_key_serv) leftright
+  -> (page_table ref * page_table_key, na_key_serv) Either.t
        Ocsigen_base.Cache.Dlist.t
 
 val get_cookie_info : server_params -> [< cookie_level] -> tables cookie_info

--- a/src/lib/content_functor.client.ml
+++ b/src/lib/content_functor.client.ml
@@ -67,7 +67,7 @@ struct
          log_inspect (Client_core.rebuild_node' Ns.content_ns (Kind.toelt elt));
          raise_error ~section:eliom_logs_src
            "Cannot call %s on a node which is not an element" name)
-      id
+      Fun.id
 
   let raw_appendChild ?before node elt2 =
     match before with
@@ -204,21 +204,19 @@ struct
     Js.Opt.to_option res
 
   let insertBefore ~before elt =
-    Lib.Option.iter
+    Option.iter
       (fun parent -> appendChild ~before parent elt)
       (parentNode before)
 
   let insertAfter ~after elt =
-    Lib.Option.iter
+    Option.iter
       (fun parent ->
          let before = nextSibling after in
          appendChild ?before parent elt)
       (parentNode after)
 
   let replaceSelf elt1 elt2 =
-    Lib.Option.iter
-      (fun parent -> replaceChild parent elt2 elt1)
-      (parentNode elt1)
+    Option.iter (fun parent -> replaceChild parent elt2 elt1) (parentNode elt1)
 
   module RawNamed = struct
     let appendChild ?before id1 elt2 =
@@ -500,7 +498,7 @@ module Html = struct
            (Dom_html.CoerceTo.element (get_unique_node name elt))
            Dom_html.CoerceTo.input)
         (fun () -> failwith (Printf.sprintf "Non element node (%s)" name))
-        id
+        Fun.id
 
     let get_unique_elt_select name elt : Dom_html.selectElement Js.t =
       Js.Opt.case
@@ -508,7 +506,7 @@ module Html = struct
            (Dom_html.CoerceTo.element (get_unique_node name elt))
            Dom_html.CoerceTo.select)
         (fun () -> failwith (Printf.sprintf "Non element node (%s)" name))
-        id
+        Fun.id
 
     let get_unique_elt_textarea name elt : Dom_html.textAreaElement Js.t =
       Js.Opt.case
@@ -516,7 +514,7 @@ module Html = struct
            (Dom_html.CoerceTo.element (get_unique_node name elt))
            Dom_html.CoerceTo.textarea)
         (fun () -> failwith (Printf.sprintf "Non element node (%s)" name))
-        id
+        Fun.id
 
     let get_unique_elt_img name elt : Dom_html.imageElement Js.t =
       Js.Opt.case
@@ -524,7 +522,7 @@ module Html = struct
            (Dom_html.CoerceTo.element (get_unique_node name elt))
            Dom_html.CoerceTo.img)
         (fun () -> failwith (Printf.sprintf "Non element node (%s)" name))
-        id
+        Fun.id
 
     let scrollIntoView ?(bottom = false) elt =
       let elt = get_unique_elt "Css.background" elt in

--- a/src/lib/eliom_uri.shared.ml
+++ b/src/lib/eliom_uri.shared.ml
@@ -301,7 +301,7 @@ let make_uri_components
         then uri ^ suff
         else String.concat "/" [uri; suff]
   in
-  let fragment = Lib.Option.map Lib.Url.encode fragment in
+  let fragment = Option.map Lib.Url.encode fragment in
   uri, params @ pregetparams, fragment
 
 let make_string_uri_from_components (uri, params, fragment) =

--- a/src/lib/lib.client.mli
+++ b/src/lib/lib.client.mli
@@ -26,7 +26,6 @@ include
   module type of Ocsigen_lib_base
   with type poly = Ocsigen_lib_base.poly
    and type yesnomaybe = Ocsigen_lib_base.yesnomaybe
-   and type ('a, 'b) leftright = ('a, 'b) Ocsigen_lib_base.leftright
    and type 'a Clist.t = 'a Ocsigen_lib_base.Clist.t
    and type 'a Clist.node = 'a Ocsigen_lib_base.Clist.node
 

--- a/src/lib/lib.server.mli
+++ b/src/lib/lib.server.mli
@@ -25,7 +25,6 @@ include
   module type of Ocsigen_base.Lib
   with type poly = Ocsigen_base.Lib.poly
    and type yesnomaybe = Ocsigen_base.Lib.yesnomaybe
-   and type ('a, 'b) leftright = ('a, 'b) Ocsigen_base.Lib.leftright
    and type 'a Clist.t = 'a Ocsigen_base.Lib.Clist.t
    and type 'a Clist.node = 'a Ocsigen_base.Lib.Clist.node
 

--- a/src/lib/mkreg.server.ml
+++ b/src/lib/mkreg.server.ml
@@ -284,8 +284,8 @@ let register_aux
         , Common.SAtt_csrf_safe (id, scope, secure_session) ) ->
           let tablereg, forsession =
             match table with
-            | Lib.Left globtbl -> globtbl, false
-            | Lib.Right (sp, ct, sec) ->
+            | Either.Left globtbl -> globtbl, false
+            | Either.Right (sp, ct, sec) ->
                 if secure_session <> sec || scope <> ct
                 then raise S.Wrong_session_table_for_CSRF_safe_coservice;
                 ( !(State.get_session_service_table ?secure:secure_session
@@ -311,8 +311,8 @@ let register_aux
       | `Get, Common.SAtt_csrf_safe (id, scope, secure_session), _ ->
           let tablereg, forsession =
             match table with
-            | Left globtbl -> globtbl, false
-            | Right (sp, ct, sec) ->
+            | Either.Left globtbl -> globtbl, false
+            | Either.Right (sp, ct, sec) ->
                 if secure_session <> sec || ct <> scope
                 then raise S.Wrong_session_table_for_CSRF_safe_coservice;
                 ( !(State.get_session_service_table ?secure:secure_session
@@ -337,8 +337,8 @@ let register_aux
       | _ ->
           let tablereg =
             match table with
-            | Left globtbl -> globtbl
-            | Right (sp, scope, secure_session) ->
+            | Either.Left globtbl -> globtbl
+            | Either.Right (sp, scope, secure_session) ->
                 !(State.get_session_service_table ?secure:secure_session ~scope
                     ~sp ())
           in
@@ -384,8 +384,8 @@ let register_aux
           (* CSRF safe coservice: we'll do the registration later *)
           let tablereg, forsession =
             match table with
-            | Left globtbl -> globtbl, false
-            | Right (sp, ct, sec) ->
+            | Either.Left globtbl -> globtbl, false
+            | Either.Right (sp, ct, sec) ->
                 if secure_session <> sec || ct <> scope
                 then raise S.Wrong_session_table_for_CSRF_safe_coservice;
                 ( !(State.get_session_service_table ?secure:secure_session
@@ -410,8 +410,8 @@ let register_aux
           (* CSRF safe coservice: we'll do the registration later *)
           let tablereg, forsession =
             match table with
-            | Left globtbl -> globtbl, false
-            | Right (sp, ct, sec) ->
+            | Either.Left globtbl -> globtbl, false
+            | Either.Right (sp, ct, sec) ->
                 if secure_session <> sec || ct <> scope
                 then raise S.Wrong_session_table_for_CSRF_safe_coservice;
                 ( !(State.get_session_service_table ?secure:secure_session
@@ -435,8 +435,8 @@ let register_aux
       | _ ->
           let tablereg =
             match table with
-            | Left globtbl -> globtbl
-            | Right (sp, scope, secure_session) ->
+            | Either.Left globtbl -> globtbl
+            | Either.Right (sp, scope, secure_session) ->
                 !(State.get_session_service_table ?secure:secure_session ~scope
                     ~sp ())
           in
@@ -473,7 +473,7 @@ let register
         | S.Nonattached naser ->
             Common.remove_unregistered_na sitedata (S.na_name naser));
         register_aux pages ?options ?charset ?code ?content_type ?headers
-          (Left sitedata.Common.global_services) ~service ?error_handler
+          (Either.Left sitedata.Common.global_services) ~service ?error_handler
           page_gen
       in
       match Common.global_register_allowed () with
@@ -491,13 +491,13 @@ let register
   | None, Some _ | Some `Site, Some _ ->
       register_aux pages ?options ?charset ?code ?content_type ?headers
         ?error_handler
-        (Lib.Left (State.get_global_table ()))
+        (Either.Left (State.get_global_table ()))
         ~service page_gen
   | _, None -> raise (failwith "Missing sp while registering service")
   | Some (#Common.user_scope as scope), Some sp ->
       register_aux pages ?options ?charset ?code ?content_type ?headers
         ?error_handler
-        (Right (sp, scope, secure_session))
+        (Either.Right (sp, scope, secure_session))
         ~service page_gen
 
 (* WARNING: if we create a new service without registering it,

--- a/src/lib/parameter_base.shared.ml
+++ b/src/lib/parameter_base.shared.ml
@@ -416,7 +416,7 @@ let make_params_names params =
   in
   aux false "" "" params
 
-let string_of_param_name = id
+let string_of_param_name = Fun.id
 
 (* Add a prefix to parameters *)
 let rec add_pref_params : type a c.
@@ -475,7 +475,7 @@ let empty_nl_params_set = String.Table.empty
 let add_nl_parameter (s : nl_params_set) t v =
   (fun (_, a, _) -> a) (construct_params_list_raw s (TNLParams t) v)
 
-let table_of_nl_params_set = id
+let table_of_nl_params_set = Fun.id
 let list_of_nl_params_set nlp = snd (construct_params_list nlp unit ())
 
 let string_of_nl_params_set nlp =

--- a/src/lib/registration.server.ml
+++ b/src/lib/registration.server.ml
@@ -124,7 +124,7 @@ module Html_base = struct
     Content.Html.Printer.pp ~encode ()
 
   let send ?options:_ ?charset ?code ?content_type ?headers c =
-    let status = Lib.Option.map Cohttp.Code.status_of_code code
+    let status = Option.map Cohttp.Code.status_of_code code
     and content_type = content_type_html content_type
     and body = Ocsigen.Response.Body.of_string (Format.asprintf "%a" out c) in
     result_of_content ?charset ?headers ?status ~content_type body
@@ -149,7 +149,7 @@ module Flow5_base = struct
       Lwt_list.iter_s (fun x -> write (Format.asprintf "%a" out x)) l)
 
   let send ?options:_ ?charset ?code ?content_type ?headers c =
-    let status = Lib.Option.map Cohttp.Code.status_of_code code
+    let status = Option.map Cohttp.Code.status_of_code code
     and content_type = content_type_html content_type
     and body = body c in
     result_of_content ?charset ?headers ?status ~content_type body
@@ -178,7 +178,7 @@ module String_base = struct
   let send_appl_content = Service.XNever
 
   let send ?options ?charset ?code ?content_type:_ ?headers (c, content_type) =
-    let status = Lib.Option.map Cohttp.Code.status_of_code code
+    let status = Option.map Cohttp.Code.status_of_code code
     and body = Ocsigen.Response.Body.of_string c
     and headers =
       add_cache_header options (Ocsigen_http.Header.of_option headers)
@@ -1211,7 +1211,7 @@ module App_base (App_param : Registration_sigs.APP_PARAM) = struct
         Cohttp.Header.replace h Common_base.response_url_header
           (Polytables.get ~table ~key:Mkreg.suffix_redir_uri_key)
       with Not_found -> h
-    and status = Lib.Option.map Cohttp.Code.status_of_code code
+    and status = Option.map Cohttp.Code.status_of_code code
     and content_type = content_type_html content_type in
     result_of_content ?charset ?status ~content_type ~headers body
 end

--- a/src/lib/route.client.ml
+++ b/src/lib/route.client.ml
@@ -36,7 +36,7 @@ module A = struct
     [`Ptc of unit option * (params, result) Common.service list]
 
   type service =
-    (table ref * Common.page_table_key, Common.na_key_serv) Lib.leftright
+    (table ref * Common.page_table_key, Common.na_key_serv) Either.t
 
   and node = service list
   and table = table_content Raw_table.t

--- a/src/lib/route.server.ml
+++ b/src/lib/route.server.ml
@@ -38,7 +38,7 @@ include Route_base.Make (struct
       type t =
         ( Common.page_table ref * Common.page_table_key
           , Common.na_key_serv )
-          leftright
+          Either.t
           Ocsigen_base.Cache.Dlist.node
 
       let up = Ocsigen_base.Cache.Dlist.up
@@ -229,7 +229,7 @@ let add_naservice tables name (max_use, expdate, naservice) =
   let node =
     match name with
     | Common.SNa_get' _ | Common.SNa_post' _ ->
-        Some (tables.Common.service_dlist_add ?sp (Right name))
+        Some (tables.Common.service_dlist_add ?sp (Either.Right name))
     | _ -> None
   in
   tables.Common.table_naservices :=

--- a/src/lib/route_base.shared.ml
+++ b/src/lib/route_base.shared.ml
@@ -77,7 +77,7 @@ module type PARAM = sig
     val dlist_add :
        ?sp:Common.server_params
       -> t
-      -> (Table.t ref * Common.page_table_key, Common.na_key_serv) Lib.leftright
+      -> (Table.t ref * Common.page_table_key, Common.na_key_serv) Either.t
       -> Node.t
 
     val get : t -> (int * int * Table.t Common.dircontent ref) list
@@ -219,7 +219,7 @@ module Make (P : PARAM) = struct
         | Some node -> P.Node.up node);
         tref := P.Table.add key (nodeopt, [service]) newt
       with Not_found ->
-        let node = P.Container.dlist_add ?sp tables (Left (tref, key)) in
+        let node = P.Container.dlist_add ?sp tables (Either.Left (tref, key)) in
         tref := P.Table.add key (Some node, [service]) !tref)
     | {Common.key_state = Common.SAtt_no, Common.SAtt_no; _} -> (
       try

--- a/src/lib/server/Eliom/mod_gc.ml
+++ b/src/lib/server/Eliom/mod_gc.ml
@@ -204,13 +204,13 @@ let service_session_gc sitedata =
                     else return_unit)
                    >>= fun () ->
                    (match !session_group with
-                   | _, _scope, Right _
+                   | _, _scope, Either.Right _
                    (* no group *)
                    (*VVV check this *)
                      when Mod_sessiongroups.Serv.group_size
                             ( Common.get_site_dir_string sitedata
                             , `Client_process
-                            , Left k )
+                            , Either.Left k )
                           = 0
                           (* no tab sessions *)
                           && Common.service_tables_are_empty tables ->
@@ -254,12 +254,12 @@ let data_session_gc sitedata =
                    return_unit
                | _ -> (
                  match !session_group with
-                 | _, scope, Right _
+                 | _, scope, Either.Right _
                  (* no group *)
                    when Mod_sessiongroups.Data.group_size
                           ( Common.get_site_dir_string sitedata
                           , `Client_process
-                          , Left k )
+                          , Either.Left k )
                         = 0
                         (* no tab sessions *)
                         && not_bound_in_data_tables k ->

--- a/src/lib/server/Eliom/mod_main.ml
+++ b/src/lib/server/Eliom/mod_main.ml
@@ -163,7 +163,7 @@ let create_sitedata_aux site_dir config_info =
        Mod_sessiongroups.Data.remove_group fullbrowsersessgrp;
        (* Then we remove data from group tables: *)
        match Tuple3.thd fullbrowsersessgrp with
-       | Left key ->
+       | Either.Left key ->
            (* iterate on all session data tables: *)
            sitedata.Common.remove_session_data key
        | _ ->
@@ -270,7 +270,7 @@ let parse_eliom_option
           Common_base.Default_comet_hier
       | s -> Common_base.User_hier s
     in
-    a, Lib.Option.map parse_scope_hierarchy sn, ct
+    a, Option.map parse_scope_hierarchy sn, ct
   in
   let convert_attr tag f v =
     try f v

--- a/src/lib/server/Eliom/mod_parameters.ml
+++ b/src/lib/server/Eliom/mod_parameters.ml
@@ -20,14 +20,14 @@
 type param = string
 type field = string
 
-let insert_string x : field = Ocsigen_base.Lib.id x
+let insert_string x : field = Fun.id x
 
 (* insert_file is implemented only on client side *)
 let insert_file _ : field =
   failwith "Constructing an URL with file parameters not possible"
 
-let to_string : field -> string = fun x -> Ocsigen_base.Lib.id x
-let inject_param_list = Ocsigen_base.Lib.id
-let get_param_list = Ocsigen_base.Lib.id
-let inject_param_table = Ocsigen_base.Lib.id
+let to_string : field -> string = fun x -> Fun.id x
+let inject_param_list = Fun.id
+let get_param_list = Fun.id
+let inject_param_table = Fun.id
 let string_of_param s = s

--- a/src/lib/server/Eliom/mod_sessiongroups.ml
+++ b/src/lib/server/Eliom/mod_sessiongroups.ml
@@ -21,7 +21,7 @@
 open Lib
 
 let make_full_named_group_name_ ~cookie_level sitedata g =
-  Common.get_site_dir_string sitedata, cookie_level, Left g
+  Common.get_site_dir_string sitedata, cookie_level, Either.Left g
 
 let make_full_group_name ~cookie_level ri site_dir_string ipv4mask ipv6mask
   = function
@@ -29,8 +29,9 @@ let make_full_group_name ~cookie_level ri site_dir_string ipv4mask ipv6mask
   | None ->
       ( site_dir_string
       , cookie_level
-      , Right (Common.network_of_request ri ~mask4:ipv4mask ~mask6:ipv6mask) )
-  | Some g -> site_dir_string, cookie_level, Left g
+      , Either.Right
+          (Common.network_of_request ri ~mask4:ipv4mask ~mask6:ipv6mask) )
+  | Some g -> site_dir_string, cookie_level, Either.Left g
 
 let make_persistent_full_group_name = Common.make_persistent_full_group_name
 let getsessgrp a = a
@@ -152,9 +153,10 @@ module Make (A : sig
       (* We create a group *)
       let size =
         match set_max, sess_grp with
-        | None, (_, `Session, Left _) -> A.max_session_per_group sitedata
-        | None, (_, `Client_process, Left _) -> A.max_tab_per_session sitedata
-        | None, (_, `Session, Right _) -> A.max_session_per_ip sitedata
+        | None, (_, `Session, Either.Left _) -> A.max_session_per_group sitedata
+        | None, (_, `Client_process, Either.Left _) ->
+            A.max_tab_per_session sitedata
+        | None, (_, `Session, Either.Right _) -> A.max_session_per_ip sitedata
         | None, _ -> assert false
         | Some v, _ -> v
       in
@@ -300,13 +302,13 @@ Besides, volatile sessions are (hopefully) going to disappear soon.
       *)
       (*VVV remove is not polymorphic enough -> remove1 remove2 *)
       match (sess_grp : GroupTable.key) with
-      | _, `Client_process, Left sess_id -> (
+      | _, `Client_process, Either.Left sess_id -> (
         try
           let {Common.Data_cookie.session_group; session_group_node; _} =
             Common.SessionCookies.find sitedata.Common.session_data sess_id
           in
           match !session_group with
-          | _, `Session, Right _
+          | _, `Session, Either.Right _
           (* no group *)
             when sitedata.Common.not_bound_in_data_tables sess_id ->
               remove1 session_group_node
@@ -373,7 +375,7 @@ Besides, volatile sessions are (hopefully) going to disappear soon.
       *)
       (*VVV remove is not polymorphic enough -> remove1 remove2 *)
       match (sess_grp : GroupTable.key) with
-      | _, `Client_process, Left sess_id -> (
+      | _, `Client_process, Either.Left sess_id -> (
         try
           let { Common.Service_cookie.session_table = tables
               ; session_group_node
@@ -501,12 +503,12 @@ module Pers = struct
            | None -> Lwt.return_unit
            | Some sg -> (
              match Common.getperssessgrp sg with
-             | _, _, Right _ ->
+             | _, _, Either.Right _ ->
                  (* No group has been set. No group table.
                  Data associated to default (automatic) groups
                  is removed when closing associated sessions. *)
                  Lwt.return_unit
-             | _, _, Left group_name -> (
+             | _, _, Either.Left group_name -> (
                  Common.Persistent_tables.remove_key_from_all_tables group_name
                  >>= fun () ->
                  (* If it is associated to a session,

--- a/src/lib/server/Eliom/mod_sessiongroups.mli
+++ b/src/lib/server/Eliom/mod_sessiongroups.mli
@@ -18,8 +18,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-open Lib
-
 val make_full_named_group_name_ :
    cookie_level:Common.cookie_level
   -> Common.sitedata
@@ -43,11 +41,11 @@ val make_persistent_full_group_name :
 
 val getsessgrp :
    Common.scope Common.sessgrp
-  -> string * Common.cookie_level * (string, Ipaddr.t) leftright
+  -> string * Common.cookie_level * (string, Ipaddr.t) Either.t
 
 val getperssessgrp :
    Common.perssessgrp
-  -> string * Common.cookie_level * (string, Ipaddr.t) leftright
+  -> string * Common.cookie_level * (string, Ipaddr.t) Either.t
 
 module type MEMTAB = sig
   type group_of_group_data

--- a/src/lib/service.client.ml
+++ b/src/lib/service.client.ml
@@ -35,7 +35,7 @@ let client_fun service =
 let has_client_fun service = client_fun service <> None
 
 let set_client_fun ?app ~service f =
-  Lib.Option.iter
+  Option.iter
     (fun name -> service.send_appl_content <- XSame_appl (name, None))
     app;
   match service.client_fun with

--- a/src/lib/state.server.ml
+++ b/src/lib/state.server.ml
@@ -304,13 +304,13 @@ let rec close_service_state_if_empty ~scope ?secure () =
     match scope with
     | `Session _ ->
         (*VVV ???        (match !(c.Common.sc_session_group) with
-          | (_, _, Right _) (* no group *)
+          | (_, _, Either.Right _) (* no group *)
               when *)
         if
           Mod_sessiongroups.Data.group_size
             ( Common.get_site_dir_string sitedata
             , `Client_process
-            , Left Common.(Hashed_cookies.to_string c.sc_hvalue) )
+            , Either.Left Common.(Hashed_cookies.to_string c.sc_hvalue) )
           = 0
           (* no tab sessions *)
           && Common.service_tables_are_empty !(c.Common.sc_table)
@@ -340,12 +340,12 @@ let rec close_volatile_state_if_empty ~scope ?secure () =
     match scope with
     | `Session _ -> (
       match !(c.Common.dc_session_group) with
-      | _, _, Right _
+      | _, _, Either.Right _
       (* no group *)
         when Mod_sessiongroups.Data.group_size
                ( Common.get_site_dir_string sitedata
                , `Client_process
-               , Left Common.(Hashed_cookies.to_string c.dc_hvalue) )
+               , Either.Left Common.(Hashed_cookies.to_string c.dc_hvalue) )
              = 0
              (* no tab sessions *)
              && sitedata.Common.not_bound_in_data_tables
@@ -431,8 +431,8 @@ let get_service_session_group ?(scope = Common.default_session_scope) ?secure ()
         ~secure_o:secure ()
     in
     match !(c.Common.sc_session_group) with
-    | _, _, Right _ -> None
-    | _, _, Left v -> Some v
+    | _, _, Either.Right _ -> None
+    | _, _, Either.Left v -> Some v
   with Not_found | Common.Eliom_Session_expired -> None
 
 let get_service_session_group_size
@@ -447,8 +447,8 @@ let get_service_session_group_size
         ~secure_o:secure ()
     in
     match !(c.Common.sc_session_group) with
-    | _, _, Right _ -> None
-    | _, _, Left _ ->
+    | _, _, Either.Right _ -> None
+    | _, _, Either.Left _ ->
         Some (Mod_sessiongroups.Serv.group_size !(c.Common.sc_session_group))
   with Not_found | Common.Eliom_Session_expired -> None
 
@@ -512,8 +512,8 @@ let get_volatile_data_session_group
         ~secure_o:secure ()
     in
     match !(c.Common.dc_session_group) with
-    | _, _, Right _ -> None
-    | _, _, Left v -> Some v
+    | _, _, Either.Right _ -> None
+    | _, _, Either.Left v -> Some v
   with Not_found | Common.Eliom_Session_expired -> None
 
 let get_volatile_data_session_group_size
@@ -528,8 +528,8 @@ let get_volatile_data_session_group_size
         ~secure_o:secure ()
     in
     match !(c.Common.dc_session_group) with
-    | _, _, Right _ -> None
-    | _, _, Left _ ->
+    | _, _, Either.Right _ -> None
+    | _, _, Either.Left _ ->
         Some (Mod_sessiongroups.Data.group_size !(c.Common.dc_session_group))
   with Not_found | Common.Eliom_Session_expired -> None
 
@@ -613,7 +613,7 @@ let get_persistent_data_session_group
          | None -> None
          | Some v -> (
            match Mod_sessiongroups.getperssessgrp v with
-           | _, _, Left s -> Some s
+           | _, _, Either.Left s -> Some s
            | _ -> None)))
     (function
       | Not_found | Common.Eliom_Session_expired -> Lwt.return_none
@@ -1238,7 +1238,7 @@ module Ext = struct
         ()
     =
     let make_sessgrp n =
-      Common.get_site_dir_string sitedata, `Session, Left n
+      Common.get_site_dir_string sitedata, `Session, Either.Left n
     in
     match state with
     | `Session_group _, `Data, group_name ->
@@ -1322,7 +1322,9 @@ module Ext = struct
       try
         let dl =
           Mod_sessiongroups.Data.find
-            (Common.get_site_dir_string sitedata, sub_states_level, Left id)
+            ( Common.get_site_dir_string sitedata
+            , sub_states_level
+            , Either.Left id )
         in
         fold f e dl
       with Not_found -> return e)
@@ -1330,7 +1332,9 @@ module Ext = struct
       try
         let dl =
           Mod_sessiongroups.Serv.find
-            (Common.get_site_dir_string sitedata, sub_states_level, Left id)
+            ( Common.get_site_dir_string sitedata
+            , sub_states_level
+            , Either.Left id )
         in
         fold f e dl
       with Not_found -> return e)
@@ -1344,8 +1348,7 @@ module Ext = struct
     =
     let state' = (state :> ('aa, 'bb) state) in
     let a = fold_sub_states_aux_aux ?sitedata ~state:state' f in
-    fold_sub_states_aux Ocsigen_base.Cache.Dlist.fold Ocsigen_base.Lib.id a e
-      state
+    fold_sub_states_aux Ocsigen_base.Cache.Dlist.fold Fun.id a e state
 
   (** Fold over the snapshot of a Dlist. *)
   let dlist_lwt_fold f acc dlist =
@@ -1494,7 +1497,7 @@ module Ext = struct
     let sitedata = Request_info.find_sitedata "get_session_group_list" in
     let dl = sitedata.Common.group_of_groups in
     Ocsigen_base.Cache.Dlist.fold
-      (fun l -> function _, `Session, Left s -> s :: l | _ -> l)
+      (fun l -> function _, `Session, Either.Left s -> s :: l | _ -> l)
       [] dl
 
   (** Iterator on service cookies *)

--- a/src/lib/unwrap.client.ml
+++ b/src/lib/unwrap.client.ml
@@ -57,7 +57,7 @@ let register_unwrapper' id f =
   if Js.Optdef.test (Js.array_get unwrap_table id)
   then
     failwith (Printf.sprintf ">> the unwrapper id %i is already registered" id);
-  let f x = Ocsigen_lib_base.Option.map Obj.repr (f (Obj.obj x)) in
+  let f x = Option.map Obj.repr (f (Obj.obj x)) in
   (* Store unwrapper *)
   Js.array_set unwrap_table id f
 


### PR DESCRIPTION
Makes `deriving` build against `ocsigenserver.8.0.0~dev`.

(Supersedes #890, which was accidentally merged into the intermediate `reformat-ocamlformat-0.29` branch instead of `deriving` — its changes never reached `deriving`. This PR targets `deriving` directly. The ocamlformat 0.29 bump from #889 is already in `deriving`.)

## Context
Ocsigen Server 8 removed the deprecated baselib helpers `id`, `leftright`, `map_filter` and the `Option` module (Eliom/Toolkit/Start to adapt in their own branches).

## Changes — migrate to stdlib equivalents (no shims)

| Removed | Replacement |
|---|---|
| `Ocsigen_base.Lib.id` / bare `id` | `Fun.id` |
| `List.map_filter` | `List.filter_map` |
| `Lib.Option` / `Ocsigen_lib_base.Option` | stdlib `Option` |
| type `leftright` | `Either.t` |
| constructors `Left` / `Right` | `Either.Left` / `Either.Right` |

Plus a now-unused `open Lib` removed, and the dependency bound bumped to `ocsigenserver (>= 8.0) (< 9.0)` (regenerated `eliom.opam`).

## Testing
`dune build`, `dune build @install`, `dune build @fmt` all clean against `ocsigenserver.8.0.0~dev`.