### PR TITLE
Require js_of_ocaml 6.4

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,13 +30,13 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   ; (ppx_sexp_conv, pulled via ocsigenserver -> cohttp) allows; newer OCaml
   ; resolves a more recent ppxlib. The ppx builds against the whole range.
   (ppxlib (>= 0.35.0))
-  (js_of_ocaml-compiler (>= 6.3.2))
-  (wasm_of_ocaml-compiler (>= 6.3.2))
-  (js_of_ocaml (>= 6.3.2))
-  (js_of_ocaml-lwt (>= 6.3.2))
-  (js_of_ocaml-ppx (>= 6.3.2))
-  (js_of_ocaml-ppx_deriving_json (>= 6.3.2))
-  (js_of_ocaml-tyxml (>= 6.3.2))
+  (js_of_ocaml-compiler (>= 6.4.0))
+  (wasm_of_ocaml-compiler (>= 6.4.0))
+  (js_of_ocaml (>= 6.4.0))
+  (js_of_ocaml-lwt (>= 6.4.0))
+  (js_of_ocaml-ppx (>= 6.4.0))
+  (js_of_ocaml-ppx_deriving_json (>= 6.4.0))
+  (js_of_ocaml-tyxml (>= 6.4.0))
   logs
   (tyxml (and (>= 4.6) (< 4.7)))
   (ocsigenserver (and (>= 8.0) (< 9.0)))

--- a/eliom.opam
+++ b/eliom.opam
@@ -22,13 +22,13 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.35.0"}
-  "js_of_ocaml-compiler" {>= "6.3.2"}
-  "wasm_of_ocaml-compiler" {>= "6.3.2"}
-  "js_of_ocaml" {>= "6.3.2"}
-  "js_of_ocaml-lwt" {>= "6.3.2"}
-  "js_of_ocaml-ppx" {>= "6.3.2"}
-  "js_of_ocaml-ppx_deriving_json" {>= "6.3.2"}
-  "js_of_ocaml-tyxml" {>= "6.3.2"}
+  "js_of_ocaml-compiler" {>= "6.4.0"}
+  "wasm_of_ocaml-compiler" {>= "6.4.0"}
+  "js_of_ocaml" {>= "6.4.0"}
+  "js_of_ocaml-lwt" {>= "6.4.0"}
+  "js_of_ocaml-ppx" {>= "6.4.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "6.4.0"}
+  "js_of_ocaml-tyxml" {>= "6.4.0"}
   "logs"
   "tyxml" {>= "4.6" & < "4.7"}
   "ocsigenserver" {>= "8.0" & < "9.0"}


### PR DESCRIPTION
Eliom now targets the js_of_ocaml 6.4 API (js 6.4 compatibility was merged from master). Bump the js_of_ocaml / wasm_of_ocaml lower bounds from 6.3.2 to 6.4.0.