### PR TITLE
doc: write the reference kinds odoc's way, with a colon

### DIFF
--- a/doc/clientserver-communication.mld
+++ b/doc/clientserver-communication.mld
@@ -47,8 +47,8 @@ Exceptions raised in the server-side function cannot be handled
 directly on the client; it is impossible to marshal them in OCaml to
 send them to the client. Instead, if an exception is raised in the
 server function, the function application fails (in Lwt) on the client
-with the exception {!exception
-Eliom_client_value.Exception_on_server} whose argument describes the original
+with the exception {!exception:Eliom_client_value.Exception_on_server}
+whose argument describes the original
 exception (according to [Printexc.to_string]).
 
 

--- a/doc/clientserver-html.mld
+++ b/doc/clientserver-html.mld
@@ -177,11 +177,11 @@ HTTP request: hence, sending an element built with
 two different pages will produce two distinct nodes. If you want to
 define a element reference that is preserved accross the different
 page of an application, you must explicitely name this element with
-the function {!val
-Eliom_content.Html.Id.create_named_elt}, that takes as parameters an
+the function {!val:Eliom_content.Html.Id.create_named_elt}
+, that takes as parameters an
 element identifier and a non named element.  Element identifiers are
-created with the function {!val
-Eliom_content.Html.Id.new_elt_id}. See also section {{!section:global}Global elements of an
+created with the function {!val:Eliom_content.Html.Id.new_elt_id}
+. See also section {{!section:global}Global elements of an
 application}.
 
 The module {!Eliom_content.Html.Manip}
@@ -381,8 +381,8 @@ your site. For this purpose, Eliom provides a notion of global element. Such
 elements are instantied only once for an application and that unique
 instance is used in every page that references the element.
 
-To create a global element, use function {{!val
-Eliom_content.Html.Id.create_global_elt}Eliom_content.Html.Id.create_global_elt}.
+To create a global element, use function {{!val:Eliom_content.Html.Id.create_global_elt}Eliom_content.Html.Id.create_global_elt}
+.
 
 {@ocaml[
 val create_global_elt: 'a elt -> 'a elt
@@ -504,8 +504,7 @@ We do not recommend this.
 Eliom provides a type-safe interface for create new attributes of the form [data-*], using  {!Eliom_content.Html.Custom_data}.
 
 {3 Creation}
-Custom data may be created either from string-conversation functions by {!val
-Eliom_content.Html.Custom_data.create}
+Custom data may be created either from string-conversation functions by {!val:Eliom_content.Html.Custom_data.create}
 
 {%wodoc:@ class=server%}
 {@ocaml[
@@ -536,7 +535,7 @@ Custom data can be injected into HTML-trees of type {!Eliom_content.Html.elt} by
 {3 Reading/writing the DOM}
 
 On the client side, custom data can be read from and written to JavaScript DOM
-elements of type {!type Js_of_ocaml.Dom_html.element}.
+elements of type {!type:Js_of_ocaml.Dom_html.element}.
 
 Custom data can be read from a DOM-element with the function
 {!Eliom_content.Html.Custom_data.get_dom}.
@@ -558,8 +557,8 @@ The custom data of a DOM-element can be set with the function
 
 {3 Default value}
 If a custom data is created with the optional argument [default], calls to
-{!val
-Eliom_content.Html.Custom_data.get_dom} return that instead of throwing an
+{!val:Eliom_content.Html.Custom_data.get_dom}
+return that instead of throwing an
 exception [Not_found].
 
 {@ocaml[

--- a/doc/clientserver-react.mld
+++ b/doc/clientserver-react.mld
@@ -50,8 +50,8 @@ let s_as_string () : string Eliom_shared.React.S.t =
   Eliom_shared.React.S.map [%shared msg_of_int] s
 ]}
 
-{!module
-Eliom_shared.React.S} implements an interface very similar to plain
+{!module:Eliom_shared.React.S}
+implements an interface very similar to plain
 [React.S]. In the example, we create a signal [s] via
 [create], which also gives us the function [f] for updating
 it. [f] can {e only} be called on the client side; calling it on

--- a/doc/eliom-language.mld
+++ b/doc/eliom-language.mld
@@ -135,8 +135,8 @@ resulting value in that specific client process.
 
 Note well that the value of an injection is {e not updated} when the
 injected value on the server changes. However, you may inject reactive
-signals (cf. {!val
-Eliom_react.S.Down.of_react}) to achieve the behavior of a client
+signals (cf. {!val:Eliom_react.S.Down.of_react}
+) to achieve the behavior of a client
 side values which updates alongside with a server correspondent.
 
 {2:sharedinjection In a shared section}
@@ -183,11 +183,11 @@ on the client side.
 The hole client value then has type [typ Eliom_client_value.t].
 
 A value of type [typ Eliom_client_value.t] is {e abstract on the
-server} (cf. {!type
-Eliom_client_value.t} (server)).  But once it is sent to the client
+server} (cf. {!type:Eliom_client_value.t}
+(server)).  But once it is sent to the client
 it becomes the value to which the expression [exp] evaluated on the
-client side (cf. {!type
-Eliom_client_value.t} (client)).
+client side (cf. {!type:Eliom_client_value.t}
+(client)).
 
 A client value expression is an arbitrary OCaml expression, but may
 additionaly contain {e injections of server variables},
@@ -256,8 +256,8 @@ are termed {e request client values}. The expressions of request
 client values are evaluated after receiving the corresponding request
 on the client in the order of their occurrence on the server. In
 requests which change the content of the page withing the application
-(originating from a service of the {!module
-Eliom_registration.App}), the expressions are evaluated {e after the
+(originating from a service of the {!module:Eliom_registration.App}
+), the expressions are evaluated {e after the
 content has changed}. That way they may refer to the new DOM.
 
 If a client value is created outside of the initialization of the

--- a/doc/server-outputs.mld
+++ b/doc/server-outputs.mld
@@ -281,8 +281,8 @@ content are:
 - Unknown content: content generated as text.
 
 Yet sometimes you may want to mix the kinds of contents a service can
-return. The function {!val
-Eliom_registration.appl_self_redirect} allows one to cast browser
+return. The function {!val:Eliom_registration.appl_self_redirect}
+allows one to cast browser
 content to application content. When an application requests some
 content cast through that function, the server sends some information
 asking the client to exit to a specific address. You should not use
@@ -311,8 +311,8 @@ let file_or_application =
            (body [p [txt "the file does not exist"]])))
 ]}
 
-Unknown content can be cast to browser content using {!val
-Eliom_registration.cast_unknown_content_kind}.
+Unknown content can be cast to browser content using {!val:Eliom_registration.cast_unknown_content_kind}
+.
 
 {2:creating Creating your own output modules}
 
@@ -504,11 +504,10 @@ You can catch exceptions raised during page generation in two places:
 
 - add an exception handler to services using the [?error_handler]
   parameter of the registration functions.
-- add a global exception handler using {!val
-  Eliom_registration.set_exn_handler}
+- add a global exception handler using {!val:Eliom_registration.set_exn_handler}
 
-You can use it to catch exception {!exception
-Eliom_common.Eliom_404} and generate a custom 404 page.
+You can use it to catch exception {!exception:Eliom_common.Eliom_404}
+and generate a custom 404 page.
 
 {@ocaml[
 let () =
@@ -536,11 +535,10 @@ let () =
 {3 Fallback services}
 
 You can check whether a service was directly called or if it was used
-as a fallback using the {!val
-Eliom_request_info.get_link_too_old} function. In case of services
+as a fallback using the {!val:Eliom_request_info.get_link_too_old}
+function. In case of services
 registered with a restricted scope, you can find out which state was
-closed using {!val
-Eliom_request_info.get_expired_service_sessions}
+closed using {!val:Eliom_request_info.get_expired_service_sessions}
 
 {3 Error in service handlers of actions}
 

--- a/doc/server-services.mld
+++ b/doc/server-services.mld
@@ -18,20 +18,20 @@ A service is composed of:
 - a service handler that will generate the answer.
 
 Services are most commonly used to create links and forms towards a
-service, using for example the function {!val
-Eliom_content.Html.D.a}. See chapter {{!page-"server-links"}Creating links and forms} for more
+service, using for example the function {!val:Eliom_content.Html.D.a}
+. See chapter {{!page-"server-links"}Creating links and forms} for more
 information.
 
 Manipulation of Eliom services can be done through the values of type
-[type Eliom_service.t] (see {!type
-Eliom_service_sigs.S.t}).  The service creation can be split in two
+[type Eliom_service.t] (see {!type:Eliom_service_sigs.S.t}
+).  The service creation can be split in two
 steps:
 
 - create a value of type [Eliom_service.t],
   most commonly by using the function
   {!Eliom_service.create}; and
-- register a service handler, e.g., using {!val
-  Eliom_registration.Html.register}. The handler receives the server
+- register a service handler, e.g., using {!val:Eliom_registration.Html.register}
+  . The handler receives the server
   parameters (GET and POST) and is responsible for producing the
   content sent to the client.
 
@@ -482,8 +482,8 @@ order):
   the time, but you may also get unexpected results (if the thread is
   executed while another site is loaded).  If you use threads in the
   initialization phase of your module (for example if you need
-  information from a database), use {!val
-  Lwt_unix.run} to wait for the end of the thread.
+  information from a database), use {!val:Lwt_unix.run}
+  to wait for the end of the thread.
 - Some services can be registered multiple times, with different
   options. This allows for example choosing between different handlers
   when the request is done in a particular session or protocol (HTTP

--- a/doc/server-state.mld
+++ b/doc/server-state.mld
@@ -160,13 +160,13 @@ with respect to how Eliom associates clients and data.
   {!Eliom_common.default_session_scope} are only
   visible to the client belonging to a same session
   (all tabs of a single browser).
-- Data and dynamic services created with scope {!val
-  Eliom_common.default_group_scope} are only visible to the clients
+- Data and dynamic services created with scope {!val:Eliom_common.default_group_scope}
+  are only visible to the clients
   whose sessions belong to the same session group.  See section
   {{!page-"server-state".session_groups}Session
   groups} for more information.
-- Data and dynamic services created with scope {!val
-  Eliom_common.default_process_scope} are only visible to a specific
+- Data and dynamic services created with scope {!val:Eliom_common.default_process_scope}
+  are only visible to a specific
   instance of the Eliom application (i.e., a single tab, running the
   Eliom client process).  See section {{!page-"clientserver-applications".session_groups}Eliom
   applications} for more information.
@@ -219,14 +219,14 @@ let custom_session = `Session custom_session_hierarchy
 
 Then, the value [custom_session] can replace the usual {!Eliom_common.default_session_scope} for the [~scope] parameter of
 the functions
-{!Eliom_reference.eref}, {!val
-Eliom_registration.Html.register},
+{!Eliom_reference.eref}, {!val:Eliom_registration.Html.register}
+,
 {!Eliom_state.discard},~ ...
 
 (Same for [`Client_process] or  [`Session_group] scope levels).
 
-The function {!val
-Eliom_common.create_scope_hierarchy} will prevent you from creating
+The function {!val:Eliom_common.create_scope_hierarchy}
+will prevent you from creating
 two scope hierarchies with the same name.
 
 {4 Example of use:}
@@ -298,9 +298,9 @@ timeout.
 
 {%wodoc:div%}
 
-  This default may be overriden by each site using {!val
-  Eliom_state.set_global_volatile_state_timeout} or {!val
-  Eliom_state.set_default_volatile_state_timeout}.  If you want your user
+  This default may be overriden by each site using {!val:Eliom_state.set_global_volatile_state_timeout}
+  or {!val:Eliom_state.set_default_volatile_state_timeout}
+  .  If you want your user
   to be able to set the default in the configuration file for your
   site (between [<site>] and [</site>]), you must parse the configuration (using
   {!Eliom_config.get_config} function).  You can also
@@ -317,9 +317,9 @@ By default, data and services saved in a session are available to
 requests using both HTTP and HTTPS. If you want to keep some state in
 a {e secure session} that is visible only to a client accessing with
 the HTTPS protocol, you may provide the optional parameter
-[~secure:true] when calling functions like {!val
-Eliom_reference.eref}, {!val
-Eliom_registration.Html.register}, etc.
+[~secure:true] when calling functions like {!val:Eliom_reference.eref}
+, {!val:Eliom_registration.Html.register}
+, etc.
 
 The default can be set in the configuration file:
 {[
@@ -348,8 +348,8 @@ it will work even if your server is using HTTP behind a local proxy.
 
 Session group is a kind of scope that allows sharing data or services
 between a set of sessions, typically all sessions for given user. For
-example, using persistent Eliom references with scope {!val
-Eliom_common.default_group_scope} is a convenient way to store data about
+example, using persistent Eliom references with scope {!val:Eliom_common.default_group_scope}
+is a convenient way to store data about
 a user without having to explicitly use an external database.
 (Persistent session group states are not discarded when all the sessions are
 closed).
@@ -436,11 +436,11 @@ Eliom references are used for example:
 Non persistent global Eliom references are equivalent to regular OCaml
 references.
 
-Eliom references are either created using the function {!val
-Eliom_reference.eref}, that works like the usual Ocaml [ref]
+Eliom references are either created using the function {!val:Eliom_reference.eref}
+, that works like the usual Ocaml [ref]
 function, but with at least one additional scope parameter.
-Or they may be created by the function {!val
-Eliom_reference.eref_from_fun}: Its argument function is evaluated the first
+Or they may be created by the function {!val:Eliom_reference.eref_from_fun}
+: Its argument function is evaluated the first
 time the reference is accessed (through {!Eliom_reference.get}),
 within one scope or after the reference has been reset.
 


### PR DESCRIPTION
odoc spells a kind-qualified reference `{!val:X}`. The manual writes `{!val X}` —
almost always wrapped, with `{!val` ending a line and the name starting the next:

```
- Data and dynamic services created with scope {!val
  Eliom_common.default_group_scope} are only visible to the clients
```

odoc does not read that as a kind. It takes the whole thing as one name, fails to
find `"val\nEliom_common.default_group_scope"`, and renders the reference as plain
text. **33 references across 7 pages, every one of them dead** on
ocsigen.org/eliom/.

Checked against odoc directly: `{!val X}` yields a span titled `valX` (the kind
glued to the name, never understood), `{!val:\nX}` fails the same way (no blank is
allowed inside a reference), and `{!val:X}` is read correctly. So the colon must be
there and the name must follow it immediately — the line break is moved to just
after the reference, which keeps the paragraphs' shape (18 lines over 90 columns in
`server-state.mld` where there were 16).

One reference stays imperfect: `{!type:Js_of_ocaml.Dom_html.element}` now reaches
the right page, but `element` is a *class type*, which odoc deploys under
`class-type-element/` — a kind wodoc does not build anchors for yet, so the anchor
is inert while the link works. Noted for wodoc rather than papered over here.

Found by the build-time diagnostics of ocsigen/wodoc#14: these are invisible to
the reader as anything but missing links, and invisible to the build as anything
at all — a reference with no label degrades to a bare `<code>`, which is why most
of these 33 were not even reported.
