### PR TITLE
doc: fix the two dead references of clientserver-html

### DIFF
--- a/doc/clientserver-html.mld
+++ b/doc/clientserver-html.mld
@@ -181,7 +181,7 @@ the function {!val
 Eliom_content.Html.Id.create_named_elt}, that takes as parameters an
 element identifier and a non named element.  Element identifiers are
 created with the function {!val
-Eliom_content.Html.Id.new_elt_id}. See also section {{!page-"clientserver-applications".global}Global elements of an
+Eliom_content.Html.Id.new_elt_id}. See also section {{!section:global}Global elements of an
 application}.
 
 The module {!Eliom_content.Html.Manip}

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -60,6 +60,6 @@
   (ocsigen-start   ocsigen-start   true  Os)
   (ocsigenserver   ocsigenserver   false Ocsigen)
   (js_of_ocaml     js_of_ocaml     subdir)
-  (tyxml           tyxml           subdir)
+  (tyxml           tyxml           subdir Tyxml)
   (lwt             lwt             subdir)
   (reactiveData    reactiveData    root))


### PR DESCRIPTION
Two dead references on https://ocsigen.org/eliom/dev/clientserver-html.html,
found while verifying ocsigen/wodoc#14 against the live docs.

**`{!Tyxml.Html}`** (line 21) renders as plain text: `js_of_ocaml` and `tyxml` are
listed in the hosted table with no wrapper module, but tyxml *has* one — it
exposes its modules through `Tyxml` and deploys them **flat**, so `Tyxml.Html`
lives at `tyxml/<v>/tyxml/Tyxml_html/index.html`. Declaring the wrapper makes the
reference resolve there (200); left blank it is built as `.../tyxml/Tyxml/Html/`,
a 404 — so this matters *before* the next doc rebuild, wodoc#14 having taught the
resolver to link wrapper-less projects through their own root module.

`js_of_ocaml`, `lwt` and `reactiveData` are correctly blank: they keep odoc's
nested layout (`lwt/latest/lwt/Lwt/index.html`, checked).

**`{{!page-"clientserver-applications".global}Global elements of an application}`**
(line 184) points at a section of another page that has no such anchor — the
section `{2:global Global elements of an application}` is in *this* page, further
down at line 374. Turned into a local `{{!section:global}…}` reference.

Verified with `wodoc resolve-refs` using the amended table: `Tyxml.Html` →
`tyxml/latest/tyxml/Tyxml_html/index.html`, 200. The anchor form was checked
against odoc directly (`{{!section:global}…}` → `<a href="#global">`).

`ocsigen.org/eliom/dev/` will pick both up at the next push to master (its doc CI
rebuilds `dev`); `latest` needs the usual re-freeze.
