### PR TITLE
ci(doc): cache the opam switch to skip recompiling the dependency tree

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -56,20 +56,43 @@ jobs:
         with:
           token: ${{ github.token }}
 
-      - name: Install dependencies
+      # The bottleneck of this job is compiling the dependency tree (~6 min): lwt,
+      # js_of_ocaml, wasm_of_ocaml, react, tyxml, ocsigenserver... plus wodoc/odoc
+      # from source. setup-ocaml only caches the base switch (the compiler), so
+      # they recompiled on every push. Cache the whole _opam switch keyed on
+      # eliom.opam (the dep set) and wodoc's HEAD commit. On a cache hit the deps
+      # and wodoc are restored and only eliom itself is (re)built below; the key
+      # changes — and the deps/wodoc rebuild once — only when eliom.opam or wodoc
+      # move.
+      - name: Resolve wodoc HEAD commit
+        id: wodoc
+        run: echo "sha=$(git ls-remote https://github.com/ocsigen/wodoc.git HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the opam switch (deps + wodoc)
+        id: switch-cache
+        uses: actions/cache@v4
+        with:
+          path: _opam
+          key: opam-switch-${{ runner.os }}-ocaml5.4.0-${{ hashFiles('eliom.opam') }}-wodoc-${{ steps.wodoc.outputs.sha }}
+
+      - name: Install dependencies and wodoc
+        # Cache miss only: build the dependency tree and wodoc once, then re-cache.
+        if: steps.switch-cache.outputs.cache-hit != 'true'
         run: |
-          # Install eliom (from the ref being built) so odoc_driver documents
-          # these sources. eliom is installed WITHOUT --with-doc: its server and
-          # client libraries share module names, so building eliom's own @doc
-          # collides ("Multiple rules for .../eliom/Eliom_bus/index.html"). wodoc
-          # builds the docs via `odoc_driver --remap` instead.
           opam install . --deps-only --with-doc
-          opam install .
           # wodoc themes the pages. Its opam pin-depends pulls odoc / odoc-driver
           # from the balat/odoc fork (the cross-library link fix, not yet upstream),
           # so we do NOT pin odoc ourselves here.
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
           opam install wodoc
+
+      - name: Install eliom
+        # Always: eliom's own sources change on every push, so odoc_driver must
+        # document the freshly-built package. eliom is installed WITHOUT --with-doc:
+        # its server and client libraries share module names, so building eliom's
+        # own @doc collides ("Multiple rules for .../eliom/Eliom_bus/index.html").
+        # wodoc builds the docs via `odoc_driver --remap` instead.
+        run: opam install .
 
       - name: Build documentation (dev)
         # wodoc build runs `odoc_driver eliom --remap` on the installed package


### PR DESCRIPTION
## Problem

The `Documentation` workflow takes ~8 min per push (sometimes 15+), of which **~6 min is `Install dependencies`** — recompiling the whole dependency tree (lwt, js_of_ocaml, wasm_of_ocaml, react, tyxml, ocsigenserver…) plus wodoc and odoc from source every time. `setup-ocaml@v3` only caches the base switch (the compiler), so none of that was cached.

Recent run breakdown:

| Step | Duration |
|---|---|
| Set up OCaml + Binaryen | ~25 s |
| **Install dependencies** | **5 min 58 s** |
| Build documentation (dev) | 1 min 22 s |

## Fix

Cache the whole `_opam` switch with `actions/cache`, keyed on `eliom.opam` (the dependency set) and wodoc's resolved HEAD commit. The install is split:

- **Install dependencies and wodoc** — runs only on a cache miss (deps tree + wodoc).
- **Install eliom** — runs **always**: eliom's own sources change every push, so `opam install .` re-syncs the local pin and rebuilds the package for odoc_driver to document. Only eliom recompiles on the hot path, not its dependencies.

The cache rebuilds once when `eliom.opam` or wodoc's HEAD move, then is reused.

This mirrors the pilot done on ocsigen.github.io (4 min → ~1 min). The first run on this branch is a cache miss (populates the cache); the speed-up shows on the next run.

> Note: this is the doc-CI pilot for the API-project pattern. Once confirmed, the same change rolls out to ocsigenserver, toolkit, start, tyxml, i18n, ocsipersist, lwt, reactiveData (and tuto / wodoc with their own variants).