### PR TITLE
doc: repair every dead page reference and tutorial URL

### DIFF
--- a/doc/clientserver-applications.mld
+++ b/doc/clientserver-applications.mld
@@ -43,7 +43,7 @@ services for one client process, or even set cookies for one tab.
 
 {2 How it works}
 
-The code of an Eliom application is written in OCaml, with {{!page-"clientserver-language"}a syntax extension} to distinguish
+The code of an Eliom application is written in OCaml, with {{!page-"eliom-language"}a syntax extension} to distinguish
 between server and client code. The files using this syntax
 usually have the extension [.eliom]. As the compling process is quite
 complex, we provide commands called [eliomc], [eliomopt] and [js_of_eliom] that

--- a/doc/clientserver-communication.mld
+++ b/doc/clientserver-communication.mld
@@ -304,7 +304,7 @@ are stateless channels: the memory consumption does not depend on
 the number of users requesting data on it. When the channels are not
 reachable from the server code, they are garbage-collected and closed.
 Named stateless channels can be accessed from
-{{!page-"clientserver-applications".cors_channels}other servers}.
+{{!section:cors_channels}other servers}.
 
 - Channels created with scope
   {!Eliom_common.default_process_scope}

--- a/doc/clientserver-html.mld
+++ b/doc/clientserver-html.mld
@@ -474,7 +474,7 @@ let%server _ =
             (body [p [reload_link]])))
 ]}
 
-{2 HTML syntax extension}
+{2:syntax HTML syntax extension}
 
 It is possible to use regular HTML syntax using Tyxml's PPX syntax extension.
 

--- a/doc/eliom-language.mld
+++ b/doc/eliom-language.mld
@@ -16,13 +16,8 @@ direct usage of server-side toplevel values in client sections, and
 the declaration and handling of client values within the code for the
 server.
 
