### PR TITLE
ci(doc): fail the build on a dead reference or a leftover wiki image

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -102,6 +102,7 @@ jobs:
           opam exec -- wodoc build --config doc/wodoc
           --menu https://ocsigen.org/doc/menu.html
           --out "$PWD/_doc-site/dev" --label dev
+          --strict-refs
 
       - name: Deploy to gh-pages (replace only dev/, keep the rest)
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
`wodoc build` reports the markup that was meant to become a link or an image and
did not, and `--strict-refs` makes it fatal (ocsigen/wodoc#14, refined in #17, #18
and #20).

eliom was the last project where this could not be turned on. After #897 (the
tyxml wrapper and the `global` anchor), #898 (33 malformed kind references) and
#899 (every dead page reference and tutorial URL), its build reports:

```
wodoc: 1 reference into a dependency this site does not host in 1 page
```

Zero repairable defects — down from the ~350 unresolved references the first
instrumented build reported.

Added to the `dev` build only; the release job freezes what is already on
gh-pages and has nothing to check.
