### PR TITLE
Adapt to TyXML 5.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -39,7 +39,7 @@ The client-side code is compiled to JS using Ocsigen Js_of_ocaml or to Wasm usin
   (js_of_ocaml-ppx_deriving_json (>= 6.3.2))
   (js_of_ocaml-tyxml (>= 6.3.2))
   logs
-  (tyxml (and (>= 4.6) (< 4.7)))
+  (tyxml (and (>= 5.0) (< 6.0)))
   (ocsigenserver (and (>= 7.0) (< 8.0)))
   (ipaddr (>= 2.1))
   (reactiveData (>= 0.2.1))

--- a/eliom.opam
+++ b/eliom.opam
@@ -31,7 +31,7 @@ depends: [
   "js_of_ocaml-ppx_deriving_json" {>= "6.3.2"}
   "js_of_ocaml-tyxml" {>= "6.3.2"}
   "logs"
-  "tyxml" {>= "4.6" & < "4.7"}
+  "tyxml" {>= "5.0" & < "6.0"}
   "ocsigenserver" {>= "7.0" & < "8.0"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}

--- a/src/lib/eliom_shared_content.eliom
+++ b/src/lib/eliom_shared_content.eliom
@@ -231,6 +231,9 @@ module Svg = struct
     let string_of_numbers_semicolon () =
       [%shared Raw_wrapped_functions_svg.string_of_numbers_semicolon]
 
+    let string_of_semicolonstrings () =
+      [%shared Raw_wrapped_functions_svg.string_of_semicolonstrings]
+
     let string_of_offset () =
       ([%shared Raw_wrapped_functions_svg.string_of_offset]
         : (Svg_types.offset -> string) Eliom_shared.Value.t
@@ -252,6 +255,9 @@ module Svg = struct
 
     let string_of_transforms () =
       [%shared Raw_wrapped_functions_svg.string_of_transforms]
+
+    let unoption_string () =
+      [%shared Raw_wrapped_functions_svg.unoption_string]
   end
 
   module Xml = struct
@@ -329,6 +335,11 @@ module Html = struct
 
     let string_of_bool () = [%shared Raw_wrapped_functions.string_of_bool]
 
+    let string_of_blocking () =
+      ([%shared Raw_wrapped_functions.string_of_blocking]
+        : (Html_types.blocking_token list -> string) Eliom_shared.Value.t
+        :> ([< Html_types.blocking_token] list -> string) Eliom_shared.Value.t)
+
     let string_of_character () =
       [%shared Raw_wrapped_functions.string_of_character]
 
@@ -358,6 +369,11 @@ module Html = struct
         :> ([< Html_types.number_or_datetime] -> string) Eliom_shared.Value.t)
 
     let string_of_numbers () = [%shared Raw_wrapped_functions.string_of_numbers]
+
+    let string_of_ol_type () =
+      ([%shared Raw_wrapped_functions.string_of_ol_type]
+        : (Html_types.ol_type -> string) Eliom_shared.Value.t
+        :> ([< Html_types.ol_type] -> string) Eliom_shared.Value.t)
 
     let string_of_sandbox () =
       ([%shared Raw_wrapped_functions.string_of_sandbox]


### PR DESCRIPTION
Same change as #901, for the `master` branch.

TyXML 5.0 adds four functions to the `Wrapped_functions` module types. Eliom implements those signatures by hand, one `let` per function wrapping the raw function in a `[%shared ...]`, rather than by inclusion, so each new function has to be added explicitly:

- `string_of_blocking` and `string_of_ol_type` for HTML, with the usual `Eliom_shared.Value.t` coercion since both take a `[< ... ]` argument;
- `string_of_semicolonstrings` and `unoption_string` for SVG, which need no coercion. (`unoption_string` already existed on the HTML side.)

The version constraint moves from `(and (>= 4.6) (< 4.7))` to `(and (>= 5.0) (< 6.0))`.

### Checks

`opam install eliom` succeeds against TyXML 5.0 in a switch where the four TyXML packages are pinned to `tyxml#master` and labelled 5.0.0, so the new constraint is actually exercised by the solver rather than merely written down.

Nothing else in Eliom is affected. Eliom is the only package in the ecosystem that uses `Make_with_wrapped_functions`; everything else goes through `Html_f.Make` and `Svg_f.Make`, which build the `Wrapped_functions` internally, and `Xml_sigs.T` is unchanged in 5.0.