-It is advisable to read the section about {{!page-"workflow-compilation".compilation}compiling eliom
+It is advisable to read the section about {{!page-"workflow-distillery".compilation}compiling eliom
 applications} first.
-
-For an outline of the implementation of those features, please refer
-to the chapter on {{!page-"workflow-compilation".implementation}compiling eliom applications}.
-
-
 
 {1:sections Sections (partitioning into client- and server-side)}
 

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -110,6 +110,6 @@ to function [Eliom_reference.eref].
 
 {1 Learning Eliom}
 
-More documentation {{:https://ocsigen.org/tuto/latest/manual/basics}here}.
+More documentation {{:https://ocsigen.org/tuto/latest/basics.html}here}.
 
 Write your first Web and mobile application with Eliom using {{!/ocsigen-start/page-index}Ocsigen Start}.

--- a/doc/intro.mld
+++ b/doc/intro.mld
@@ -4,8 +4,8 @@
 detailed explanation of all Eliom concepts.
 If you want to learn how to program with Ocsigen, please read
 the {{:https://ocsigen.org/tuto/}Ocsigen tutorial} first,
-and especially {{:https://ocsigen.org/tuto/basics.html}this overview of all concepts}
-or the {{:https://ocsigen.org/tuto/basics-server.html}server-side programming guide}.}
+and especially {{:https://ocsigen.org/tuto/latest/basics.html}this overview of all concepts}
+or the {{:https://ocsigen.org/tuto/latest/basics-server.html}server-side programming guide}.}
 
 Eliom is a framework for developing Web and mobile applications.
 It can be used to implement either basic server-side Web sites,

--- a/doc/overview.mld
+++ b/doc/overview.mld
@@ -127,9 +127,9 @@ to function `Eliom_reference.eref`.
 {1 Learning Eliom}
 
 To learn Eliom, read one the main documentation pages first:
-{{:https://ocsigen.org/tuto/basics.html}application development} (client-server programming)
+{{:https://ocsigen.org/tuto/latest/basics.html}application development} (client-server programming)
 or
-{{:https://ocsigen.org/tuto/basics-server.html}website development} (server-side programming).
+{{:https://ocsigen.org/tuto/latest/basics-server.html}website development} (server-side programming).
 
 Write your first Web and mobile application with Eliom using
 {{!/ocsigen-start/page-index}Ocsigen Start}

--- a/doc/overview.mld
+++ b/doc/overview.mld
@@ -136,8 +136,8 @@ Write your first Web and mobile application with Eliom using
 
 If you want to use Eliom as a traditional server-side Web framework,
 have a look at these tutorials:
-- {{:https://ocsigen.org/tuto/basicwebsite.html}A basic Web site in OCaml}
-- {{:https://ocsigen.org/tuto/how-to-register-session-data.html}Session data: Eliom references}
-- {{:https://ocsigen.org/tuto/interaction.html}Service based Web programming}
+- {{:https://ocsigen.org/tuto/latest/basics-server.html}A basic Web site in OCaml}
+- {{:https://ocsigen.org/tuto/latest/how-to-register-session-data.html}Session data: Eliom references}
+- {{:https://ocsigen.org/tuto/latest/interaction.html}Service based Web programming}
 
 The full {{!page-"intro"}reference manual}, for technical details

--- a/doc/server-outputs.mld
+++ b/doc/server-outputs.mld
@@ -54,11 +54,11 @@ using polymorphic variant types. You may use constructor functions from {!Eliom_
 {%wodoc:div class="paragraph"%} Sending caml values to client side code {%wodoc:end%}
 
 - {!Eliom_registration.Ocaml}: Registration of services sending marshalled OCaml values. See the section on
-{{!page-"clientserver-applications".communication}communications in the chapter about client-server applications}.
+{{!page-"clientserver-communication"}communications in the chapter about client-server applications}.
 
 {%wodoc:div class="paragraph"%} Runtime choice of content {%wodoc:end%}
 
-- {!Eliom_registration.Any}: Registration of services that can choose what they send, for example an HTML page or a file, depending on some situation (parameter, user logged or not, page present in a cache ...). It is also possible to create your own modules for other types of pages. See {{!page-"server-services".any}here} for an example of use.
+- {!Eliom_registration.Any}: Registration of services that can choose what they send, for example an HTML page or a file, depending on some situation (parameter, user logged or not, page present in a cache ...). It is also possible to create your own modules for other types of pages. See {{:https://ocsigen.org/tuto/latest/how-to-register-a-service-that-decides-itself-what-to-send.html}here} for an example of use.
 
 {2 Advanced output modules}
 

--- a/doc/server-state.mld
+++ b/doc/server-state.mld
@@ -168,7 +168,7 @@ with respect to how Eliom associates clients and data.
 - Data and dynamic services created with scope {!val:Eliom_common.default_process_scope}
   are only visible to a specific
   instance of the Eliom application (i.e., a single tab, running the
-  Eliom client process).  See section {{!page-"clientserver-applications".session_groups}Eliom
+  Eliom client process).  See section {{!page-"clientserver-applications"}Eliom
   applications} for more information.
 
 User scopes are organised in a {e hierarchy}: client processes belong

--- a/doc/workflow-distillery.mld
+++ b/doc/workflow-distillery.mld
@@ -39,7 +39,7 @@ This creates a project named [<name>] from the ["app.exe"]
 template in the directory [<dir>] or [<name>] by default.
 The project name should be a valid name for an OCaml compilation unit.
 
-{2 Compilation & Running:}
+{2:compilation Compilation & Running:}
 
 Read the README file provided with the template.
 

--- a/src/lib/eliom_client_value.client.mli
+++ b/src/lib/eliom_client_value.client.mli
@@ -19,7 +19,7 @@
 
 (** {2 Client and shared values}
 
-    See the {{!page-"clientserver-language"}manual}. *)
+    See the {{!page-"eliom-language"}manual}. *)
 
 type 'a t = 'a
 (** An ['a] client value on the client is just an ['a].  See also {{!Eliom_client_value.t}the abstract representation on

--- a/src/lib/eliom_client_value.server.mli
+++ b/src/lib/eliom_client_value.server.mli
@@ -19,11 +19,11 @@
 
 (** {2 Client and shared values}
 
-    See the {{!page-"clientserver-language"}manual}. *)
+    See the {{!page-"eliom-language"}manual}. *)
 
 type +'a t
 (** Client values on the server are created by the syntax [{typ{ expr
-    }}] in the server section (cf. {{!page-"clientserver-language".clientvalues}the
+    }}] in the server section (cf. {{!page-"eliom-language".clientvalues}the
     manual}).  They are abstract, but become concrete once sent to
     the client. See also {{!Eliom_client_value.t}the
     concrete representation on the client}. *)

--- a/src/lib/eliom_registration.server.mli
+++ b/src/lib/eliom_registration.server.mli
@@ -467,7 +467,7 @@ module Streamlist : Eliom_registration_sigs.S_with_create
 (** {2 Customizing registration} *)
 
 (** The [Customize] functor allows specialization of service
-    registration functions by customizing the page type. See the {{!page-"interaction"}Eliom
+    registration functions by customizing the page type. See the {{:https://ocsigen.org/tuto/latest/interaction.html}Eliom
     tutorial} for example. *)
 module Customize
     (R : Eliom_registration_sigs.S_with_create)

--- a/src/lib/eliom_registration_sigs.shared.mli
+++ b/src/lib/eliom_registration_sigs.shared.mli
@@ -113,7 +113,7 @@ module type S = sig
       request, and should return the corresponding page.
 
       The optional parameter [~scope] is {!Eliom_common.global_scope}
-      by default. See the Eliom manual for detailed description {{!page-"server-services".scope}of
+      by default. See the Eliom manual for detailed description {{!page-"server-services".service_scope}of
       different scopes}.
 
       The optional parameter [~options] is specific to each output

--- a/src/lib/eliom_syntax.server.mli
+++ b/src/lib/eliom_syntax.server.mli
@@ -34,7 +34,7 @@ val client_value :
 val set_global : bool -> unit
 (** All client values created between [set_global true] and
     [set_global false] are considered global client values
-    (cf. {{!page-"clientserver-language"}the manual}).  *)
+    (cf. {{!page-"eliom-language"}the manual}).  *)
 
 val global_context : unit -> bool
 (** Returns whether client values created in the current context


### PR DESCRIPTION
Every remaining dead reference in eliom's own documentation, found by the
build-time diagnostics of ocsigen/wodoc#14. Five commits, one per kind of repair.

### Renamed page, renamed anchor

`page-"clientserver-language"` (4 references) is now `eliom-language`, and the
scope section of `server-services` carries the label `service_scope`, not `scope`.
The second one sits in `eliom_registration_sigs.shared.mli`, so it was dead on the
**25 generated pages** that signature reaches.

### Sections that moved out of clientserver-applications

Three references point at anchors that page no longer has. The CORS channels are
in `clientserver-communication` and the session groups in `server-state` — in the
very pages holding the references, so they become local `{{!section:…}}` ones —
and the communication chapter is a page of its own. The session-groups reference
is labelled *"Eliom applications"*, so it keeps that page as its target, minus the
anchor.

### Sections nobody could reference

*HTML syntax extension* and the distillery's *Compilation & Running* carry no
label, so `{{!page-"clientserver-html".syntax}}` and the compilation reference had
nothing to resolve to. Give them the labels the references already use.

The chapter outlining the implementation of the language features is gone and
nothing replaced it, so that sentence is dropped rather than pointed somewhere it
does not belong (your call, per our exchange). Likewise the request for an example
of `Eliom_registration.Any` now links the tutorial page that actually shows one.

### Dead tutorial URLs — invisible to the checker

Seven links into the tutorial are missing its version directory
(`ocsigen.org/tuto/basics.html`, `/tuto/latest/manual/basics`, …) and answer 404.
These are plain URLs, not odoc references, so nothing reported them. One more,
`page-"interaction"`, was written as an odoc page reference, which cannot resolve
from here — the rest of the manual links the tutorial by URL, so it does the same
now. And *"A basic Web site in OCaml"* pointed at a tutorial page that no longer
exists; `basics-server` is the server-side website guide it described.

### Verification

Every `ocsigen.org` URL in `doc/` and `src/` fetches **200** (7 distinct, checked
with curl), and each anchor targeted was confirmed to exist in the deployed page
(`service_scope`, `cors_channels`, `session_groups`, `clientvalues`,
`extensions`, `basic_menu`, `hier_menu`).

Two things the checker reported that are NOT defects, for the record: references
of page from a `.mli` do resolve here (`Eliom_content` →
`../../clientserver-html.html`) since the manual and the API are one package; and
a library's index page repeats each module's synopsis without resolving its
references, which ocsigen/wodoc#20 now skips.
